### PR TITLE
#222 [layout] MyProfileFragment Scroll with tabItem

### DIFF
--- a/app/src/main/res/layout/fragment_my_profile.xml
+++ b/app/src/main/res/layout/fragment_my_profile.xml
@@ -2,213 +2,210 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
-
     <data>
-
         <variable
             name="userInfo"
             type="com.daily.dayo.profile.model.ResponseMyProfile" />
     </data>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:overScrollMode="never">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
+        android:background="@color/gray_6_F6F6F6">
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/gray_6_F6F6F6">
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_my_profile_action_bar"
-                android:layout_width="0dp"
-                android:layout_height="?actionBarSize"
-                android:background="@color/white_FFFFFF"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <ImageButton
-                    android:id="@+id/btn_my_profile_option"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="5dp"
-                    android:background="@android:color/transparent"
-                    android:paddingHorizontal="13dp"
-                    android:src="@drawable/ic_option_horizontal"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_my_profile"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent">
+            <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/background_profile_round_bottom_corner"
-                android:paddingBottom="37dp"
-                app:layout_constraintTop_toBottomOf="@+id/layout_my_profile_action_bar">
+                app:contentScrim="@android:color/transparent"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_my_profile_action_bar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?actionBarSize"
+                    android:background="@color/white_FFFFFF"
+                    app:layout_collapseMode="parallax">
+                    <ImageButton
+                        android:id="@+id/btn_my_profile_option"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_marginEnd="5dp"
+                        android:background="@android:color/transparent"
+                        android:paddingHorizontal="13dp"
+                        android:src="@drawable/ic_option_horizontal"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/img_my_profile_user_profile"
-                    android:layout_width="70dp"
-                    android:layout_height="70dp"
-                    android:scaleType="centerCrop"
-                    android:src="@drawable/ic_profile_default_user_profile"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:shapeAppearanceOverlay="@style/roundedImageViewRounded" />
-
-                <TextView
-                    android:id="@+id/tv_my_profile_user_nickname"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="11dp"
-                    android:text="@{userInfo.nickname}"
-                    android:textColor="@color/gray_1_313131"
-                    android:textSize="20dp"
-                    android:textStyle="bold"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/img_my_profile_user_profile"
-                    tools:text="Nickname" />
-
-                <TextView
-                    android:id="@+id/tv_my_profile_user_email"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
-                    android:text="@{userInfo.email}"
-                    android:textColor="@color/gray_3_9C9C9C"
-                    android:textSize="11dp"
-                    app:layout_constraintEnd_toEndOf="@id/tv_my_profile_user_nickname"
-                    app:layout_constraintStart_toStartOf="@id/tv_my_profile_user_nickname"
-                    app:layout_constraintTop_toBottomOf="@id/tv_my_profile_user_nickname"
-                    tools:text="ovo123098@naver.com" />
-
-                <LinearLayout
-                    android:id="@+id/layout_my_profile_count"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_my_profile"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="90dp"
-                    android:layout_marginTop="41dp"
-                    android:orientation="horizontal"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_my_profile_user_email">
+                    android:background="@drawable/background_profile_round_bottom_corner"
+                    android:layout_marginTop="?attr/actionBarSize"
+                    android:paddingBottom="37dp"
+                    android:layout_marginBottom="13dp"
+                    app:layout_collapseMode="parallax">
+
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/img_my_profile_user_profile"
+                        android:layout_width="70dp"
+                        android:layout_height="70dp"
+                        android:scaleType="centerCrop"
+                        android:src="@drawable/ic_profile_default_user_profile"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:shapeAppearanceOverlay="@style/roundedImageViewRounded" />
+
+                    <TextView
+                        android:id="@+id/tv_my_profile_user_nickname"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="11dp"
+                        android:text="@{userInfo.nickname}"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="20dp"
+                        android:textStyle="bold"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/img_my_profile_user_profile"
+                        tools:text="Nickname" />
+
+                    <TextView
+                        android:id="@+id/tv_my_profile_user_email"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="5dp"
+                        android:text="@{userInfo.email}"
+                        android:textColor="@color/gray_3_9C9C9C"
+                        android:textSize="11dp"
+                        app:layout_constraintEnd_toEndOf="@id/tv_my_profile_user_nickname"
+                        app:layout_constraintStart_toStartOf="@id/tv_my_profile_user_nickname"
+                        app:layout_constraintTop_toBottomOf="@id/tv_my_profile_user_nickname"
+                        tools:text="ovo123098@naver.com" />
 
                     <LinearLayout
-                        android:id="@+id/layout_my_profile_post_count"
-                        android:layout_width="0dp"
+                        android:id="@+id/layout_my_profile_count"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:layout_marginHorizontal="90dp"
+                        android:layout_marginTop="41dp"
+                        android:orientation="horizontal"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/tv_my_profile_user_email">
 
-                        <TextView
-                            android:id="@+id/tv_my_profile_post_count"
-                            android:layout_width="wrap_content"
+                        <LinearLayout
+                            android:id="@+id/layout_my_profile_post_count"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_marginBottom="9dp"
-                            android:text="@{Integer.toString(userInfo.postCount)}"
-                            android:textColor="#5A5A5A"
-                            android:textSize="15dp"
-                            android:textStyle="bold"
-                            tools:text="0" />
+                            android:layout_weight="1"
+                            android:orientation="vertical">
 
-                        <TextView
-                            android:layout_width="wrap_content"
+                            <TextView
+                                android:id="@+id/tv_my_profile_post_count"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_marginBottom="9dp"
+                                android:text="@{Integer.toString(userInfo.postCount)}"
+                                android:textColor="#5A5A5A"
+                                android:textSize="15dp"
+                                android:textStyle="bold"
+                                tools:text="0" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:text="게시글"
+                                android:textColor="@color/gray_3_9C9C9C"
+                                android:textSize="11dp"
+                                android:textStyle="bold" />
+                        </LinearLayout>
+
+                        <View
+                            android:id="@+id/view_my_profile_count_post_vertical_line"
+                            android:layout_width="0.6dp"
+                            android:layout_height="match_parent"
+                            android:background="@color/gray_4_D3D2D2" />
+
+                        <LinearLayout
+                            android:id="@+id/layout_my_profile_follower_count"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:text="게시글"
-                            android:textColor="@color/gray_3_9C9C9C"
-                            android:textSize="11dp"
-                            android:textStyle="bold" />
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/tv_my_profile_follower_count"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_marginBottom="9dp"
+                                android:text="@{Integer.toString(userInfo.followerCount)}"
+                                android:textColor="#5A5A5A"
+                                android:textSize="15dp"
+                                android:textStyle="bold"
+                                tools:text="0" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:text="팔로워"
+                                android:textColor="@color/gray_3_9C9C9C"
+                                android:textSize="11dp"
+                                android:textStyle="bold" />
+
+                        </LinearLayout>
+
+                        <View
+                            android:id="@+id/view_my_profile_count_follower_vertical_line"
+                            android:layout_width="0.6dp"
+                            android:layout_height="match_parent"
+                            android:background="@color/gray_4_D3D2D2" />
+
+                        <LinearLayout
+                            android:id="@+id/layout_my_profile_following_count"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/tv_my_profile_following_count"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_marginBottom="9dp"
+                                android:text="@{Integer.toString(userInfo.followingCount)}"
+                                android:textColor="#5A5A5A"
+                                android:textSize="15dp"
+                                android:textStyle="bold"
+                                tools:text="0" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:text="팔로잉"
+                                android:textColor="@color/gray_3_9C9C9C"
+                                android:textSize="11dp"
+                                android:textStyle="bold" />
+                        </LinearLayout>
                     </LinearLayout>
-
-                    <View
-                        android:id="@+id/view_my_profile_count_post_vertical_line"
-                        android:layout_width="0.6dp"
-                        android:layout_height="match_parent"
-                        android:background="@color/gray_4_D3D2D2" />
-
-                    <LinearLayout
-                        android:id="@+id/layout_my_profile_follower_count"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/tv_my_profile_follower_count"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_marginBottom="9dp"
-                            android:text="@{Integer.toString(userInfo.followerCount)}"
-                            android:textColor="#5A5A5A"
-                            android:textSize="15dp"
-                            android:textStyle="bold"
-                            tools:text="0" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:text="팔로워"
-                            android:textColor="@color/gray_3_9C9C9C"
-                            android:textSize="11dp"
-                            android:textStyle="bold" />
-
-                    </LinearLayout>
-
-                    <View
-                        android:id="@+id/view_my_profile_count_follower_vertical_line"
-                        android:layout_width="0.6dp"
-                        android:layout_height="match_parent"
-                        android:background="@color/gray_4_D3D2D2" />
-
-                    <LinearLayout
-                        android:id="@+id/layout_my_profile_following_count"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/tv_my_profile_following_count"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_marginBottom="9dp"
-                            android:text="@{Integer.toString(userInfo.followingCount)}"
-                            android:textColor="#5A5A5A"
-                            android:textSize="15dp"
-                            android:textStyle="bold"
-                            tools:text="0" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:text="팔로잉"
-                            android:textColor="@color/gray_3_9C9C9C"
-                            android:textSize="11dp"
-                            android:textStyle="bold" />
-                    </LinearLayout>
-                </LinearLayout>
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabs_my_profile"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_marginTop="13dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_my_profile"
+                android:layout_height="wrap_content"
 
                 app:tabGravity="center"
                 app:tabIndicator="@drawable/tab_indicator"
@@ -221,7 +218,6 @@
                 app:tabSelectedTextColor="@color/gray_1_313131"
                 app:tabTextAppearance="@style/tab_profile"
                 app:tabTextColor="@color/gray_3_9C9C9C">
-
                 <com.google.android.material.tabs.TabItem
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -243,26 +239,20 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:background="@color/gray_6_F6F6F6"
-                app:layout_constraintBottom_toBottomOf="@+id/tabs_my_profile"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <View
-                android:id="@+id/view_empty_horizontal"
-                android:layout_width="match_parent"
-                android:layout_height="30dp"
-                android:background="@color/white_FFFFFF"
-                app:layout_constraintTop_toBottomOf="@id/view_tabs_horizontal_line"/>
-
+                app:layout_constraintStart_toStartOf="parent"/>
+        </com.google.android.material.appbar.AppBarLayout>
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/pager_my_profile"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/white_FFFFFF"
+                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/view_empty_horizontal" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_profile_bookmark_post_list.xml
+++ b/app/src/main/res/layout/fragment_profile_bookmark_post_list.xml
@@ -12,11 +12,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:overScrollMode="never"
+        android:clipToPadding="false"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:spanCount="2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:paddingTop="30dp"
         tools:listitem="@layout/item_profile_like_post"  />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_profile_folder_list.xml
+++ b/app/src/main/res/layout/fragment_profile_folder_list.xml
@@ -10,10 +10,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:overScrollMode="never"
+        android:clipToPadding="false"
         android:layout_marginHorizontal="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:paddingTop="30dp"
         tools:listitem="@layout/item_profile_folder" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_profile_like_post_list.xml
+++ b/app/src/main/res/layout/fragment_profile_like_post_list.xml
@@ -13,9 +13,11 @@
         android:overScrollMode="never"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:spanCount="2"
+        android:clipToPadding="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:paddingTop="30dp"
         tools:listitem="@layout/item_profile_like_post" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 내용
- 스크롤 시, 상단 프로필 메뉴는 접히면서, 툴바는 고정되어 스크롤 형태가 필요
- RecyclerView 스크롤시, 상단에 존재하는 간격또한 사라져야 함

## 작업 사항
- 접히는 스크롤을 구현을 위해 `NestedScrollView` 대신 `CollapsingToolbarLayout` 사용을 위한 `CoordinatorLayout` 및 `AppBarLayout` 도입 및 적용
- 메뉴 아래 공백 스크롤 활용을 위해 `view_empty_horizonal` View 삭제 및 각 RecyclerView에 대한 padding 추가 및 `clptToPadding` 속성 `false` 설정

resolved: #222