### PR TITLE
#160 [feature] FeedFragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/di/ServiceModule.kt
+++ b/app/src/main/java/com/daily/dayo/di/ServiceModule.kt
@@ -1,5 +1,8 @@
 package com.daily.dayo.di
 
+import com.daily.dayo.network.feed.FeedApiHelper
+import com.daily.dayo.network.feed.FeedApiHelperImpl
+import com.daily.dayo.network.feed.FeedApiService
 import com.daily.dayo.network.post.PostApiHelper
 import com.daily.dayo.network.post.PostApiHelperImpl
 import com.daily.dayo.network.post.PostApiService
@@ -114,6 +117,18 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideFollowRepository(followApiHelper: FollowApiHelper) : FollowRepository = FollowRepository(followApiHelper)
+
+    @Singleton
+    @Provides
+    fun provideFeedApiService(retrofit: Retrofit) = retrofit.create(FeedApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideFeedApiHelper(feedApiHelperImpl: FeedApiHelperImpl): FeedApiHelper = feedApiHelperImpl
+
+    @Singleton
+    @Provides
+    fun provideFeedRepository(feedApiHelper: FeedApiHelper) : FeedRepository = FeedRepository(feedApiHelper)
 
 
 }

--- a/app/src/main/java/com/daily/dayo/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/feed/FeedFragment.kt
@@ -1,17 +1,15 @@
 package com.daily.dayo.feed
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentFeedBinding
 import com.daily.dayo.feed.adapter.FeedListAdapter
@@ -20,12 +18,13 @@ import com.daily.dayo.feed.viewmodel.FeedViewModel
 import com.daily.dayo.post.model.RequestLikePost
 import com.daily.dayo.util.Status
 import com.daily.dayo.util.autoCleared
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
-class FeedFragment: Fragment() {
+class FeedFragment : Fragment() {
     private var binding by autoCleared<FragmentFeedBinding>()
     private val feedViewModel by activityViewModels<FeedViewModel>()
-    private lateinit var feedListAdapter : FeedListAdapter
+    private lateinit var feedListAdapter: FeedListAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -34,50 +33,46 @@ class FeedFragment: Fragment() {
         binding = FragmentFeedBinding.inflate(inflater, container, false)
         setRvFeedListAdapter()
         setFeedPostList()
-        setFeedPostSearchButtonClickListener()
         setFeedPostLikeClickListener()
         return binding.root
     }
 
-    private fun setFeedPostSearchButtonClickListener() {
-        binding.btnPostSearch.setOnClickListener {
-            findNavController().navigate(R.id.action_FeedFragment_to_SearchFragment)
-        }
+    override fun onResume() {
+        super.onResume()
+        feedViewModel.requestFeedList()
     }
 
-    private fun setRvFeedListAdapter(){
+    private fun setRvFeedListAdapter() {
         feedListAdapter = FeedListAdapter()
         binding.rvFeedPost.adapter = feedListAdapter
     }
 
-    private fun setFeedPostList(){
+    private fun setFeedPostList() {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                feedViewModel.feedList.observe(viewLifecycleOwner, Observer {
-                    when (it.status) {
-                        Status.SUCCESS -> {
-                            it.data?.let { feedList ->
-                                feedListAdapter.submitList(feedList.data?.toMutableList())
-                            }
-                        }
-                        Status.LOADING -> {
-                        }
-                        Status.ERROR -> {
-
+            feedViewModel.feedList.observe(viewLifecycleOwner, Observer {
+                when (it.status) {
+                    Status.SUCCESS -> {
+                        it.data?.let { feedList ->
+                            feedListAdapter.submitList(feedList.data?.toMutableList())
                         }
                     }
-                })
-            }
+                    Status.LOADING -> {
+                    }
+                    Status.ERROR -> {
+
+                    }
+                }
+            })
         }
     }
 
-    private fun setFeedPostLikeClickListener(){
-        feedListAdapter.setOnItemClickListener(object : FeedListAdapter.OnItemClickListener{
+    private fun setFeedPostLikeClickListener() {
+        feedListAdapter.setOnItemClickListener(object : FeedListAdapter.OnItemClickListener {
             override fun likePostClick(btn: ImageButton, data: FeedContent, pos: Int) {
                 if (!data.heart) {
                     btn.setImageDrawable(
                         resources.getDrawable(
-                            R.drawable.ic_like_pressed,
+                            R.drawable.ic_post_like_checked,
                             context?.theme
                         )
                     )
@@ -85,13 +80,22 @@ class FeedFragment: Fragment() {
                 } else {
                     btn.setImageDrawable(
                         resources.getDrawable(
-                            R.drawable.ic_like_default,
+                            R.drawable.ic_post_like_default,
                             context?.theme
                         )
                     )
                     feedViewModel.requestUnlikePost(data.id)
+                }.let { it.invokeOnCompletion { throwable ->
+                    when (throwable) {
+                        is CancellationException -> Log.e("Post Like Click", "CANCELLED")
+                        null -> {
+                            feedViewModel.requestFeedList()
+                            }
+                        }
+                    }
                 }
             }
         })
     }
+
 }

--- a/app/src/main/java/com/daily/dayo/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/feed/FeedFragment.kt
@@ -4,32 +4,94 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentFeedBinding
+import com.daily.dayo.feed.adapter.FeedListAdapter
+import com.daily.dayo.feed.model.FeedContent
+import com.daily.dayo.feed.viewmodel.FeedViewModel
+import com.daily.dayo.post.model.RequestLikePost
+import com.daily.dayo.util.Status
 import com.daily.dayo.util.autoCleared
+import kotlinx.coroutines.launch
 
 class FeedFragment: Fragment() {
     private var binding by autoCleared<FragmentFeedBinding>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
+    private val feedViewModel by activityViewModels<FeedViewModel>()
+    private lateinit var feedListAdapter : FeedListAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentFeedBinding.inflate(inflater, container, false)
-
-        setPostSearchButtonClickListener()
+        setRvFeedListAdapter()
+        setFeedPostList()
+        setFeedPostSearchButtonClickListener()
+        setFeedPostLikeClickListener()
         return binding.root
     }
 
-    private fun setPostSearchButtonClickListener() {
+    private fun setFeedPostSearchButtonClickListener() {
         binding.btnPostSearch.setOnClickListener {
             findNavController().navigate(R.id.action_FeedFragment_to_SearchFragment)
         }
+    }
+
+    private fun setRvFeedListAdapter(){
+        feedListAdapter = FeedListAdapter()
+        binding.rvFeedPost.adapter = feedListAdapter
+    }
+
+    private fun setFeedPostList(){
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                feedViewModel.feedList.observe(viewLifecycleOwner, Observer {
+                    when (it.status) {
+                        Status.SUCCESS -> {
+                            it.data?.let { feedList ->
+                                feedListAdapter.submitList(feedList.data?.toMutableList())
+                            }
+                        }
+                        Status.LOADING -> {
+                        }
+                        Status.ERROR -> {
+
+                        }
+                    }
+                })
+            }
+        }
+    }
+
+    private fun setFeedPostLikeClickListener(){
+        feedListAdapter.setOnItemClickListener(object : FeedListAdapter.OnItemClickListener{
+            override fun likePostClick(btn: ImageButton, data: FeedContent, pos: Int) {
+                if (!data.heart) {
+                    btn.setImageDrawable(
+                        resources.getDrawable(
+                            R.drawable.ic_like_pressed,
+                            context?.theme
+                        )
+                    )
+                    feedViewModel.requestLikePost(RequestLikePost(data.id))
+                } else {
+                    btn.setImageDrawable(
+                        resources.getDrawable(
+                            R.drawable.ic_like_default,
+                            context?.theme
+                        )
+                    )
+                    feedViewModel.requestUnlikePost(data.id)
+                }
+            }
+        })
     }
 }

--- a/app/src/main/java/com/daily/dayo/feed/adapter/FeedCommentAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/feed/adapter/FeedCommentAdapter.kt
@@ -1,0 +1,38 @@
+package com.daily.dayo.feed.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.daily.dayo.databinding.ItemFeedPostCommentBinding
+import com.daily.dayo.post.model.PostCommentContent
+
+class FeedCommentAdapter : ListAdapter<PostCommentContent, FeedCommentAdapter.FeedCommentViewHolder>(diffCallback) {
+    companion object {
+        private val diffCallback = object : DiffUtil.ItemCallback<PostCommentContent>() {
+            override fun areItemsTheSame(oldItem: PostCommentContent, newItem: PostCommentContent) =
+                oldItem.commentId == newItem.commentId
+
+            override fun areContentsTheSame(oldItem: PostCommentContent, newItem: PostCommentContent): Boolean =
+                oldItem == newItem
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedCommentViewHolder
+            = FeedCommentViewHolder (ItemFeedPostCommentBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+
+    override fun onBindViewHolder(holder: FeedCommentAdapter.FeedCommentViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    override fun submitList(list: MutableList<PostCommentContent>?) {
+        super.submitList(list?.let { ArrayList(it) })
+    }
+
+    inner class FeedCommentViewHolder(private val binding: ItemFeedPostCommentBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(postCommentContent: PostCommentContent) {
+            binding.feedComment = postCommentContent
+        }
+    }
+}

--- a/app/src/main/java/com/daily/dayo/feed/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/feed/adapter/FeedListAdapter.kt
@@ -1,13 +1,24 @@
 package com.daily.dayo.feed.adapter
 
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.daily.dayo.DayoApplication
+import com.daily.dayo.R
+import com.daily.dayo.SharedManager
 import com.daily.dayo.databinding.ItemFeedPostBinding
+import com.daily.dayo.feed.FeedFragmentDirections
 import com.daily.dayo.feed.model.FeedContent
+import com.daily.dayo.post.model.PostCommentContent
+import com.daily.dayo.util.TimeChangerUtil
+import com.google.android.material.chip.Chip
 
 class FeedListAdapter : ListAdapter<FeedContent, FeedListAdapter.FeedListViewHolder>(diffCallback){
     companion object {
@@ -47,6 +58,115 @@ class FeedListAdapter : ListAdapter<FeedContent, FeedListAdapter.FeedListViewHol
 
         fun bind(feedContent: FeedContent, currentPosition: Int) {
             binding.feedContent = feedContent
+            binding.feedContentCategory = when(feedContent.category) {
+                "SCHEDULER" -> "스케줄러"
+                "STUDY_PLANNER" -> "스터디 플래너"
+                "GOOD_NOTE" -> "굿노트"
+                "POCKET_BOOK" -> "포켓북"
+                "SIX_DIARY" -> "6공 다이어리"
+                "ETC" -> "기타"
+                else -> ""
+            }
+            binding.feedContentCreateTime = TimeChangerUtil.timeChange(binding.tvFeedPostTime.context, feedContent.localDateTime)
+            Glide.with(binding.imgFeedPostUserProfile.context)
+                .load("http://117.17.198.45:8080/images/" + feedContent.userProfileImage)
+                .centerCrop()
+                .into(binding.imgFeedPostUserProfile)
+            Glide.with(binding.imgFeedPost.context)
+                .load("http://117.17.198.45:8080/images/" + feedContent.thumbnailImage)
+                .centerCrop()
+                .into(binding.imgFeedPost)
+            setOnUserProfileClickListener(feedContent.memberId)
+            setOnPostClickListener(feedContent.id, feedContent.nickname)
+
+            // 댓글
+            if(feedContent.commentCount > 2) {
+                setCommentList(feedContent.comments.subList(0,2))
+                binding.tvFeedPostMoreComment.visibility = View.VISIBLE
+            }
+            else{
+                setCommentList(feedContent.comments)
+                binding.tvFeedPostMoreComment.visibility = View.GONE
+            }
+
+            // 해시태그
+            if(feedContent.hashtags.isNotEmpty()) {
+                binding.layoutFeedPostTagList.visibility = View.VISIBLE
+                setTagList(feedContent.hashtags)
+            }
+            else{
+                binding.layoutFeedPostTagList.visibility = View.GONE
+            }
+
+            // 좋아요
+            val pos = adapterPosition
+            if(pos!= RecyclerView.NO_POSITION) {
+                binding.btnFeedPostLike.setOnClickListener {
+                    listener?.likePostClick(binding.btnFeedPostLike, feedContent, pos)
+                }
+            }
+        }
+
+        private fun setTagList(tagList : List<String>) {
+            binding.chipgroupFeedPostTagList.removeAllViews()
+            if(!tagList.isNullOrEmpty()){
+                (tagList.indices).mapNotNull { index ->
+                    val chip = LayoutInflater.from(binding.chipgroupFeedPostTagList.context).inflate(R.layout.item_post_tag, null) as Chip
+                    val layoutParams = ViewGroup.MarginLayoutParams(ViewGroup.MarginLayoutParams.WRAP_CONTENT, ViewGroup.MarginLayoutParams.WRAP_CONTENT)
+                    with(chip) {
+                        chipBackgroundColor =
+                            ColorStateList(
+                                arrayOf(intArrayOf(-android.R.attr.state_pressed), intArrayOf(android.R.attr.state_pressed)),
+                                intArrayOf(resources.getColor(R.color.gray_7_F6F6F6, context?.theme), resources.getColor(
+                                    R.color.primary_green_23C882, context?.theme))
+                            )
+
+                        setTextColor(
+                            ColorStateList(
+                                arrayOf(intArrayOf(-android.R.attr.state_pressed), intArrayOf(android.R.attr.state_pressed)),
+                                intArrayOf(resources.getColor(R.color.gray_1_313131,context?.theme), resources.getColor(
+                                    R.color.white_FFFFFF, context?.theme))
+                            )
+                        )
+                        text = "# ${tagList[index].trim()}"
+                    }
+                    binding.chipgroupFeedPostTagList.addView(chip, layoutParams)
+                }
+            }
+        }
+
+        private fun setCommentList(comments:List<PostCommentContent>){
+            val feedCommentAdapter = FeedCommentAdapter()
+            binding.rvFeedPostComment.adapter = feedCommentAdapter
+            feedCommentAdapter.submitList(comments?.toMutableList())
+        }
+
+        private fun setOnUserProfileClickListener(postMemberId:String){
+            binding.imgFeedPostUserProfile.setOnClickListener {
+                if (postMemberId == SharedManager(DayoApplication.applicationContext()).getCurrentUser().memberId) {
+                    Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToMyProfileFragment())
+                }
+                else{
+                    Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToOtherProfileFragment(postMemberId))
+                }
+            }
+            binding.tvFeedPostUserNickname.setOnClickListener {
+                if (postMemberId == SharedManager(DayoApplication.applicationContext()).getCurrentUser().memberId) {
+                    Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToMyProfileFragment())
+                }
+                else{
+                    Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToOtherProfileFragment(postMemberId))
+                }
+            }
+        }
+
+        private fun setOnPostClickListener(postId:Int, nickname:String){
+            binding.tvFeedPostContent.setOnClickListener{
+                Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToPostFragment(postId,nickname))
+            }
+            binding.tvFeedPostMoreComment.setOnClickListener{
+                Navigation.findNavController(it).navigate(FeedFragmentDirections.actionFeedFragmentToPostFragment(postId,nickname))
+            }
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/feed/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/feed/adapter/FeedListAdapter.kt
@@ -1,0 +1,52 @@
+package com.daily.dayo.feed.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.ImageButton
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.daily.dayo.databinding.ItemFeedPostBinding
+import com.daily.dayo.feed.model.FeedContent
+
+class FeedListAdapter : ListAdapter<FeedContent, FeedListAdapter.FeedListViewHolder>(diffCallback){
+    companion object {
+        private val diffCallback = object : DiffUtil.ItemCallback<FeedContent>() {
+            override fun areItemsTheSame(oldItem: FeedContent, newItem: FeedContent) =
+                oldItem.id == newItem.id
+
+            override fun areContentsTheSame(oldItem: FeedContent, newItem: FeedContent): Boolean =
+                oldItem.hashCode() == newItem.hashCode()
+        }
+    }
+
+    interface OnItemClickListener{
+        fun likePostClick(btn: ImageButton, data: FeedContent, pos: Int)
+    }
+    private var listener: OnItemClickListener?= null
+    fun setOnItemClickListener(listener: OnItemClickListener) {
+        this.listener = listener
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : FeedListViewHolder {
+        return FeedListViewHolder(
+            ItemFeedPostBinding.inflate(LayoutInflater.from(parent.context), parent,false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: FeedListViewHolder, position: Int) {
+        val item = getItem(position)
+        holder.bind(item, position)
+    }
+
+    override fun submitList(list: MutableList<FeedContent>?) {
+        super.submitList(list?.let { ArrayList(it) })
+    }
+
+    inner class FeedListViewHolder(private val binding: ItemFeedPostBinding): RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(feedContent: FeedContent, currentPosition: Int) {
+            binding.feedContent = feedContent
+        }
+    }
+}

--- a/app/src/main/java/com/daily/dayo/feed/model/Feed.kt
+++ b/app/src/main/java/com/daily/dayo/feed/model/Feed.kt
@@ -12,16 +12,24 @@ data class ResponseFeedList(
 )
 
 data class FeedContent(
+    @SerializedName("category")
+    val category: String,
     @SerializedName("commentCount")
     val commentCount: Int,
     @SerializedName("comments")
-    val comments: PostCommentContent,
+    val comments: List<PostCommentContent>,
+    @SerializedName("contents")
+    val contents: String,
+    @SerializedName("hashtags")
+    val hashtags: List<String>,
     @SerializedName("heart")
     val heart: Boolean,
     @SerializedName("heartCount")
     val heartCount: Int,
     @SerializedName("id")
     val id: Int,
+    @SerializedName("localDateTime")
+    val localDateTime: String,
     @SerializedName("memberId")
     val memberId: String,
     @SerializedName("nickname")

--- a/app/src/main/java/com/daily/dayo/feed/model/Feed.kt
+++ b/app/src/main/java/com/daily/dayo/feed/model/Feed.kt
@@ -1,0 +1,33 @@
+package com.daily.dayo.feed.model
+
+import com.daily.dayo.post.model.PostCommentContent
+import com.google.gson.annotations.SerializedName
+
+data class ResponseFeedList(
+    @SerializedName("count")
+    val count: Int,
+    @SerializedName("data")
+    val data: List<FeedContent>
+
+)
+
+data class FeedContent(
+    @SerializedName("commentCount")
+    val commentCount: Int,
+    @SerializedName("comments")
+    val comments: PostCommentContent,
+    @SerializedName("heart")
+    val heart: Boolean,
+    @SerializedName("heartCount")
+    val heartCount: Int,
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("memberId")
+    val memberId: String,
+    @SerializedName("nickname")
+    val nickname: String,
+    @SerializedName("thumbnailImage")
+    val thumbnailImage: String,
+    @SerializedName("userProfileImage")
+    val userProfileImage: String
+)

--- a/app/src/main/java/com/daily/dayo/feed/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/feed/viewmodel/FeedViewModel.kt
@@ -1,0 +1,52 @@
+package com.daily.dayo.feed.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daily.dayo.feed.model.ResponseFeedList
+import com.daily.dayo.post.model.RequestLikePost
+import com.daily.dayo.post.model.ResponseLikePost
+import com.daily.dayo.repository.FeedRepository
+import com.daily.dayo.util.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FeedViewModel @Inject constructor(private val feedRepository: FeedRepository):ViewModel(){
+    private val _feedList = MutableLiveData<Resource<ResponseFeedList>>()
+    val feedList: LiveData<Resource<ResponseFeedList>> get() = _feedList
+
+    private val _postliked = MutableLiveData<Resource<ResponseLikePost>>()
+    val postLiked: LiveData<Resource<ResponseLikePost>> get() = _postliked
+
+    init {
+        requestFeedList()
+    }
+
+    fun requestFeedList() = viewModelScope.launch {
+        _feedList.postValue(Resource.loading(null))
+        feedRepository.requestFeedList().let {
+            if(it.isSuccessful){
+                _feedList.postValue(Resource.success(it.body()))
+            } else{
+                _feedList.postValue(Resource.error(it.errorBody().toString(), null))
+            }
+        }
+    }
+
+    fun requestLikePost(request: RequestLikePost) = viewModelScope.launch {
+        feedRepository.requestLikePost(request).let {
+            if(it.isSuccessful) {
+                _postliked.postValue(Resource.success(it.body()))
+            } else {
+                _postliked.postValue(Resource.error(it.errorBody().toString(), null))
+            }
+        }
+    }
+
+    fun requestUnlikePost(postId: Int) = viewModelScope.launch {
+        feedRepository.requestUnlikePost(postId)
+    }
+}

--- a/app/src/main/java/com/daily/dayo/feed/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/feed/viewmodel/FeedViewModel.kt
@@ -21,10 +21,6 @@ class FeedViewModel @Inject constructor(private val feedRepository: FeedReposito
     private val _postliked = MutableLiveData<Resource<ResponseLikePost>>()
     val postLiked: LiveData<Resource<ResponseLikePost>> get() = _postliked
 
-    init {
-        requestFeedList()
-    }
-
     fun requestFeedList() = viewModelScope.launch {
         _feedList.postValue(Resource.loading(null))
         feedRepository.requestFeedList().let {

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelper.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelper.kt
@@ -1,0 +1,8 @@
+package com.daily.dayo.network.feed
+
+import com.daily.dayo.feed.model.ResponseFeedList
+import retrofit2.Response
+
+interface FeedApiHelper {
+    suspend fun requestFeedList(): Response<ResponseFeedList>
+}

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelper.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelper.kt
@@ -1,8 +1,12 @@
 package com.daily.dayo.network.feed
 
 import com.daily.dayo.feed.model.ResponseFeedList
+import com.daily.dayo.post.model.RequestLikePost
+import com.daily.dayo.post.model.ResponseLikePost
 import retrofit2.Response
 
 interface FeedApiHelper {
     suspend fun requestFeedList(): Response<ResponseFeedList>
+    suspend fun requestLikePost(request : RequestLikePost) : Response<ResponseLikePost>
+    suspend fun requestUnlikePost(postId: Int) : Response<Void>
 }

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelperImpl.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelperImpl.kt
@@ -1,0 +1,10 @@
+package com.daily.dayo.network.feed
+
+import com.daily.dayo.feed.model.ResponseFeedList
+import retrofit2.Response
+import javax.inject.Inject
+
+class FeedApiHelperImpl @Inject constructor(private val feedApiService: FeedApiService) : FeedApiHelper {
+    override suspend fun requestFeedList(): Response<ResponseFeedList> =
+        feedApiService.requestFeedList()
+}

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelperImpl.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiHelperImpl.kt
@@ -1,10 +1,16 @@
 package com.daily.dayo.network.feed
 
 import com.daily.dayo.feed.model.ResponseFeedList
+import com.daily.dayo.post.model.RequestLikePost
+import com.daily.dayo.post.model.ResponseLikePost
 import retrofit2.Response
 import javax.inject.Inject
 
 class FeedApiHelperImpl @Inject constructor(private val feedApiService: FeedApiService) : FeedApiHelper {
     override suspend fun requestFeedList(): Response<ResponseFeedList> =
         feedApiService.requestFeedList()
+    override suspend fun requestLikePost(request: RequestLikePost): Response<ResponseLikePost> =
+        feedApiService.requestLikePost(request)
+    override suspend fun requestUnlikePost(postId: Int): Response<Void> =
+        feedApiService.requestUnlikePost(postId)
 }

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiService.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiService.kt
@@ -1,0 +1,10 @@
+package com.daily.dayo.network.feed
+
+import com.daily.dayo.feed.model.ResponseFeedList
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface FeedApiService {
+    @GET("/api/v1/posts/feed/list")
+    suspend fun requestFeedList(): Response<ResponseFeedList>
+}

--- a/app/src/main/java/com/daily/dayo/network/feed/FeedApiService.kt
+++ b/app/src/main/java/com/daily/dayo/network/feed/FeedApiService.kt
@@ -1,10 +1,19 @@
 package com.daily.dayo.network.feed
 
 import com.daily.dayo.feed.model.ResponseFeedList
+import com.daily.dayo.post.model.RequestLikePost
+import com.daily.dayo.post.model.ResponseLikePost
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface FeedApiService {
     @GET("/api/v1/posts/feed/list")
     suspend fun requestFeedList(): Response<ResponseFeedList>
+    @POST("/api/v1/heart")
+    suspend fun requestLikePost(@Body body : RequestLikePost) : Response<ResponseLikePost>
+    @POST("/api/v1/heart/delete/{postId}")
+    suspend fun requestUnlikePost(@Path("postId") postId : Int) : Response<Void>
 }

--- a/app/src/main/java/com/daily/dayo/repository/FeedRepository.kt
+++ b/app/src/main/java/com/daily/dayo/repository/FeedRepository.kt
@@ -2,10 +2,14 @@ package com.daily.dayo.repository
 
 import com.daily.dayo.feed.model.ResponseFeedList
 import com.daily.dayo.network.feed.FeedApiHelper
+import com.daily.dayo.post.model.RequestLikePost
 import retrofit2.Response
 import javax.inject.Inject
 
 class FeedRepository@Inject constructor(private val feedApiHelper: FeedApiHelper){
 
     suspend fun requestFeedList(): Response<ResponseFeedList> = feedApiHelper.requestFeedList()
+    suspend fun requestLikePost(request : RequestLikePost) = feedApiHelper.requestLikePost(request).verify()
+    suspend fun requestUnlikePost(postId: Int) = feedApiHelper.requestUnlikePost(postId)
+
 }

--- a/app/src/main/java/com/daily/dayo/repository/FeedRepository.kt
+++ b/app/src/main/java/com/daily/dayo/repository/FeedRepository.kt
@@ -1,0 +1,11 @@
+package com.daily.dayo.repository
+
+import com.daily.dayo.feed.model.ResponseFeedList
+import com.daily.dayo.network.feed.FeedApiHelper
+import retrofit2.Response
+import javax.inject.Inject
+
+class FeedRepository@Inject constructor(private val feedApiHelper: FeedApiHelper){
+
+    suspend fun requestFeedList(): Response<ResponseFeedList> = feedApiHelper.requestFeedList()
+}

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -6,74 +6,31 @@
     android:layout_height="match_parent"
     tools:context=".feed.FeedFragment">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/layout_swipe_feed"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/layout_scroll_feed"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/layout_scroll_feed"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/layout_feed_action_bar"
-                    android:layout_width="0dp"
-                    android:layout_height="?actionBarSize"
-                    android:elevation="24dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-                    <View
-                        android:id="@+id/view_feed_horizontal_line"
-                        android:layout_width="0dp"
-                        android:layout_height="1dp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        android:background="@color/gray_5_F6F6F6"
-                        />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_feed_post"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginBottom="24dp"
+                android:overScrollMode="never"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:listitem="@layout/item_feed_post" />
 
-                    <ImageButton
-                        android:id="@+id/btn_post_search"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:background="@android:color/transparent"
-                        android:src="@drawable/ic_search"
-                        tools:ignore="ContentDescription"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        android:layout_marginTop="15dp"
-                        android:layout_marginEnd="16dp"
-                        />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_feed_post"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:overScrollMode="never"
-                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:layout_constraintTop_toBottomOf="@+id/layout_feed_action_bar"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    android:layout_marginBottom="24dp"
-                    tools:listitem="@layout/item_feed_post"/>
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.core.widget.NestedScrollView>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_feed_post.xml
+++ b/app/src/main/res/layout/item_feed_post.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="feedContent"
+            type="com.daily.dayo.feed.model.FeedContent" />
+    </data>
+
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -30,23 +38,32 @@
             android:textSize="14dp"
             android:textStyle="bold"
             android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/tv_feed_post_time"
+            app:layout_constraintTop_toTopOf="@+id/img_feed_post_user_profile"
             app:layout_constraintStart_toEndOf="@id/img_feed_post_user_profile"
             android:layout_marginStart="7dp"
             tools:text="Nickname"/>
 
         <TextView
+            android:id="@+id/tv_feed_post_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="기타  | "
+            android:textSize="10dp"
+            android:textColor="@color/gray_3_9C9C9C"
+            app:layout_constraintBottom_toBottomOf="@id/img_feed_post_user_profile"
+            app:layout_constraintStart_toEndOf="@id/img_feed_post_user_profile"
+            android:layout_marginStart="7dp"
+            tools:text="기타  | " />
+        <TextView
             android:id="@+id/tv_feed_post_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="8.5dp"
+            android:text=" 18시간 전"
+            android:textSize="10dp"
             android:textColor="@color/gray_3_9C9C9C"
-
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/img_feed_post_user_profile"
-            android:layout_marginStart="7dp"
-            tools:text="18시간 전"/>
+            app:layout_constraintBottom_toBottomOf="@id/img_feed_post_user_profile"
+            app:layout_constraintStart_toEndOf="@id/tv_feed_post_category"
+            tools:text=" 18시간 전"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -87,21 +104,10 @@
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
         android:src="@drawable/ic_post_like_default"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="19dp"
         android:layout_marginTop="15dp"
         app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
         app:layout_constraintStart_toStartOf="parent"/>
-
-    <ImageButton
-        android:id="@+id/btn_feed_post_comment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
-        android:src="@drawable/ic_comment"
-        android:layout_marginStart="17dp"
-        android:layout_marginTop="15dp"
-        app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
-        app:layout_constraintStart_toEndOf="@+id/btn_feed_post_like"/>
 
     <ImageButton
         android:id="@+id/btn_feed_post_share"
@@ -113,7 +119,7 @@
         android:layout_marginTop="15dp"
         android:layout_marginEnd="15dp"
         app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
-        app:layout_constraintStart_toEndOf="@+id/btn_feed_post_comment"/>
+        app:layout_constraintStart_toEndOf="@+id/btn_feed_post_like"/>
 
     <ImageButton
         android:id="@+id/btn_feed_post_bookmark"
@@ -128,36 +134,26 @@
         app:layout_constraintEnd_toEndOf="parent"/>
 
     <TextView
-        android:id="@+id/tv_main_post_like_count"
+        android:id="@+id/tv_feed_post_content_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="12dp"
+        android:text="좋아요 135개   |   댓글 12개"
+        android:textSize="13dp"
+        android:textStyle="bold"
         android:textColor="@color/gray_1_313131"
-        android:layout_marginTop="52dp"
-        android:layout_marginStart="19dp"
-        app:layout_constraintTop_toBottomOf="@id/vp_feed_post"
+        android:layout_marginTop="12dp"
+        app:layout_constraintTop_toBottomOf="@id/btn_feed_post_like"
         app:layout_constraintStart_toStartOf="parent"
-        tools:text="좋아요 135"/>
-
-    <TextView
-        android:id="@+id/tv_main_post_comment_count"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="12dp"
-        android:textColor="@color/gray_1_313131"
-        android:layout_marginTop="52dp"
-        android:layout_marginStart="19dp"
-        app:layout_constraintTop_toBottomOf="@id/vp_feed_post"
-        app:layout_constraintStart_toEndOf="@+id/tv_main_post_like_count"
-        tools:text="댓글 4"/>
+        android:layout_marginHorizontal="18dp"
+        tools:text="좋아요 135개   |   댓글 12개"/>
 
     <View
-        android:id="@+id/view_feed_horizontal_line"
+        android:id="@+id/view_feed_post_horizontal_line"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="14dp"
         android:layout_marginBottom="10dp"
-        app:layout_constraintTop_toBottomOf="@id/tv_main_post_like_count"
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_post_content_count"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -169,20 +165,20 @@
         android:ellipsize="end"
         android:textSize="12dp"
         android:textColor="@color/gray_1_313131"
-        android:layout_marginStart="19dp"
-        android:layout_marginEnd="19dp"
+        android:layout_marginStart="18dp"
+        android:layout_marginTop="11dp"
+        android:layout_marginEnd="21dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/view_feed_horizontal_line"
+        app:layout_constraintTop_toBottomOf="@id/view_feed_post_horizontal_line"
         tools:text="다이어리를 꾸며봤어요~! 블랙 앤 화이트로 꾸며봤습니다:) 일기를 써보았어요. 이러쿵 저러쿵"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_feed_post_comment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="19dp"
-        android:layout_marginEnd="19dp"
-        android:layout_marginTop="14dp"
+        android:layout_marginHorizontal="18dp"
+        android:layout_marginTop="21dp"
         app:layout_constraintTop_toBottomOf="@+id/tv_feed_post_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -197,7 +193,7 @@
         android:layout_height="wrap_content"
         android:textSize="12dp"
         android:textColor="@color/gray_3_9C9C9C"
-        android:layout_marginTop="3dp"
+        android:layout_marginTop="14dp"
         android:layout_marginBottom="18dp"
         android:layout_marginStart="19dp"
         app:layout_constraintTop_toBottomOf="@id/rv_feed_post_comment"
@@ -207,12 +203,35 @@
         tools:visibility="visible"
         tools:text="댓글 11개 더보기"/>
 
-    <View
+
+    <com.google.android.flexbox.FlexboxLayout
+        android:id="@+id/layout_feed_post_tag_list"
         android:layout_width="match_parent"
-        android:layout_height="15dp"
-        android:layout_marginTop="10dp"
-        app:layout_constraintTop_toBottomOf="@id/tv_feed_post_more_comment"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginHorizontal="18dp"
+        app:alignContent="stretch"
+        app:alignItems="stretch"
+        app:flexWrap="wrap"
+        app:layout_constraintBottom_toTopOf="@id/view_feed_post_content_comment_divider"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_post_more_comment">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chipgroup_feed_post_tag_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </com.google.android.flexbox.FlexboxLayout>
+
+    <View
+        android:id="@+id/view_feed_post_content_comment_divider"
+        android:layout_width="match_parent"
+        android:layout_height="10dp"
+        android:layout_marginTop="25dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_feed_post_tag_list"
+        android:background="@color/gray_7_F6F6F6" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_feed_post.xml
+++ b/app/src/main/res/layout/item_feed_post.xml
@@ -208,7 +208,7 @@
         android:layout_marginTop="4dp"
         android:layout_marginBottom="18dp"
         android:layout_marginStart="19dp"
-        android:text="@{`댓글 `+ Integer.toString(feedContent.commentCount)+`개 더보기`}"
+        android:text="@{`댓글 `+ Integer.toString(feedContent.commentCount - 2) +`개 더보기`}"
         app:layout_constraintTop_toBottomOf="@id/rv_feed_post_comment"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_feed_post.xml
+++ b/app/src/main/res/layout/item_feed_post.xml
@@ -7,6 +7,12 @@
         <variable
             name="feedContent"
             type="com.daily.dayo.feed.model.FeedContent" />
+        <variable
+            name="feedContentCategory"
+            type="String" />
+        <variable
+            name="feedContentCreateTime"
+            type="String" />
     </data>
 
 <androidx.constraintlayout.widget.ConstraintLayout
@@ -19,17 +25,18 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="14dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/vp_feed_post"
+        app:layout_constraintBottom_toTopOf="@+id/img_feed_post"
         app:layout_constraintStart_toStartOf="parent">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/img_feed_post_user_profile"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="37dp"
+            android:layout_height="37dp"
+            app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginStart="16dp"
-            tools:src="@drawable/ic_dayo_circle_grayscale"/>
+            tools:src="@drawable/ic_user_profile_image_empty"/>
 
         <TextView
             android:id="@+id/tv_feed_post_user_nickname"
@@ -38,6 +45,7 @@
             android:textSize="14dp"
             android:textStyle="bold"
             android:textColor="@color/gray_1_313131"
+            android:text="@{feedContent.nickname}"
             app:layout_constraintTop_toTopOf="@+id/img_feed_post_user_profile"
             app:layout_constraintStart_toEndOf="@id/img_feed_post_user_profile"
             android:layout_marginStart="7dp"
@@ -47,9 +55,11 @@
             android:id="@+id/tv_feed_post_category"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="기타  | "
+            android:text="@{feedContentCategory+`  |  `}"
             android:textSize="10dp"
             android:textColor="@color/gray_3_9C9C9C"
+            android:layout_marginTop="5dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_feed_post_user_nickname"
             app:layout_constraintBottom_toBottomOf="@id/img_feed_post_user_profile"
             app:layout_constraintStart_toEndOf="@id/img_feed_post_user_profile"
             android:layout_marginStart="7dp"
@@ -58,11 +68,12 @@
             android:id="@+id/tv_feed_post_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text=" 18시간 전"
+            android:text="@{feedContentCreateTime}"
             android:textSize="10dp"
             android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintBottom_toBottomOf="@id/img_feed_post_user_profile"
-            app:layout_constraintStart_toEndOf="@id/tv_feed_post_category"
+            app:layout_constraintTop_toTopOf="@id/tv_feed_post_category"
+            app:layout_constraintBottom_toBottomOf="@id/tv_feed_post_category"
+            app:layout_constraintStart_toEndOf="@+id/tv_feed_post_category"
             tools:text=" 18시간 전"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -78,36 +89,36 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/vp_feed_post"
+    <ImageView
+        android:id="@+id/img_feed_post"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintDimensionRatio="1"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/layout_feed_post_info"
-        tools:listitem="@layout/item_feed_post_image" />
+        app:layout_constraintTop_toBottomOf="@+id/layout_feed_post_info" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/view_feed_post_image_indicators"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="14dp"
-        app:layout_constraintStart_toStartOf="@+id/vp_feed_post"
-        app:layout_constraintEnd_toEndOf="@+id/vp_feed_post"
-        app:layout_constraintBottom_toBottomOf="@id/vp_feed_post"/>
+        app:layout_constraintStart_toStartOf="@+id/img_feed_post"
+        app:layout_constraintEnd_toEndOf="@+id/img_feed_post"
+        app:layout_constraintBottom_toBottomOf="@id/img_feed_post"/>
 
     <ImageButton
         android:id="@+id/btn_feed_post_like"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
-        android:src="@drawable/ic_post_like_default"
+        android:src="@{feedContent.heart == true ? @drawable/ic_post_like_checked : @drawable/ic_post_like_default}"
         android:layout_marginStart="19dp"
         android:layout_marginTop="15dp"
-        app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@+id/img_feed_post"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:src="@drawable/ic_post_like_default"/>
 
     <ImageButton
         android:id="@+id/btn_feed_post_share"
@@ -118,7 +129,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="15dp"
         android:layout_marginEnd="15dp"
-        app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
+        app:layout_constraintTop_toBottomOf="@+id/img_feed_post"
         app:layout_constraintStart_toEndOf="@+id/btn_feed_post_like"/>
 
     <ImageButton
@@ -130,14 +141,14 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="15dp"
         android:layout_marginEnd="17dp"
-        app:layout_constraintTop_toBottomOf="@+id/vp_feed_post"
+        app:layout_constraintTop_toBottomOf="@+id/img_feed_post"
         app:layout_constraintEnd_toEndOf="parent"/>
 
     <TextView
         android:id="@+id/tv_feed_post_content_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="좋아요 135개   |   댓글 12개"
+        android:text="@{`좋아요 `+ Integer.toString(feedContent.heartCount)+`개   |   댓글 `+ Integer.toString(feedContent.commentCount)+`개`}"
         android:textSize="13dp"
         android:textStyle="bold"
         android:textColor="@color/gray_1_313131"
@@ -164,6 +175,7 @@
         android:maxLines="2"
         android:ellipsize="end"
         android:textSize="12dp"
+        android:text="@{feedContent.contents}"
         android:textColor="@color/gray_1_313131"
         android:layout_marginStart="18dp"
         android:layout_marginTop="11dp"
@@ -171,7 +183,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/view_feed_post_horizontal_line"
-        tools:text="다이어리를 꾸며봤어요~! 블랙 앤 화이트로 꾸며봤습니다:) 일기를 써보았어요. 이러쿵 저러쿵"/>
+        tools:text="다이어리를 꾸며봤어요~! 블랙 앤 화이트로 꾸며봤습니다:) 일기를 써보았어요. 이러쿵 저러쿵" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_feed_post_comment"
@@ -182,7 +194,7 @@
         app:layout_constraintTop_toBottomOf="@+id/tv_feed_post_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         android:overScrollMode="never"
         tools:itemCount="2"
         tools:listitem="@layout/item_feed_post_comment"/>
@@ -193,14 +205,13 @@
         android:layout_height="wrap_content"
         android:textSize="12dp"
         android:textColor="@color/gray_3_9C9C9C"
-        android:layout_marginTop="14dp"
+        android:layout_marginTop="4dp"
         android:layout_marginBottom="18dp"
         android:layout_marginStart="19dp"
+        android:text="@{`댓글 `+ Integer.toString(feedContent.commentCount)+`개 더보기`}"
         app:layout_constraintTop_toBottomOf="@id/rv_feed_post_comment"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:visibility="invisible"
-        tools:visibility="visible"
         tools:text="댓글 11개 더보기"/>
 
 
@@ -208,7 +219,7 @@
         android:id="@+id/layout_feed_post_tag_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:paddingTop="20dp"
         android:layout_marginHorizontal="18dp"
         app:alignContent="stretch"
         app:alignItems="stretch"

--- a/app/src/main/res/layout/item_feed_post_comment.xml
+++ b/app/src/main/res/layout/item_feed_post_comment.xml
@@ -1,18 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/tv_feed_post_comment"
-        android:layout_width="wrap_content"
+    <data>
+        <variable
+            name="feedComment"
+            type="com.daily.dayo.post.model.PostCommentContent" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="12dp"
-        android:textColor="@color/gray_1_313131"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:paddingBottom="8dp"
-        tools:text="ammondee  와 ~.... 다이어리가 예뻐요~......." />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_marginBottom="10dp">
+
+        <TextView
+            android:id="@+id/tv_feed_post_comment_user_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{feedComment.nickname}"
+            android:textSize="13dp"
+            android:textStyle="bold"
+            android:textColor="@color/gray_1_313131"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="ammondee"/>
+
+        <TextView
+            android:id="@+id/tv_feed_post_comment_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{feedComment.contents}"
+            android:textColor="@color/gray_1_313131"
+            android:textSize="13dp"
+            android:layout_marginStart="10dp"
+            app:layout_constraintStart_toEndOf="@id/tv_feed_post_comment_user_nickname"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:maxLines="1"
+            android:ellipsize="end"
+            tools:text="와~ 다이어리가 예뻐요~" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -55,6 +55,15 @@
         <action
             android:id="@+id/action_feedFragment_to_writeFragment"
             app:destination="@id/WriteFragment" />
+        <action
+            android:id="@+id/action_feedFragment_to_otherProfileFragment"
+            app:destination="@+id/OtherProfileFragment"/>
+        <action
+            android:id="@+id/action_feedFragment_to_myProfileFragment"
+            app:destination="@+id/MyProfileFragment"/>
+        <action
+            android:id="@+id/action_feedFragment_to_postFragment"
+            app:destination="@+id/PostFragment"/>
     </fragment>
 
     <fragment


### PR DESCRIPTION
+ FeedFragment 레이아웃 디자인 변경사항 적용
+ 피드 관련 API통신 구현

### 게시글 내용 표시 
+ databinding사용하여 게시글 정보 표시
+ 댓글이 없을 시 해당 레이아웃을 보이지 않도록 함
  + 댓글이 2개 초과일 경우 2개만 보이도록 하며, 더보기 문구를 띄움
+ 해시태그가 없을 시 해당 레이아웃을 보이지 않도록 함

### 클릭 이벤트 
+ 피드에서 작성자 프로필 클릭 시 해당 프로필로 이동
+ 댓글 더보기나 게시글 내용 클릭 시 해당 게시글의 PostFragment로 이동
+ 하트 아이콘 클릭 시 좋아요, 좋아요 취소 구현

resolved: #160

