### PR TITLE
#120 [layout] Improving Signup with Email

### DIFF
--- a/app/src/main/java/com/daily/dayo/signup/email/SignupEmailSetPasswordConfirmationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/signup/email/SignupEmailSetPasswordConfirmationFragment.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.signup.email
 
-import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
@@ -10,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -34,19 +32,18 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
         binding = FragmentSignupEmailSetPasswordConfirmationBinding.inflate(inflater, container, false)
         setBackClickListener()
         setNextClickListener()
+        initEditText()
         setLimitEditTextInputType()
-        setEditTextErrorMessage()
         setTextEditorActionListener()
+        verifyNickname()
         setUserPasswordEditText()
         return binding.root
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.setOnTouchListener { _, _ ->
-            binding.etSignupEmailSetPasswordConfirmationUserInput.clearFocus()
-            val inputMethodManager : InputMethodManager = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            inputMethodManager.hideSoftInputFromWindow(activity?.currentFocus?.windowToken, 0)
-            setEditTextTitle()
+            HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetPasswordConfirmationUserInput)
+            changeEditTextTitle()
             true
         }
     }
@@ -56,15 +53,19 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
             when(actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
                     HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetPasswordConfirmationUserInput)
-                    setEditTextTitle()
+                    changeEditTextTitle()
                     true
                 } else -> false
             }
         }
+    }
+
+    private fun initEditText() {
         binding.etSignupEmailSetPasswordConfirmationUserInput.setOnFocusChangeListener { _, hasFocus ->
             with(binding.layoutSignupEmailSetPasswordConfirmationUserInput) {
                 if(hasFocus){
                     hint = getString(R.string.password_confirmation)
+                    boxStrokeColor = resources.getColor(R.color.primary_green_23C882, context?.theme)
                 } else {
                     hint = getString(R.string.signup_email_set_password_confirmation_edittext_hint)
                 }
@@ -72,10 +73,9 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
         }
     }
 
-
-    private fun setEditTextTitle() {
+    private fun changeEditTextTitle() {
         with(binding.layoutSignupEmailSetPasswordConfirmationUserInput) {
-            if(binding.etSignupEmailSetPasswordConfirmationUserInput.text.isNullOrEmpty() && !binding.etSignupEmailSetPasswordConfirmationUserInput.isFocused) {
+            if(binding.etSignupEmailSetPasswordConfirmationUserInput.text.isNullOrEmpty()) {
                 hint = getString(R.string.signup_email_set_password_confirmation_edittext_hint)
             } else {
                 hint = getString(R.string.password_confirmation)
@@ -83,29 +83,34 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
         }
     }
 
-    private fun setEditTextErrorMessage() {
+    private fun verifyNickname() {
         binding.etSignupEmailSetPasswordConfirmationUserInput.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
             override fun afterTextChanged(s: Editable?) {
-                with(binding.layoutSignupEmailSetPasswordConfirmationUserInput) {
-                    isErrorEnabled = true
-                    if(args.password != binding.etSignupEmailSetPasswordConfirmationUserInput.text.toString().trim() ){ // 동일 비밀번호 검사
-                        error = getString(R.string.signup_email_set_password_confirmation_message_fail)
-                    } else {
-                        isErrorEnabled = false
-                    }
-
-                    if(isErrorEnabled){
-                        binding.layoutSignupEmailSetPasswordConfirmationUserInput.boxStrokeColor = resources.getColor(R.color.red_FF4545, context?.theme)
-                        ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordConfirmationNext)
-                    } else {
-                        binding.layoutSignupEmailSetPasswordConfirmationUserInput.boxStrokeColor = resources.getColor(R.color.primary_green_23C882, context?.theme)
-                        ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetPasswordConfirmationNext)
-                    }
+                if(args.password != binding.etSignupEmailSetPasswordConfirmationUserInput.text.toString().trim() ){ // 동일 비밀번호 검사
+                    setEditTextTheme(getString(R.string.signup_email_set_password_confirmation_message_fail), false)
+                    ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordConfirmationNext)
+                } else {
+                    setEditTextTheme(null, true)
+                    ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetPasswordConfirmationNext)
                 }
             }
         })
+    }
+
+    private fun setEditTextTheme(errorMessage: String?, pass: Boolean) {
+        with(binding.layoutSignupEmailSetPasswordConfirmationUserInput) {
+            error = errorMessage
+            errorIconDrawable = null
+            if(pass) {
+                isErrorEnabled = false
+                boxStrokeColor = resources.getColor(R.color.primary_green_23C882, context?.theme)
+            } else {
+                isErrorEnabled = true
+                boxStrokeColor = resources.getColor(R.color.red_FF4545, context?.theme)
+            }
+        }
     }
 
     private fun setLimitEditTextInputType() {
@@ -132,9 +137,7 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
 
     private fun setNextClickListener() {
         binding.btnSignupEmailSetPasswordConfirmationNext.setOnClickListener {
-            if(!binding.etSignupEmailSetPasswordConfirmationUserInput.text.isNullOrBlank()) {
-                Navigation.findNavController(it).navigate(SignupEmailSetPasswordConfirmationFragmentDirections.actionSignupEmailSetPasswordConfirmationFragmentToSignupEmailSetProfileFragment(args.email,args.password))
-            }
+            Navigation.findNavController(it).navigate(SignupEmailSetPasswordConfirmationFragmentDirections.actionSignupEmailSetPasswordConfirmationFragmentToSignupEmailSetProfileFragment(args.email,args.password))
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/signup/email/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/signup/email/SignupEmailSetProfileFragment.kt
@@ -8,10 +8,13 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentSignupEmailSetProfileBinding
 import com.daily.dayo.util.ButtonActivation
+import com.daily.dayo.util.HideKeyBoardUtil
 import com.daily.dayo.util.autoCleared
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.regex.Pattern
@@ -19,6 +22,7 @@ import java.util.regex.Pattern
 @AndroidEntryPoint
 class SignupEmailSetProfileFragment : Fragment() {
     private var binding by autoCleared<FragmentSignupEmailSetProfileBinding>()
+    private val args by navArgs<SignupEmailSetProfileFragmentArgs>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -27,22 +31,31 @@ class SignupEmailSetProfileFragment : Fragment() {
         binding = FragmentSignupEmailSetProfileBinding.inflate(inflater, container, false)
         setBackClickListener()
         setNextClickListener()
-        textWatcherEditText()
+        setLimitEditTextInputType()
+        setTextEditorActionListener()
+        verifyNickname()
         return binding.root
     }
 
-    private fun textWatcherEditText() {
-        // InputFilter로 띄어쓰기 입력만 막고 나머지는 안내메시지로 띄워지도록 사용자에게 유도
-        val filterInputCheck = InputFilter { source, start, end, dest, dstart, dend ->
-            val ps = Pattern.compile("^[ ]+\$")
-            if (ps.matcher(source).matches()) {
-                return@InputFilter ""
-            }
-            null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.setOnTouchListener { _, _ ->
+            HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetProfileNickname)
+            true
         }
-        val lengthFilter = InputFilter.LengthFilter(10)
-        binding.etSignupEmailSetProfileNickname.filters = arrayOf(filterInputCheck, lengthFilter)
+    }
+    private fun setTextEditorActionListener() {
+        binding.etSignupEmailSetProfileNickname.setOnEditorActionListener {  _, actionId, _ ->
+            when(actionId) {
+                EditorInfo.IME_ACTION_DONE -> {
+                    HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetProfileNickname)
+                    true
+                } else -> false
+            }
+        }
+    }
 
+    private fun verifyNickname() {
         binding.etSignupEmailSetProfileNickname.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
@@ -54,44 +67,57 @@ class SignupEmailSetProfileFragment : Fragment() {
                         tvSignupEmailSetProfileNicknameCount.text = "${s.toString().trim().length}${getString(R.string.my_profile_edit_nickname_edittext_count)}"
                     }
 
-                    if(s.toString().trim().length < 2) { // 닉네임 길이 검사
-                        tvSignupEmailSetProfileNicknameMessage.visibility = View.VISIBLE
-                        tvSignupEmailSetProfileNicknameMessage.text = getString(R.string.my_profile_edit_nickname_message_length_fail_min)
-                        tvSignupEmailSetProfileNicknameMessage.setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
-                        etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+                    if(s.toString().trim().length < 2) { // 닉네임 길이 검사 1
+                        setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_length_fail_min), false)
                         ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
-                    } else if(s.toString().trim().length > 10) {
-                        tvSignupEmailSetProfileNicknameMessage.visibility = View.VISIBLE
-                        tvSignupEmailSetProfileNicknameMessage.text = getString(R.string.my_profile_edit_nickname_message_length_fail_max)
-                        tvSignupEmailSetProfileNicknameMessage.setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
-                        etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+                    } else if(s.toString().trim().length > 10) { // 닉네임 길이 검사 2
+                        setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_length_fail_max), false)
                         ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
                     } else {
                         if(Pattern.matches("^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$", s.toString().trim())) { // 닉네임 양식 검사
-                            if(true) { // TODO : 닉네임 중복검사 통과
-                                tvSignupEmailSetProfileNicknameMessage.visibility = View.INVISIBLE
-                                tvSignupEmailSetProfileNicknameMessage.text = getString(R.string.my_profile_edit_nickname_message_success)
-                                tvSignupEmailSetProfileNicknameMessage.setTextColor(resources.getColor(R.color.primary_green_23C882, context?.theme))
-                                etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.primary_green_23C882, context?.theme)
+                            if(true) { // TODO : 닉네임 중복검사 통과 코드 작성
+                                setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_success), true)
                                 ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetProfileNext)
                             } else {
-                                tvSignupEmailSetProfileNicknameMessage.visibility = View.VISIBLE
-                                tvSignupEmailSetProfileNicknameMessage.text = getString(R.string.my_profile_edit_nickname_message_duplicate_fail)
-                                tvSignupEmailSetProfileNicknameMessage.setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
-                                etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+                                setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_duplicate_fail), false)
                                 ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
                             }
                         } else {
-                            tvSignupEmailSetProfileNicknameMessage.visibility = View.VISIBLE
-                            tvSignupEmailSetProfileNicknameMessage.text = getString(R.string.my_profile_edit_nickname_message_format_fail)
-                            tvSignupEmailSetProfileNicknameMessage.setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
-                            etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+                            setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_format_fail), false)
                             ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
                         }
                     }
                 }
             }
         })
+    }
+
+    private fun setEditTextTheme(checkMessage: String?, pass: Boolean) {
+        with(binding.tvSignupEmailSetProfileNicknameMessage) {
+            visibility = View.VISIBLE
+            if(pass) {
+                text = checkMessage
+                setTextColor(resources.getColor(R.color.primary_green_23C882, context?.theme))
+                binding.etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.primary_green_23C882, context?.theme)
+            } else {
+                text = checkMessage
+                setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
+                binding.etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+            }
+        }
+    }
+
+    private fun setLimitEditTextInputType() {
+        // InputFilter로 띄어쓰기 입력만 막고 나머지는 안내메시지로 띄워지도록 사용자에게 유도
+        val filterInputCheck = InputFilter { source, start, end, dest, dstart, dend ->
+            val ps = Pattern.compile("^[ ]+\$")
+            if (ps.matcher(source).matches()) {
+                return@InputFilter ""
+            }
+            null
+        }
+        val lengthFilter = InputFilter.LengthFilter(10)
+        binding.etSignupEmailSetProfileNickname.filters = arrayOf(filterInputCheck, lengthFilter)
     }
 
     private fun setBackClickListener(){

--- a/app/src/main/res/layout/fragment_signup_email_set_email_address.xml
+++ b/app/src/main/res/layout/fragment_signup_email_set_email_address.xml
@@ -86,6 +86,7 @@
             android:id="@+id/btn_signup_email_set_email_address_next"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="@string/next"
             android:textSize="16dp"
             android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_signup_email_set_password.xml
+++ b/app/src/main/res/layout/fragment_signup_email_set_password.xml
@@ -65,6 +65,9 @@
             app:hintEnabled="true"
             app:hintTextColor="@color/gray_3_9C9C9C"
             app:errorTextColor="@color/red_FF4545"
+            app:counterEnabled="false"
+            app:counterMaxLength="16"
+            app:counterTextColor="@color/red_FF4545"
 
             app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_password_title"
             app:layout_constraintStart_toStartOf="parent"
@@ -86,6 +89,7 @@
             android:id="@+id/btn_signup_email_set_password_next"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="@string/next"
             android:textSize="16dp"
             android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_signup_email_set_password_confirmation.xml
+++ b/app/src/main/res/layout/fragment_signup_email_set_password_confirmation.xml
@@ -116,6 +116,7 @@
             android:id="@+id/btn_signup_email_set_password_confirmation_next"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="@string/next"
             android:textSize="16dp"
             android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_signup_email_set_profile.xml
+++ b/app/src/main/res/layout/fragment_signup_email_set_profile.xml
@@ -124,6 +124,7 @@
             android:id="@+id/btn_signup_email_set_profile_next"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="@string/next"
             android:textSize="16dp"
             android:textStyle="bold"


### PR DESCRIPTION
- 이메일 계정으로 가입할 때의 화면 Fragment 디자인에 맞추어 개선
   - 이메일 계정 정보 입력 Fragment들 Function들이 통일성이 있도록 변경
   - 일부 Function 목적에 맞게 분리 및 생성
   - 패스워드 설정 시 Count 누락 수정
   - Next 버튼이 처음 화면에서 Enable="true"로 되어있던 Bug Fix

resolved: #120