### PR TITLE
#242 [layout] WithdrawFragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/setting/SettingFragment.kt
+++ b/app/src/main/java/com/daily/dayo/setting/SettingFragment.kt
@@ -51,7 +51,7 @@ class SettingFragment: Fragment() {
     private fun setWithdrawButtonClickListener(){
         binding.layoutSettingWithdraw.setOnClickListener {
             val withdrawAlertDialog = DefaultDialogExplanationConfirm.createDialog(requireContext(), R.string.setting_withdraw_message,
-                R.string.setting_withdraw_explanation_message,true, true, R.string.confirm, R.string.cancel, {}, {})
+                R.string.setting_withdraw_explanation_message,true, true, R.string.confirm, R.string.cancel, {doWithdraw()}, {})
             if(!withdrawAlertDialog.isShowing) {
                 withdrawAlertDialog.show()
                 DefaultDialogConfigure.dialogResize(requireContext(), withdrawAlertDialog, 0.7f, 0.23f)
@@ -60,6 +60,10 @@ class SettingFragment: Fragment() {
                 withdrawAlertDialog.dismiss()
             }
         }
+    }
+
+    private fun doWithdraw(){
+        findNavController().navigate(SettingFragmentDirections.actionSettingFragmentToWithdrawFragment())
     }
 }
 

--- a/app/src/main/java/com/daily/dayo/setting/WithdrawFragment.kt
+++ b/app/src/main/java/com/daily/dayo/setting/WithdrawFragment.kt
@@ -1,0 +1,62 @@
+package com.daily.dayo.setting
+
+import android.os.Bundle
+import android.text.Spannable
+import android.text.style.ForegroundColorSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.daily.dayo.R
+import com.daily.dayo.databinding.FragmentWithdrawBinding
+import com.daily.dayo.util.autoCleared
+
+class WithdrawFragment : Fragment() {
+    private var binding by autoCleared<FragmentWithdrawBinding>()
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentWithdrawBinding.inflate(inflater, container, false)
+        setFinalMessageTextSpan()
+        setOnClickWithdrawOtherReason()
+        setBackButtonClickListener()
+        setWithdrawButtonActivation()
+        setWithdrawButtonClickListener()
+        return binding.root
+    }
+
+    private fun setBackButtonClickListener() {
+        binding.btnWithdrawBack.setOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun setOnClickWithdrawOtherReason(){
+        binding.radiogroupWithdrawReason.setOnCheckedChangeListener { _, id ->
+            if(binding.radiogroupWithdrawReason.checkedRadioButtonId!=-1) binding.btnWithdraw.isSelected = true
+            when(id) {
+                binding.radiobuttonWithdrawReasonOther.id -> binding.etWithdrawReasonOther.visibility = View.VISIBLE
+                else -> binding.etWithdrawReasonOther.visibility = View.INVISIBLE
+            }
+        }
+    }
+
+    private fun setWithdrawButtonActivation(){
+        if(binding.radiogroupWithdrawReason.checkedRadioButtonId==-1) binding.btnWithdraw.isSelected = false
+    }
+
+    private fun setWithdrawButtonClickListener(){
+        binding.btnWithdraw.setOnClickListener {
+            // TODO : 회원 탈퇴 관련 API 호출 (탈퇴 및 사유 저장)
+            //  로그인 정보 삭제 후 로그인 화면으로 이동
+        }
+    }
+
+    private fun setFinalMessageTextSpan(){
+        val spannableText : Spannable = binding.tvWithdrawFinalMessage.text as Spannable
+        spannableText.setSpan(ForegroundColorSpan(ContextCompat.getColor(requireContext(), R.color.primary_green_23C882)), 16, 35, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+}

--- a/app/src/main/res/drawable/selector_edittext_withdraw.xml
+++ b/app/src/main/res/drawable/selector_edittext_withdraw.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white_FFFFFF"/>
+            <stroke android:width="1dp"
+                android:color="@color/gray_6_F6F6F6"/>
+            <corners android:radius="8dp"/>
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white_FFFFFF"/>
+            <stroke android:width="1dp"
+                android:color="@color/primary_green_23C882"/>
+            <corners android:radius="8dp"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/selector_radiobutton_withdraw.xml
+++ b/app/src/main/res/drawable/selector_radiobutton_withdraw.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:drawable="@drawable/ic_check_mark"/>
+    <item android:state_checked="false" android:drawable="@android:color/transparent"/>
+</selector>

--- a/app/src/main/res/drawable/selector_radiobutton_withdraw_text.xml
+++ b/app/src/main/res/drawable/selector_radiobutton_withdraw_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true"
+        android:color="@color/primary_green_23C882"/>
+    <item android:state_checked="false"
+        android:color="@color/gray_4_D3D2D2"/>
+</selector>

--- a/app/src/main/res/layout/fragment_withdraw.xml
+++ b/app/src/main/res/layout/fragment_withdraw.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_withdraw_action_bar"
+        android:layout_width="0dp"
+        android:layout_height="?actionBarSize"
+        android:elevation="24dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+        <ImageButton
+            android:id="@+id/btn_withdraw_back"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_back_sign"
+            tools:ignore="ContentDescription"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:paddingStart="18dp"/>
+        <TextView
+            android:id="@+id/tv_withdraw_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/withdraw_title"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            android:textColor="@color/gray_1_313131"
+            app:layout_constraintTop_toTopOf="@id/btn_withdraw_back"
+            app:layout_constraintBottom_toBottomOf="@id/btn_withdraw_back"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_subheading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="18dp"
+        android:layout_marginTop="17dp"
+        android:text="@string/withdraw_subheading"
+        android:textColor="@color/gray_1_313131"
+        android:textSize="18dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_withdraw_action_bar"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <TextView
+        android:id="@+id/tv_subheading_explanation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="18dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="54dp"
+        android:text="@string/withdraw_subheading_explanation"
+        android:textColor="@color/gray_2_5D5D5D"
+        android:textSize="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bㅅias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_subheading" />
+
+    <RadioGroup
+        android:id="@+id/radiogroup_withdraw_reason"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_subheading_explanation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_1"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_1"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_2"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_2"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_3"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_3"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_4"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_4"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_5"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_5"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+        <RadioButton
+            android:id="@+id/radiobutton_withdraw_reason_other"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginHorizontal="18dp"
+            android:text="@string/withdraw_reason_other"
+            android:textSize="14dp"
+            android:layoutDirection="rtl"
+            android:button="@drawable/selector_radiobutton_withdraw"
+            android:textColor="@drawable/selector_radiobutton_withdraw_text" />
+    </RadioGroup>
+
+    <EditText
+        android:id="@+id/et_withdraw_reason_other"
+        android:layout_width="match_parent"
+        android:layout_height="94dp"
+        android:layout_marginHorizontal="19dp"
+        android:background="@drawable/selector_edittext_withdraw"
+        android:gravity="top"
+        android:hint="@string/withdraw_reason_other_hint"
+        android:inputType="textMultiLine"
+        android:maxLength="100"
+        android:padding="11dp"
+        android:textColorHint="@color/gray_4_D3D2D2"
+        android:textSize="13dp"
+        android:visibility="invisible"
+        app:layout_constraintTop_toBottomOf="@id/radiogroup_withdraw_reason"
+        tools:layout_editor_absoluteX="21dp"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/tv_withdraw_final_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/withdraw_final_message"
+        android:layout_marginHorizontal="43dp"
+        android:bufferType="spannable"
+        android:gravity="center"
+        android:textSize="12dp"
+        android:textColor="@color/gray_1_313131"
+        app:layout_constraintTop_toBottomOf="@id/et_withdraw_reason_other"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btn_withdraw"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_withdraw"
+        android:layout_width="match_parent"
+        android:layout_height="54dp"
+        android:layout_margin="18dp"
+        android:text="@string/withdraw_button"
+        android:textColor="@color/white_FFFFFF"
+        android:background="@drawable/selector_button_default_green"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -306,6 +306,16 @@
         android:name="com.daily.dayo.setting.SettingFragment"
         android:label="fragment_setting"
         tools:layout="@layout/fragment_setting">
+        <action
+            android:id="@+id/action_settingFragment_to_withdrawFragment"
+            app:destination="@id/WithdrawFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/WithdrawFragment"
+        android:name="com.daily.dayo.setting.WithdrawFragment"
+        android:label="fragment_withdraw"
+        tools:layout="@layout/fragment_withdraw">
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,21 @@
     <string name="setting_logout_message">계정을 로그아웃 할까요?</string>
     <string name="setting_withdraw_message">계정을 삭제할까요?</string>
     <string name="setting_withdraw_explanation_message">모든 정보가 삭제되며, 복구가 불가능합니다.</string>
+
+    <!-- Withdraw -->
+    <string name="withdraw_title">계정 삭제하기</string>
+    <string name="withdraw_subheading">정말 계정을 삭제하시겠어요?</string>
+    <string name="withdraw_subheading_explanation">계정을 삭제하는 이유에 대해 알려주세요. 적어주신 내용은 좀 더 나은 서비스를 제공하는데 사용됩니다.</string>
+    <string name="withdraw_button">계정 삭제</string>
+    <string name="withdraw_reason_1">이용이 불편해요.</string>
+    <string name="withdraw_reason_2">기록을 삭제하고 싶어요.</string>
+    <string name="withdraw_reason_3">자주 사용하지 않아요.</string>
+    <string name="withdraw_reason_4">개인정보 유출이 우려돼요.</string>
+    <string name="withdraw_reason_5">콘텐츠가 마음에 들지않아요.</string>
+    <string name="withdraw_reason_other">기타</string>
+    <string name="withdraw_reason_other_hint">탈퇴 사유를 작성해주세요. (100자 이내)</string>
+    <string name="withdraw_final_message">계정 삭제시 정보가 회원님의 모든 콘텐츠와 활동기록이 함께 삭제됩니다. 삭제된 정보는 복구할 수 없습니다.</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 


### PR DESCRIPTION
+ 설정 페이지에서 계정 삭제하기 dialog에서 확인 누를 시 계정 삭제하기 페이지로 이동
+ 피그마 디자인에 따라 계정삭제하기 레이아웃 구현
+ span을 사용해 텍스트 일부의 색상을 다르게 설정
<img width="255" alt="image" src="https://user-images.githubusercontent.com/30407907/165284821-1f65d1a4-e577-4d25-a238-440631ac3b55.png">

resolved : #242