### PR TITLE
#248 [bug] HomeFragment Item Margin, Loading

### DIFF
--- a/app/src/main/java/com/daily/dayo/SharedManager.kt
+++ b/app/src/main/java/com/daily/dayo/SharedManager.kt
@@ -59,7 +59,7 @@ class SharedManager @Inject constructor(@ApplicationContext context: Context) {
         val result = prefs["recentSearchKeyword", ""]
         var resultArr = ArrayList<String>()
         var jsonArr : JSONArray
-        if(resultArr.isEmpty()) {
+        if(result.isEmpty()) {
             jsonArr = JSONArray()
         } else {
             jsonArr = JSONArray(result)

--- a/app/src/main/java/com/daily/dayo/home/DayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/home/DayoPickPostListFragment.kt
@@ -18,7 +18,6 @@ import com.daily.dayo.home.adapter.HomeDayoPickAdapter
 import com.daily.dayo.home.model.PostContent
 import com.daily.dayo.post.model.RequestLikePost
 import com.daily.dayo.home.viewmodel.HomeViewModel
-import com.daily.dayo.util.GridSpacingItemDecoration
 import com.daily.dayo.util.Status
 import com.daily.dayo.util.autoCleared
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,7 +46,6 @@ class DayoPickPostListFragment : Fragment() {
     private fun setRvDayoPickPostAdapter() {
         homeDayoPickAdapter = HomeDayoPickAdapter(true)
         binding.rvDayopickPost.adapter = homeDayoPickAdapter
-        binding.rvDayopickPost.addItemDecoration(GridSpacingItemDecoration(2, 29.toPx(), 4.toPx()))
     }
 
     private fun setDayoPickPostListCollect() {
@@ -128,10 +126,5 @@ class DayoPickPostListFragment : Fragment() {
                 } }
             }
         })
-    }
-
-    fun Int.toPx() : Int {
-        val density = resources.displayMetrics.density
-        return (this * density).toInt()
     }
 }

--- a/app/src/main/java/com/daily/dayo/home/NewPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/home/NewPostListFragment.kt
@@ -18,7 +18,6 @@ import com.daily.dayo.home.adapter.HomeDayoPickAdapter
 import com.daily.dayo.home.model.PostContent
 import com.daily.dayo.home.viewmodel.HomeViewModel
 import com.daily.dayo.post.model.RequestLikePost
-import com.daily.dayo.util.GridSpacingItemDecoration
 import com.daily.dayo.util.Status
 import com.daily.dayo.util.autoCleared
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,7 +46,6 @@ class NewPostListFragment : Fragment() {
     private fun setRvNewPostAdapter() {
         homeNewPostListAdapter = HomeDayoPickAdapter(false)
         binding.rvNewPost.adapter = homeNewPostListAdapter
-        binding.rvNewPost.addItemDecoration(GridSpacingItemDecoration(2, 29.toPx(), 4.toPx()))
     }
 
     private fun setNewPostListCollect() {
@@ -128,10 +126,5 @@ class NewPostListFragment : Fragment() {
                 } }
             }
         })
-    }
-
-    fun Int.toPx() : Int {
-        val density = resources.displayMetrics.density
-        return (this * density).toInt()
     }
 }

--- a/app/src/main/res/layout/fragment_dayo_pick_post_list.xml
+++ b/app/src/main/res/layout/fragment_dayo_pick_post_list.xml
@@ -2,6 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -11,124 +12,144 @@
             android:id="@+id/layout_scroll_dayo_pick_post_list"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
+
                 <HorizontalScrollView
                     android:id="@+id/layout_dayo_pick_post_category"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingHorizontal="19dp"
                     android:scrollbars="none"
-                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    android:paddingHorizontal="19dp">
+                    app:layout_constraintTop_toTopOf="parent">
+
                     <RadioGroup
                         android:id="@+id/radiogroup_dayopick_post_category"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
                         android:paddingTop="14dp"
-                        android:paddingBottom="20dp">
+                        android:paddingBottom="20dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_all"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:checked="true"
-                            android:text="@string/all"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:checked="true"
+                            android:text="@string/all"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
+
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_scheduler"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/scheduler"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/scheduler"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_studyplanner"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/studyplanner"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/studyplanner"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_pocketbook"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/pocketbook"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/pocketbook"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_6holediary"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/sixHoleDiary"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/sixHoleDiary"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
+
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_digital"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/digital"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/digital"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
+
                         <RadioButton
                             android:id="@+id/radiobutton_dayopick_post_category_etc"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/etc"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
                             android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"/>
+                            android:button="@null"
+                            android:text="@string/etc"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
                     </RadioGroup>
                 </HorizontalScrollView>
 
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline_dayopick_contents_start"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.039" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline_dayopick_contents_end"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.961" />
+
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_dayopick_post"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:overScrollMode="never"
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:spanCount="2"
+                    app:layout_constraintEnd_toEndOf="@id/guideline_dayopick_contents_end"
+                    app:layout_constraintStart_toStartOf="@id/guideline_dayopick_contents_start"
                     app:layout_constraintTop_toBottomOf="@id/layout_dayo_pick_post_category"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    android:layout_marginHorizontal="14dp"
+                    app:spanCount="2"
                     tools:listitem="@layout/item_main_post" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_new_post_list.xml
+++ b/app/src/main/res/layout/fragment_new_post_list.xml
@@ -2,6 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -11,125 +12,144 @@
             android:id="@+id/layout_scroll_new_post_list"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
+
                 <HorizontalScrollView
                     android:id="@+id/layout_new_post_category"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingHorizontal="19dp"
                     android:scrollbars="none"
-                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    android:paddingHorizontal="19dp">
+                    app:layout_constraintTop_toTopOf="parent">
+
                     <RadioGroup
                         android:id="@+id/radiogroup_new_post_category"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
                         android:paddingTop="14dp"
-                        android:paddingBottom="20dp">
+                        android:paddingBottom="20dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_all"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:checked="true"
-                            android:text="@string/all"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:checked="true"
+                            android:text="@string/all"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
+
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_scheduler"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/scheduler"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/scheduler"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_studyplanner"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/studyplanner"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/studyplanner"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_pocketbook"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/pocketbook"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/pocketbook"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_6holediary"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/sixHoleDiary"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/sixHoleDiary"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
 
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_digital"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/digital"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
+                            android:layout_marginEnd="8dp"
                             android:background="@drawable/selector_button_home_post_category"
                             android:button="@null"
-                            android:layout_marginEnd="8dp"/>
+                            android:text="@string/digital"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
+
                         <RadioButton
                             android:id="@+id/radiobutton_new_post_category_etc"
                             android:layout_width="83dp"
                             android:layout_height="26dp"
-                            android:text="@string/etc"
-                            android:textSize="12dp"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textAlignment="center"
                             android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"/>
+                            android:button="@null"
+                            android:text="@string/etc"
+                            android:textAlignment="center"
+                            android:textColor="@drawable/selector_button_home_post_category_text"
+                            android:textSize="12dp" />
                     </RadioGroup>
                 </HorizontalScrollView>
 
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline_new_contents_start"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.039" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline_new_contents_end"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.961" />
+
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_new_post"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:overScrollMode="never"
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:spanCount="2"
+                    app:layout_constraintEnd_toEndOf="@id/guideline_new_contents_end"
+                    app:layout_constraintStart_toStartOf="@id/guideline_new_contents_start"
                     app:layout_constraintTop_toBottomOf="@id/layout_new_post_category"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    android:layout_marginHorizontal="14dp"
+                    app:spanCount="2"
                     tools:listitem="@layout/item_main_post" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_main_post.xml
+++ b/app/src/main/res/layout/item_main_post.xml
@@ -2,64 +2,83 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="postData"
             type="com.daily.dayo.home.model.PostContent" />
     </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="4dp">
+        android:layout_marginHorizontal="4dp">
 
         <ImageView
             android:id="@+id/img_main_post"
-            android:layout_width="158dp"
-            android:layout_height="158dp"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
             android:scaleType="centerCrop"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:src="@drawable/ic_dayo_circle_grayscale"/>
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            android:src="@drawable/ic_dayo_circle_grayscale" />
 
         <ImageButton
             android:id="@+id/btn_main_post_like"
             android:layout_width="38dp"
             android:layout_height="38dp"
             android:background="@android:color/transparent"
+            android:paddingEnd="4dp"
+            android:paddingBottom="3dp"
             android:src="@{postData.heart == true ? @drawable/ic_like_pressed : @drawable/ic_like_default}"
             app:layout_constraintBottom_toBottomOf="@id/img_main_post"
             app:layout_constraintEnd_toEndOf="@id/img_main_post"
-            android:paddingBottom="3dp"
-            android:paddingEnd="4dp"/>
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="@id/img_main_post"
+            app:layout_constraintTop_toTopOf="@id/img_main_post"
+            app:layout_constraintVertical_bias="1.0" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_post_ranking_number"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="@id/img_main_post"
-            app:layout_constraintStart_toStartOf="@id/img_main_post"
-            android:layout_marginTop="11dp"
             android:layout_marginStart="11dp"
-            android:visibility="visible">
+            android:layout_marginTop="11dp"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/img_main_post"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@id/img_main_post"
+            app:layout_constraintTop_toTopOf="@id/img_main_post"
+            app:layout_constraintVertical_bias="0.0">
+
             <ImageView
                 android:id="@+id/img_background_post_ranking_number"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_background_post_ranking_number"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
             <TextView
                 android:id="@+id/tv_post_ranking_number"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="@color/white_FFFFFF"
                 android:textSize="15dp"
                 android:textStyle="bold"
-                android:textColor="@color/white_FFFFFF"
-                android:gravity="center"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:text="1" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -67,53 +86,79 @@
             android:id="@+id/img_main_post_user_profile"
             android:layout_width="17dp"
             android:layout_height="17dp"
-            app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
-            app:strokeWidth="1dp"
-            app:strokeColor="@color/gray_4_D3D2D2"
-            android:src="@drawable/ic_user_profile_image_empty"
-            app:layout_constraintTop_toBottomOf="@id/img_main_post"
-            app:layout_constraintStart_toStartOf="@+id/img_main_post"
             android:layout_marginTop="11dp"
+            android:src="@drawable/ic_user_profile_image_empty"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/img_main_post"
+            app:layout_constraintTop_toBottomOf="@id/img_main_post"
+            app:layout_constraintVertical_bias="0.0"
+            app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
+            app:strokeColor="@color/gray_4_D3D2D2"
+            app:strokeWidth="1dp"
             tools:src="@drawable/ic_dayo_circle_grayscale" />
 
         <TextView
             android:id="@+id/tv_main_post_user_nickname"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="14dp"
-            android:textStyle="bold"
-            android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="@id/img_main_post_user_profile"
-            app:layout_constraintBottom_toBottomOf="@id/img_main_post_user_profile"
-            app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile"
             android:layout_marginStart="5dp"
             android:text="@{postData.nickname}"
-            tools:text="Nickname"/>
+            android:textColor="@color/gray_1_313131"
+            android:textSize="14dp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/img_main_post_user_profile"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile"
+            app:layout_constraintTop_toTopOf="@id/img_main_post_user_profile"
+            tools:text="Nickname" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/tv_main_post_like_count"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="11dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintTop_toBottomOf="@id/img_main_post_user_profile"
-            app:layout_constraintStart_toStartOf="@id/img_main_post_user_profile"
             android:layout_marginTop="6dp"
-            app:main="@{@string/like(Integer.toString(postData.heartCount))}"
-            app:secondTextInteger="@{postData.heartCount}"
-            tools:text="좋아요 135"/>
+            android:layout_marginBottom="24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@id/img_main_post_user_profile"
+            app:layout_constraintTop_toBottomOf="@id/img_main_post_user_profile"
+            app:layout_constraintVertical_bias="0.0">
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/tv_main_post_hit_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="11dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count"
-            app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count"
-            android:layout_marginStart="8dp"
-            app:main="@{@string/comment(Integer.toString(postData.commentCount))}"
-            app:secondTextInteger="@{postData.commentCount}"
-            tools:text="댓글 1,230"/>
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_main_post_like_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/gray_3_9C9C9C"
+                android:textSize="11dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.0"
+                app:main="@{@string/like(Integer.toString(postData.heartCount))}"
+                app:secondTextInteger="@{postData.heartCount}"
+                tools:text="좋아요 135" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_main_post_hit_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:textColor="@color/gray_3_9C9C9C"
+                android:textSize="11dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count"
+                app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count"
+                app:layout_constraintVertical_bias="0.0"
+                app:main="@{@string/comment(Integer.toString(postData.commentCount))}"
+                app:secondTextInteger="@{postData.commentCount}"
+                tools:text="댓글 1,230" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 내용
- 홈 화면의 Item의 크기를 기기의 디스플레이 크기에 따라 늘어날 수 있도록 비율로 조정
- 홈 화면 Item간 여백 조정
- 홈 화면 Post들의 Thumbnail 이미지 로딩 최적화

## 작업사항
- 홈 화면의 Item을 담는 Recyclerview의 width 크기를 Guideline에 따라 비율로 조정될 수 있도록 변경
- 홈 화면의 Item의 Margin을 XML을 구현하도록 설정하였으며, Decoration 설정 제거
- Coroutine을 활용해 Background에서 이미지를 로딩하도록 한 뒤, 작업이 끝나면 해당 이미지가 이미지뷰에 로딩되도록 설정
- Glide의 override를 통하여 ImageView의 크기에 맞게 받아오도록 하여, Memory 사용량 낮춤
- 이외의 관련 파일 Code Formatting

## 참고
resolved : #248 