### PR TITLE
#162 [feature] WriteModifyFragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/network/write/WriteApiHelper.kt
+++ b/app/src/main/java/com/daily/dayo/network/write/WriteApiHelper.kt
@@ -1,10 +1,12 @@
 package com.daily.dayo.network.write
 
+import com.daily.dayo.write.model.RequestEditWrite
+import com.daily.dayo.write.model.ResponseEditWrite
 import com.daily.dayo.write.model.ResponseWrite
 import okhttp3.MultipartBody
 import retrofit2.Response
 
 interface WriteApiHelper {
-    suspend fun requestUploadPost(category: String, contents: String, files: List<MultipartBody.Part>, folderId: Int, memberId: String,
-                                  privacy: String, tags: Array<String>): Response<ResponseWrite>
+    suspend fun requestUploadPost(category: String, contents: String, files: List<MultipartBody.Part>, folderId: Int, tags: Array<String>): Response<ResponseWrite>
+    suspend fun requestEditPost(postId: Int, request: RequestEditWrite): Response<ResponseEditWrite>
 }

--- a/app/src/main/java/com/daily/dayo/network/write/WriteApiHelperImpl.kt
+++ b/app/src/main/java/com/daily/dayo/network/write/WriteApiHelperImpl.kt
@@ -1,11 +1,13 @@
 package com.daily.dayo.network.write
 
+import com.daily.dayo.write.model.RequestEditWrite
+import com.daily.dayo.write.model.ResponseEditWrite
 import com.daily.dayo.write.model.ResponseWrite
 import okhttp3.MultipartBody
 import retrofit2.Response
 import javax.inject.Inject
 
 class WriteApiHelperImpl @Inject constructor(private val writeApiService: WriteApiService) : WriteApiHelper {
-    override suspend fun requestUploadPost(category: String, contents: String, files: List<MultipartBody.Part>, folderId: Int,
-        memberId: String, privacy: String, tags: Array<String>): Response<ResponseWrite> = writeApiService.requestUploadPost(category, contents, files, folderId, memberId, privacy, tags)
+    override suspend fun requestUploadPost(category: String, contents: String, files: List<MultipartBody.Part>, folderId: Int, tags: Array<String>): Response<ResponseWrite> = writeApiService.requestUploadPost(category, contents, files, folderId, tags)
+    override suspend fun requestEditPost(postId: Int, request: RequestEditWrite): Response<ResponseEditWrite> = writeApiService.requestEditPost(postId, request)
 }

--- a/app/src/main/java/com/daily/dayo/network/write/WriteApiService.kt
+++ b/app/src/main/java/com/daily/dayo/network/write/WriteApiService.kt
@@ -1,17 +1,18 @@
 package com.daily.dayo.network.write
 
+import com.daily.dayo.write.model.RequestEditWrite
+import com.daily.dayo.write.model.ResponseEditWrite
 import com.daily.dayo.write.model.ResponseWrite
 import okhttp3.MultipartBody
 import retrofit2.Response
-import retrofit2.http.Multipart
-import retrofit2.http.POST
-import retrofit2.http.Part
+import retrofit2.http.*
 
 interface WriteApiService {
     @Multipart
     @POST("/api/v1/posts")
     suspend fun requestUploadPost(@Part("category") category: String, @Part("contents") contents: String,
                                   @Part files: List<MultipartBody.Part>, @Part("folderId") folderId: Int,
-                                  @Part("memberId") memberId: String, @Part("privacy") privacy: String,
-                                  @Part("tags") tags: Array<String>,): Response<ResponseWrite>
+                                  @Part("tags") tags: Array<String>): Response<ResponseWrite>
+    @POST("/api/v1/posts/{postId}/edit")
+    suspend fun requestEditPost(@Path("postId") postId:Int, @Body body : RequestEditWrite) : Response<ResponseEditWrite>
 }

--- a/app/src/main/java/com/daily/dayo/post/model/ResponsePost.kt
+++ b/app/src/main/java/com/daily/dayo/post/model/ResponsePost.kt
@@ -11,6 +11,10 @@ data class ResponsePost (
     val contents: String,
     @SerializedName("createDateTime")
     val createDateTime: String,
+    @SerializedName("folderId")
+    val folderId: Int,
+    @SerializedName("folderName")
+    val folderName: String,
     @SerializedName("hashtags")
     val hashtags: List<String>,
     @SerializedName("heart")

--- a/app/src/main/java/com/daily/dayo/repository/WriteRepository.kt
+++ b/app/src/main/java/com/daily/dayo/repository/WriteRepository.kt
@@ -1,6 +1,8 @@
 package com.daily.dayo.repository
 
 import com.daily.dayo.network.write.WriteApiHelper
+import com.daily.dayo.write.model.RequestEditWrite
+import com.daily.dayo.write.model.ResponseEditWrite
 import com.daily.dayo.write.model.ResponseWrite
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -10,7 +12,7 @@ import java.io.File
 import javax.inject.Inject
 
 class WriteRepository @Inject constructor(private val writeApiHelper: WriteApiHelper) {
-    suspend fun requestUploadPost(postCategory: String, postContents: String, files: Array<File>, postFolderId: Int, memberId: String, postPrivacy: String, postTags: Array<String>): Response<ResponseWrite> {
+    suspend fun requestUploadPost(postCategory: String, postContents: String, files: Array<File>, postFolderId: Int, postTags: Array<String>): Response<ResponseWrite> {
         val uploadFiles: ArrayList<MultipartBody.Part> = ArrayList()
         for(i in 0 until files.size) {
             val imageFile = files.get(i)
@@ -19,6 +21,7 @@ class WriteRepository @Inject constructor(private val writeApiHelper: WriteApiHe
             val uploadFile = MultipartBody.Part.createFormData("files",fileNameDivideList[fileNameDivideList.size - 1], requestBodyFile)
             uploadFiles.add(uploadFile)
         }
-        return writeApiHelper.requestUploadPost(postCategory, postContents, uploadFiles, postFolderId, memberId, postPrivacy, postTags)
+        return writeApiHelper.requestUploadPost(postCategory, postContents, uploadFiles, postFolderId, postTags)
     }
+    suspend fun requestEditPost(postId: Int, request: RequestEditWrite) : Response<ResponseEditWrite> = writeApiHelper.requestEditPost(postId, request)
 }

--- a/app/src/main/java/com/daily/dayo/write/WriteOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/write/WriteOptionFragment.kt
@@ -68,14 +68,16 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
 
     private fun setUploadButtonClickListener() {
         binding.btnWriteOptionConfirm.setOnClickListener {
-            val privacy = setPrivacySetting()
             val memberId = SharedManager(DayoApplication.applicationContext()).getCurrentUser().memberId.toString()
-            if(postFolderId==""){
+            if(postFolderId==""){ // 폴더 미선택시 글 업로드 불가
                 Toast.makeText(requireContext(), "폴더를 선택해 주세요", Toast.LENGTH_SHORT).show()
+            } else if(args.postId != 0) { // 기존 게시글을 수정하는 경우
+                writeOptionViewModel.requestEditPost(args.postId, postCategory, postContents, postFolderId.toInt(), postTagList)
+                Toast.makeText(requireContext(), R.string.write_post_upload_alert_message_loading, Toast.LENGTH_SHORT).show()
+                findNavController().navigateUp()
             }
-            else{
-                writeOptionViewModel.requestUploadPost(postCategory, postContents, postImageFileList.toTypedArray(),
-                    postFolderId.toInt(), memberId, privacy, postTagList)
+            else{ // 새로 글을 작성하는 경우
+                writeOptionViewModel.requestUploadPost(postCategory, postContents, postImageFileList.toTypedArray(), postFolderId.toInt(), postTagList)
                 Toast.makeText(requireContext(), R.string.write_post_upload_alert_message_loading, Toast.LENGTH_SHORT).show()
                 findNavController().navigateUp()
             }
@@ -85,18 +87,6 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
     private fun setFolderDescription(){
         if(postFolderId!=""){
             binding.tvWriteOptionDescriptionFolder.text = postFolderName
-        }
-    }
-
-    private fun setPrivacySetting() : String {
-        val radioButton = binding.radiogroupWriteOptionDescriptionPrivate?.findViewById<View>(binding.radiogroupWriteOptionDescriptionPrivate!!.checkedRadioButtonId)
-        val radioId = binding.radiogroupWriteOptionDescriptionPrivate!!.indexOfChild(radioButton)
-        val btn = binding.radiogroupWriteOptionDescriptionPrivate!!.getChildAt(radioId) as RadioButton
-        return when(btn.text as String) {
-            getString(R.string.privacy_all) -> getString(R.string.privacy_all_eng)
-            getString(R.string.privacy_following) -> getString(R.string.privacy_following_eng)
-            getString(R.string.privacy_private) -> getString(R.string.privacy_private_eng)
-            else -> getString(R.string.privacy_private_eng)
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/write/adapter/WriteUploadImageListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/write/adapter/WriteUploadImageListAdapter.kt
@@ -3,12 +3,13 @@ package com.daily.dayo.write.adapter
 import android.content.Context
 import android.net.Uri
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.daily.dayo.databinding.ItemWritePostUploadImageBinding
 
-class WriteUploadImageListAdapter (private val items: ArrayList<Uri>, val context: Context) :
+class WriteUploadImageListAdapter (private val items: ArrayList<Uri>, val context: Context, val postId: Int) :
     RecyclerView.Adapter<WriteUploadImageListAdapter.WriteUploadImageListViewHolder>() {
     interface OnItemClickListener{
         fun deleteUploadImageClick(pos: Int)
@@ -45,6 +46,7 @@ class WriteUploadImageListAdapter (private val items: ArrayList<Uri>, val contex
                     listener?.deleteUploadImageClick(pos)
                 }
             }
+            if(postId != 0) { binding.btnImgUploadDelete.visibility = View.INVISIBLE }
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/write/model/Write.kt
+++ b/app/src/main/java/com/daily/dayo/write/model/Write.kt
@@ -23,3 +23,19 @@ data class ResponseWrite (
     @SerializedName("id")
     val id: Int
 )
+
+data class RequestEditWrite (
+    @SerializedName("category")
+    val category: String,
+    @SerializedName("contents")
+    val contents : String,
+    @SerializedName("folderId")
+    val folderId : Int,
+    @SerializedName("hashtags")
+    val hashtags : List<String>
+)
+
+data class ResponseEditWrite (
+    @SerializedName("postId")
+    val postId: Int
+)

--- a/app/src/main/java/com/daily/dayo/write/viewmodel/WriteOptionViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/write/viewmodel/WriteOptionViewModel.kt
@@ -8,6 +8,7 @@ import com.daily.dayo.post.model.ResponsePost
 import com.daily.dayo.repository.PostRepository
 import com.daily.dayo.repository.WriteRepository
 import com.daily.dayo.util.Event
+import com.daily.dayo.write.model.RequestEditWrite
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
@@ -20,20 +21,35 @@ class WriteOptionViewModel @Inject constructor(private val writeRepository: Writ
     val writePostId : LiveData<Event<Int>> get() = _writePostId
     private val _writeSuccess = MutableLiveData<Event<Boolean>>()
     val writeSuccess : LiveData<Event<Boolean>> get() =_writeSuccess
+    private val _writeEditSuccess = MutableLiveData<Event<Boolean>>()
+    val writeEditSuccess : LiveData<Event<Boolean>> get() =_writeEditSuccess
 
     private val _writeCurrentPostDetail = MutableLiveData<Event<ResponsePost>>()
     val writeCurrentPostDetail: LiveData<Event<ResponsePost>> get() = _writeCurrentPostDetail
     private val _getCurrentPostSuccess = MutableLiveData<Event<Boolean>>()
     val getCurrentPostSuccess : LiveData<Event<Boolean>> get() =_getCurrentPostSuccess
 
-    fun requestUploadPost(postCategory: String, postContents: String, files: Array<File>,
-                   postFolderId: Int, memberId: String, postPrivacy: String, postTags: Array<String>) = viewModelScope.launch {
-        val response = writeRepository.requestUploadPost(postCategory, postContents, files, postFolderId, memberId, postPrivacy, postTags)
+    fun requestUploadPost(postCategory: String, postContents: String, files: Array<File>, postFolderId: Int, postTags: Array<String>)
+    = viewModelScope.launch {
+        val response = writeRepository.requestUploadPost(postCategory, postContents, files, postFolderId, postTags)
         if(response.isSuccessful) {
             _writePostId.postValue(Event(response.body()?.id) as Event<Int>?)
             _writeSuccess.postValue(Event(true))
         } else {
             _writeSuccess.postValue(Event(false))
+        }
+    }
+
+    fun requestEditPost(postId: Int, postCategory: String, postContents: String, postFolderId: Int, postTags: Array<String>)
+    = viewModelScope.launch {
+        val response = writeRepository.requestEditPost(postId,
+            RequestEditWrite(postCategory, postContents, postFolderId, postTags.toList())
+        )
+        if(response.isSuccessful) {
+            _writePostId.postValue(Event(response.body()?.postId) as Event<Int>)
+            _writeEditSuccess.postValue(Event(true))
+        } else {
+            _writeEditSuccess.postValue(Event(false))
         }
     }
 

--- a/app/src/main/res/layout/fragment_write_option.xml
+++ b/app/src/main/res/layout/fragment_write_option.xml
@@ -65,80 +65,10 @@
         android:layout_marginTop="23dp"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_write_option_private"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/view_folder_horizontal_line"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:paddingTop="17dp"
-        android:layout_marginHorizontal="18dp" >
-        <TextView
-            android:id="@+id/tv_write_option_title_private"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/write_option_title_private"
-            android:textSize="15dp"
-            android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"/>
-        <RadioGroup
-            android:id="@+id/radiogroup_write_option_description_private"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
-            <RadioButton
-                android:checked="true"
-                android:id="@+id/radiobutton_write_option_description_private_all"
-                android:layout_width="77dp"
-                android:layout_height="27dp"
-                android:text="@string/privacy_all"
-                android:textSize="13dp"
-                android:textColor="@drawable/selector_button_write_option_private_text"
-                android:textAlignment="center"
-                android:background="@drawable/selector_button_write_option_private"
-                android:button="@null"
-                android:layout_marginEnd="7dp"/>
-            <RadioButton
-                android:id="@+id/radiobutton_write_option_description_private_following"
-                android:layout_width="77dp"
-                android:layout_height="27dp"
-                android:text="@string/privacy_following"
-                android:textSize="13dp"
-                android:textColor="@drawable/selector_button_write_option_private_text"
-                android:textAlignment="center"
-                android:background="@drawable/selector_button_write_option_private"
-                android:button="@null"
-                android:layout_marginEnd="7dp"/>
-            <RadioButton
-                android:id="@+id/radiobutton_write_option_description_private_only_me"
-                android:layout_width="77dp"
-                android:layout_height="27dp"
-                android:text="@string/privacy_private"
-                android:textSize="13dp"
-                android:textColor="@drawable/selector_button_write_option_private_text"
-                android:textAlignment="center"
-                android:background="@drawable/selector_button_write_option_private"
-                android:button="@null"/>
-        </RadioGroup>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    <View
-        android:id="@+id/view_private_horizontal_line"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/gray_6_EDEDED"
-        app:layout_constraintTop_toBottomOf="@id/layout_write_option_private"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="17dp"/>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_write_option_tag"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/view_private_horizontal_line"
+        app:layout_constraintTop_toBottomOf="@id/view_folder_horizontal_line"
         app:layout_constraintStart_toStartOf="parent"
         android:paddingTop="18dp"
         android:layout_marginHorizontal="18dp">

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -117,6 +117,10 @@
         android:label="fragment_write_option"
         tools:layout="@layout/fragment_write_option">
         <argument
+            android:name="postId"
+            app:argType="integer"
+            android:defaultValue="0"/>
+        <argument
             android:name="postCategory"
             app:argType="string"/>
         <argument


### PR DESCRIPTION
- 글 상세보기에서 게시글 수정 클릭 시 글 작성화면으로 기존 글 콘텐츠가 삽입되면서 이동 구현
- 글 수정시, 이미지 삭제및 추가 불가능 처리
- 기존 글 수정 및 새로운 글 작성 구분을 위한 nav_graph.xml에서 WriteOptionFragment의 argument 추가
- 글 상세보기 기존 response Model 수정
- 글 작성에 대한 기존 글 수정 Model 추가
- privacy 설정 삭제

resolved: #162