### PR TITLE
#259 [feature] HomeFragment Image Loading Optimization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,7 +119,8 @@ dependencies {
 
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.11.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+    kapt 'com.github.bumptech.glide:compiler:4.11.0'
+    kapt "android.arch.lifecycle:compiler:1.1.1"
 
     // Preference
     implementation 'androidx.preference:preference-ktx:1.1.1'
@@ -134,6 +135,9 @@ dependencies {
 
     // Lottie
     implementation "com.airbnb.android:lottie:$lottie_version"
+
+    // Shimmer
+    implementation 'com.facebook.shimmer:shimmer:0.5.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/app/src/main/java/com/daily/dayo/common/GlideModule.kt
+++ b/app/src/main/java/com/daily/dayo/common/GlideModule.kt
@@ -1,0 +1,9 @@
+package com.daily.dayo.common
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+@GlideModule
+class GlideModule : AppGlideModule() {
+
+}

--- a/app/src/main/java/com/daily/dayo/domain/model/Post.kt
+++ b/app/src/main/java/com/daily/dayo/domain/model/Post.kt
@@ -1,12 +1,14 @@
 package com.daily.dayo.domain.model
 
+import android.graphics.Bitmap
+
 data class Post(
     val postId: Int?,
     val memberId: String?,
     val nickname: String,
     val userProfileImage: String,
     val category: Category?,
-    val thumbnailImage: String?,
+    var thumbnailImage: String?,
     val postImages: List<String>?,
     val contents: String?,
     val createDateTime: String?,
@@ -17,5 +19,7 @@ data class Post(
     val heart: Boolean,
     val heartCount: Int,
     val folderId: Int?,
-    val folderName: String?
+    val folderName: String?,
+    var preLoadThumbnail: Bitmap?=null,
+    var preLoadUserImg: Bitmap?=null
 )

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeFragmentPagerStateAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeFragmentPagerStateAdapter.kt
@@ -1,5 +1,6 @@
 package com.daily.dayo.presentation.adapter
 
+import android.os.Handler
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -27,6 +28,10 @@ class HomeFragmentPagerStateAdapter(fragmentActivity: FragmentActivity) : Fragme
 
     fun refreshFragment(index: Int, fragment: Fragment) {
         fragments[index] = fragment
-        notifyItemChanged(index)
+        Handler().post(object: Runnable {
+            override fun run() {
+                notifyDataSetChanged()
+            }
+        })
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -23,8 +23,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManager: RequestManager) :
-    ListAdapter<Post, HomeDayoPickAdapter.HomeDayoPickViewHolder>(diffCallback) {
+class HomeNewAdapter(val rankingShowing: Boolean, private val requestManager: RequestManager) :
+    ListAdapter<Post, HomeNewAdapter.HomeNewViewHolder>(diffCallback) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Post>() {
             override fun areItemsTheSame(oldItem: Post, newItem: Post) =
@@ -44,8 +44,8 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
         this.clickListener = listener
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeDayoPickViewHolder {
-        return HomeDayoPickViewHolder(
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeNewViewHolder {
+        return HomeNewViewHolder(
             ItemMainPostBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
@@ -54,7 +54,7 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
         )
     }
 
-    override fun onBindViewHolder(holder: HomeDayoPickViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: HomeNewViewHolder, position: Int) {
         val item = getItem(position)
         holder.bind(item, position)
 
@@ -72,16 +72,11 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
         }
     }
 
-    override fun getItemViewType(position: Int): Int {
-        // ViewHolder Pattern의 이점을 잃었지만, 카테고리 간 이동하면서 랭킹 숫자가 잘못 표시되는 점을 해결
-        return position
-    }
-
     override fun submitList(list: MutableList<Post>?) {
         super.submitList(list?.let { ArrayList(it) })
     }
 
-    inner class HomeDayoPickViewHolder(private val binding: ItemMainPostBinding) :
+    inner class HomeNewViewHolder(private val binding: ItemMainPostBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         var postImg = binding.imgMainPost
@@ -89,7 +84,6 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
         var userThumbnailImg = binding.imgMainPostUserProfile
 
         fun bind(postContent: Post, currentPosition: Int) {
-            Log.e("DAYO ADAPTER", "current Position: $currentPosition")
             binding.layoutContentsShimmer.startShimmer()
             binding.layoutContentsShimmer.visibility = View.VISIBLE
             binding.layoutContents.visibility = View.INVISIBLE

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -1,5 +1,6 @@
 package com.daily.dayo.presentation.fragment.home
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -11,6 +12,9 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentHomeDayoPickPostListBinding
@@ -20,7 +24,10 @@ import com.daily.dayo.presentation.adapter.HomeDayoPickAdapter
 import com.daily.dayo.presentation.viewmodel.HomeViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class HomeDayoPickPostListFragment : Fragment() {
@@ -29,31 +36,57 @@ class HomeDayoPickPostListFragment : Fragment() {
     private lateinit var homeDayoPickAdapter: HomeDayoPickAdapter
     private lateinit var currentCategory: Category
 
+    lateinit var mGlideRequestManager: RequestManager
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mGlideRequestManager = Glide.with(this)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentHomeDayoPickPostListBinding.inflate(inflater, container, false)
-        currentCategory = Category.ALL
+        setInitialCategory()
         setRvDayoPickPostAdapter()
         setDayoPickPostListCollect()
         setPostLikeClickListener()
+
+        binding.layoutDayopickPostShimmer.startShimmer()
         return binding.root
     }
 
+    private fun setInitialCategory() {
+        with(binding) {
+            radiogroupDayopickPostCategory.check(
+                when (homeViewModel.currentDayoPickCategory) {
+                    Category.ALL -> radiobuttonDayopickPostCategoryAll.id
+                    Category.SCHEDULER -> radiobuttonDayopickPostCategoryScheduler.id
+                    Category.STUDY_PLANNER -> radiobuttonDayopickPostCategoryStudyplanner.id
+                    Category.GOOD_NOTE -> radiobuttonDayopickPostCategoryDigital.id
+                    Category.POCKET_BOOK -> radiobuttonDayopickPostCategoryPocketbook.id
+                    Category.SIX_DIARY -> radiobuttonDayopickPostCategory6holediary.id
+                    Category.ETC -> radiobuttonDayopickPostCategoryEtc.id
+                }
+            )
+        }
+    }
+
     private fun setRvDayoPickPostAdapter() {
-        homeDayoPickAdapter = HomeDayoPickAdapter(true)
+        homeDayoPickAdapter = HomeDayoPickAdapter(true, mGlideRequestManager)
         binding.rvDayopickPost.adapter = homeDayoPickAdapter
     }
 
     private fun setDayoPickPostListCollect() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                homeViewModel.postList.observe(viewLifecycleOwner) {
+                homeViewModel.dayoPickPostList.observe(viewLifecycleOwner) {
+                    // TODO : 하단 BottomNavigation을 통해 Fragment를 이동하고 나서 돌아오고나서 카테고리를 선택하면 observe가 중복해서 생겨난다
+                    //  해당 LiveData 객체가 1개 더 생성되는듯 하다
                     when (it.status) {
                         Status.SUCCESS -> {
                             it.data?.let { postList ->
-                                homeDayoPickAdapter.submitList(postList.toMutableList())
+                                loadPostThumbnail(postList)
                             }
                         }
                         Status.LOADING -> {
@@ -68,24 +101,31 @@ class HomeDayoPickPostListFragment : Fragment() {
         with(binding) {
             radiobuttonDayopickPostCategoryAll.setOnClickListener {
                 setCategoryPostList(Category.ALL)
+                loadingPost()
             }
             radiobuttonDayopickPostCategoryScheduler.setOnClickListener {
                 setCategoryPostList(Category.SCHEDULER)
+                loadingPost()
             }
             radiobuttonDayopickPostCategoryStudyplanner.setOnClickListener {
                 setCategoryPostList(Category.STUDY_PLANNER)
+                loadingPost()
             }
             radiobuttonDayopickPostCategoryPocketbook.setOnClickListener {
                 setCategoryPostList(Category.POCKET_BOOK)
+                loadingPost()
             }
             radiobuttonDayopickPostCategory6holediary.setOnClickListener {
                 setCategoryPostList(Category.SIX_DIARY)
+                loadingPost()
             }
             radiobuttonDayopickPostCategoryDigital.setOnClickListener {
                 setCategoryPostList(Category.GOOD_NOTE)
+                loadingPost()
             }
             radiobuttonDayopickPostCategoryEtc.setOnClickListener {
                 setCategoryPostList(Category.ETC)
+                loadingPost()
             }
         }
     }
@@ -93,10 +133,10 @@ class HomeDayoPickPostListFragment : Fragment() {
     private fun setCategoryPostList(selectCategory: Category) {
         currentCategory = selectCategory
         if (selectCategory == Category.ALL) {
-            homeViewModel.currentCategory = selectCategory
+            homeViewModel.currentDayoPickCategory = selectCategory
             homeViewModel.requestHomeDayoPickPostList()
         } else {
-            homeViewModel.currentCategory = selectCategory
+            homeViewModel.currentDayoPickCategory = selectCategory
             homeViewModel.requestHomeDayoPickPostListCategory(selectCategory)
         }
     }
@@ -115,7 +155,9 @@ class HomeDayoPickPostListFragment : Fragment() {
                             is CancellationException -> Log.e("Post Like Click", "CANCELLED")
                             null -> {
                                 if (currentCategory != Category.ALL) {
-                                    homeViewModel.requestHomeDayoPickPostListCategory(currentCategory)
+                                    homeViewModel.requestHomeDayoPickPostListCategory(
+                                        currentCategory
+                                    )
                                 } else {
                                     homeViewModel.requestHomeDayoPickPostList()
                                 }
@@ -125,5 +167,61 @@ class HomeDayoPickPostListFragment : Fragment() {
                 }
             }
         })
+    }
+
+    private fun loadPostThumbnail(postList: List<Post>) {
+        val thumbnailImgList = emptyList<Bitmap>().toMutableList()
+        val userImgList = emptyList<Bitmap>().toMutableList()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
+                thumbnailImgList.add(withContext(Dispatchers.IO) {
+                    Glide.with(requireContext())
+                        .asBitmap()
+                        .override(158, 158)
+                        .load("http://117.17.198.45:8080/images/" + postList[i].thumbnailImage)
+                        .priority(Priority.HIGH)
+                        .submit()
+                        .get()
+                })
+                userImgList.add(withContext(Dispatchers.IO) {
+                    Glide.with(requireContext())
+                        .asBitmap()
+                        .override(17, 17)
+                        .load("http://117.17.198.45:8080/images/" + postList[i].userProfileImage)
+                        .submit()
+                        .get()
+                })
+            }
+        }.invokeOnCompletion { throwable ->
+            when (throwable) {
+                is CancellationException -> Log.e("Image Loading", "CANCELLED")
+                null -> {
+                    var loadedPostList = postList.toMutableList()
+                    for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
+                        loadedPostList[i].preLoadThumbnail = thumbnailImgList[i]
+                        loadedPostList[i].preLoadUserImg = userImgList[i]
+                    }
+                    homeDayoPickAdapter.submitList(postList.toMutableList())
+                    completeLoadPost()
+                    thumbnailImgList.clear()
+                    userImgList.clear()
+                }
+            }
+        }
+    }
+
+    private fun loadingPost() {
+        binding.layoutDayopickPostShimmer.startShimmer()
+        binding.layoutDayopickPostShimmer.visibility = View.VISIBLE
+        binding.radiogroupDayopickPostCategory.visibility = View.INVISIBLE
+        binding.rvDayopickPost.visibility = View.INVISIBLE
+    }
+
+    private fun completeLoadPost() {
+        binding.layoutDayopickPostShimmer.stopShimmer()
+        binding.layoutDayopickPostShimmer.visibility = View.GONE
+        binding.radiogroupDayopickPostCategory.visibility = View.VISIBLE
+        binding.rvDayopickPost.visibility = View.VISIBLE
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeFragment.kt
@@ -12,6 +12,7 @@ import androidx.viewpager2.widget.ViewPager2
 import com.daily.dayo.R
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentHomeBinding
+import com.daily.dayo.domain.model.Category
 import com.daily.dayo.presentation.adapter.HomeFragmentPagerStateAdapter
 import com.daily.dayo.presentation.viewmodel.HomeViewModel
 import com.google.android.material.tabs.TabLayout
@@ -30,20 +31,31 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
-        viewPager = binding.pagerHomePost
-        tabLayout = binding.tabsActionbarHomeCategory
-
-        setSearchClickListener()
         return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initViewPager()
+        initPostContents()
+        setSearchClickListener()
+    }
+
+    private fun setSearchClickListener() {
+        binding.btnPostSearch.setOnClickListener {
+            findNavController().navigate(R.id.action_homeFragment_to_searchFragment)
+        }
+    }
+
+    private fun initViewPager() {
+        viewPager = binding.pagerHomePost
+        tabLayout = binding.tabsActionbarHomeCategory
+
+        viewPager.isUserInputEnabled = false // DISABLE SWIPE
 
         val pagerAdapter = HomeFragmentPagerStateAdapter(requireActivity())
         pagerAdapter.addFragment(HomeDayoPickPostListFragment())
         pagerAdapter.addFragment(HomeNewPostListFragment())
-        homeViewModel.requestDayoPickPostList()
         for (i in 0 until pagerAdapter.itemCount) {
             pagerAdapter.refreshFragment(i,pagerAdapter.fragments[i])
             Log.e("Refresh Fragment", "Page ${i+1}")
@@ -54,13 +66,14 @@ class HomeFragment : Fragment() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 Log.e("ViewPagerFragment", "Page ${position+1}")
-                when (position){
-                    0 -> homeViewModel.requestDayoPickPostList()
-                    1 -> homeViewModel.requestHomeNewPostList()
-                }
+                pagerAdapter.refreshFragment(position,pagerAdapter.fragments[position])
             }
         })
 
+        initTabLayout()
+    }
+
+    private fun initTabLayout() {
         TabLayoutMediator(tabLayout, viewPager){ tab, position ->
             when (position){
                 0 ->
@@ -71,9 +84,16 @@ class HomeFragment : Fragment() {
         }.attach()
     }
 
-    private fun setSearchClickListener() {
-        binding.btnPostSearch.setOnClickListener {
-            findNavController().navigate(R.id.action_homeFragment_to_searchFragment)
+    private fun initPostContents() {
+        if(!homeViewModel.isInitLoadingDAYOPICK) {
+            homeViewModel.requestDayoPickPostList()
+            homeViewModel.isInitLoadingDAYOPICK = true
+            homeViewModel.currentDayoPickCategory = Category.ALL
+        }
+        if(!homeViewModel.isInitLoadingNew) {
+            homeViewModel.requestNewPostList()
+            homeViewModel.isInitLoadingNew = true
+            homeViewModel.currentNewCategory = Category.ALL
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeFragment.kt
@@ -29,7 +29,7 @@ class HomeFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
     }
@@ -86,14 +86,14 @@ class HomeFragment : Fragment() {
 
     private fun initPostContents() {
         if(!homeViewModel.isInitLoadingDAYOPICK) {
+            homeViewModel.currentDayoPickCategory = Category.ALL
             homeViewModel.requestDayoPickPostList()
             homeViewModel.isInitLoadingDAYOPICK = true
-            homeViewModel.currentDayoPickCategory = Category.ALL
         }
         if(!homeViewModel.isInitLoadingNew) {
+            homeViewModel.currentNewCategory = Category.ALL
             homeViewModel.requestNewPostList()
             homeViewModel.isInitLoadingNew = true
-            homeViewModel.currentNewCategory = Category.ALL
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
@@ -1,5 +1,6 @@
 package com.daily.dayo.presentation.fragment.home
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -9,52 +10,82 @@ import android.widget.ImageButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentHomeNewPostListBinding
 import com.daily.dayo.domain.model.Category
 import com.daily.dayo.domain.model.Post
-import com.daily.dayo.presentation.adapter.HomeDayoPickAdapter
+import com.daily.dayo.presentation.adapter.HomeNewAdapter
 import com.daily.dayo.presentation.viewmodel.HomeViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class HomeNewPostListFragment : Fragment() {
     private var binding by autoCleared<FragmentHomeNewPostListBinding>()
     private val homeViewModel by activityViewModels<HomeViewModel>()
-    private lateinit var homeNewPostListAdapter: HomeDayoPickAdapter
+    private lateinit var homeNewAdapter: HomeNewAdapter
     private lateinit var currentCategory: Category
+
+    lateinit var mGlideRequestManager: RequestManager
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mGlideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentHomeNewPostListBinding.inflate(inflater, container, false)
+        setInitialCategory()
         currentCategory = Category.ALL
         setRvNewPostAdapter()
         setNewPostListCollect()
         setPostLikeClickListener()
+
+        binding.layoutNewPostShimmer.startShimmer()
         return binding.root
     }
 
+    private fun setInitialCategory() {
+        with(binding) {
+            radiogroupNewPostCategory.check(
+                when (homeViewModel.currentNewCategory) {
+                    Category.ALL -> radiobuttonNewPostCategoryAll.id
+                    Category.SCHEDULER -> radiobuttonNewPostCategoryScheduler.id
+                    Category.STUDY_PLANNER -> radiobuttonNewPostCategoryStudyplanner.id
+                    Category.GOOD_NOTE -> radiobuttonNewPostCategoryDigital.id
+                    Category.POCKET_BOOK -> radiobuttonNewPostCategoryPocketbook.id
+                    Category.SIX_DIARY -> radiobuttonNewPostCategory6holediary.id
+                    Category.ETC -> radiobuttonNewPostCategoryEtc.id
+                }
+            )
+        }
+    }
+
     private fun setRvNewPostAdapter() {
-        homeNewPostListAdapter = HomeDayoPickAdapter(false)
-        binding.rvNewPost.adapter = homeNewPostListAdapter
+        homeNewAdapter = HomeNewAdapter(false, mGlideRequestManager)
+        binding.rvNewPost.adapter = homeNewAdapter
     }
 
     private fun setNewPostListCollect() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                homeViewModel.postList.observe(viewLifecycleOwner) {
+                homeViewModel.newPostList.observe(viewLifecycleOwner) {
                     when (it.status) {
                         Status.SUCCESS -> {
                             it.data?.let { postList ->
-                                homeNewPostListAdapter.submitList(postList.toMutableList())
+                                loadPostThumbnail(postList)
                             }
                         }
                         Status.LOADING -> {
@@ -69,24 +100,31 @@ class HomeNewPostListFragment : Fragment() {
         with(binding) {
             radiobuttonNewPostCategoryAll.setOnClickListener {
                 setCategoryPostList(Category.ALL)
+                loadingPost()
             }
             radiobuttonNewPostCategoryScheduler.setOnClickListener {
                 setCategoryPostList(Category.SCHEDULER)
+                loadingPost()
             }
             radiobuttonNewPostCategoryStudyplanner.setOnClickListener {
                 setCategoryPostList(Category.STUDY_PLANNER)
+                loadingPost()
             }
             radiobuttonNewPostCategoryPocketbook.setOnClickListener {
                 setCategoryPostList(Category.POCKET_BOOK)
+                loadingPost()
             }
             radiobuttonNewPostCategory6holediary.setOnClickListener {
                 setCategoryPostList(Category.SIX_DIARY)
+                loadingPost()
             }
             radiobuttonNewPostCategoryDigital.setOnClickListener {
                 setCategoryPostList(Category.GOOD_NOTE)
+                loadingPost()
             }
             radiobuttonNewPostCategoryEtc.setOnClickListener {
                 setCategoryPostList(Category.ETC)
+                loadingPost()
             }
         }
     }
@@ -94,17 +132,17 @@ class HomeNewPostListFragment : Fragment() {
     private fun setCategoryPostList(selectCategory: Category) {
         currentCategory = selectCategory
         if (selectCategory == Category.ALL) {
-            homeViewModel.currentCategory = selectCategory
+            homeViewModel.currentNewCategory = selectCategory
             homeViewModel.requestHomeNewPostList()
         } else {
-            homeViewModel.currentCategory = selectCategory
+            homeViewModel.currentNewCategory = selectCategory
             homeViewModel.requestHomeNewPostListCategory(category = selectCategory)
         }
     }
 
     private fun setPostLikeClickListener() {
-        homeNewPostListAdapter.setOnItemClickListener(object :
-            HomeDayoPickAdapter.OnItemClickListener {
+        homeNewAdapter.setOnItemClickListener(object :
+            HomeNewAdapter.OnItemClickListener {
             override fun likePostClick(btn: ImageButton, post: Post, position: Int) {
                 if (!post.heart) {
                     homeViewModel.requestLikePost(post.postId!!)
@@ -126,5 +164,61 @@ class HomeNewPostListFragment : Fragment() {
                 }
             }
         })
+    }
+
+    private fun loadPostThumbnail(postList: List<Post>) {
+        val thumbnailImgList = emptyList<Bitmap>().toMutableList()
+        val userImgList = emptyList<Bitmap>().toMutableList()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
+                thumbnailImgList.add(withContext(Dispatchers.IO) {
+                    Glide.with(requireContext())
+                        .asBitmap()
+                        .override(158, 158)
+                        .load("http://117.17.198.45:8080/images/" + postList[i].thumbnailImage)
+                        .priority(Priority.HIGH)
+                        .submit()
+                        .get()
+                })
+                userImgList.add(withContext(Dispatchers.IO) {
+                    Glide.with(requireContext())
+                        .asBitmap()
+                        .override(17, 17)
+                        .load("http://117.17.198.45:8080/images/" + postList[i].userProfileImage)
+                        .submit()
+                        .get()
+                })
+            }
+        }.invokeOnCompletion { throwable ->
+            when (throwable) {
+                is CancellationException -> Log.e("Image Loading", "CANCELLED")
+                null -> {
+                    completeLoadPost()
+                    var loadedPostList = postList.toMutableList()
+                    for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
+                        loadedPostList[i].preLoadThumbnail = thumbnailImgList[i]
+                        loadedPostList[i].preLoadUserImg = userImgList[i]
+                    }
+                    homeNewAdapter.submitList(postList.toMutableList())
+                    thumbnailImgList.clear()
+                    userImgList.clear()
+                }
+            }
+        }
+    }
+
+    private fun loadingPost() {
+        binding.layoutNewPostShimmer.startShimmer()
+        binding.layoutNewPostShimmer.visibility = View.VISIBLE
+        binding.radiogroupNewPostCategory.visibility = View.INVISIBLE
+        binding.rvNewPost.visibility = View.INVISIBLE
+    }
+
+    private fun completeLoadPost() {
+        binding.layoutNewPostShimmer.stopShimmer()
+        binding.layoutNewPostShimmer.visibility = View.GONE
+        binding.radiogroupNewPostCategory.visibility = View.VISIBLE
+        binding.rvNewPost.visibility = View.VISIBLE
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.domain.usecase.post.RequestDayoPickPostListUseCase
 import com.daily.dayo.domain.usecase.post.RequestNewPostListCategoryUseCase
 import com.daily.dayo.domain.usecase.post.RequestNewPostListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,62 +29,75 @@ class HomeViewModel @Inject constructor(
     private val requestLikePostUseCase: RequestLikePostUseCase,
     private val requestUnlikePostUseCase: RequestUnlikePostUseCase
 ) : ViewModel() {
+    var isInitLoadingDAYOPICK = false
+    var isInitLoadingNew = false
 
-    var currentCategory = Category.ALL
+    lateinit var currentDayoPickCategory : Category
+    lateinit var currentNewCategory : Category
 
-    private val _postList = MutableLiveData<Resource<List<Post>>>()
-    val postList: LiveData<Resource<List<Post>>> get() = _postList
+    private val _dayoPickPostList = MutableLiveData<Resource<List<Post>>>()
+    val dayoPickPostList: LiveData<Resource<List<Post>>> get() = _dayoPickPostList
 
-    fun requestDayoPickPostList() = viewModelScope.launch {
-        if(currentCategory == Category.ALL){
+    private val _newPostList = MutableLiveData<Resource<List<Post>>>()
+    val newPostList: LiveData<Resource<List<Post>>> get() = _newPostList
+
+    fun requestDayoPickPostList() = viewModelScope.launch(Dispatchers.IO) {
+        if(currentDayoPickCategory == Category.ALL){
             requestHomeDayoPickPostList()
         } else {
-            requestHomeDayoPickPostListCategory(currentCategory)
+            requestHomeDayoPickPostListCategory(currentDayoPickCategory)
+        }
+    }
+    fun requestNewPostList() = viewModelScope.launch(Dispatchers.IO) {
+        if(currentNewCategory == Category.ALL){
+            requestHomeNewPostList()
+        } else {
+            requestHomeDayoPickPostListCategory(currentNewCategory)
         }
     }
 
-    fun requestHomeNewPostList() = viewModelScope.launch {
+    fun requestHomeNewPostList() = viewModelScope.launch(Dispatchers.IO) {
         val response = requestNewPostListUseCase()
         if(response.isSuccessful){
-            _postList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
+            _newPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
         } else {
-            _postList.postValue(Resource.error(response.errorBody().toString(), null))
+            _newPostList.postValue(Resource.error(response.errorBody().toString(), null))
         }
     }
 
-    fun requestHomeNewPostListCategory(category: Category) = viewModelScope.launch {
+    fun requestHomeNewPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
         val response = requestNewPostListCategoryUseCase(category = category)
         if(response.isSuccessful) {
-            _postList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
+            _newPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
         } else {
-            _postList.postValue(Resource.error(response.errorBody().toString(), null))
+            _newPostList.postValue(Resource.error(response.errorBody().toString(), null))
         }
     }
 
-    fun requestHomeDayoPickPostList() = viewModelScope.launch {
-        _postList.postValue(Resource.loading(null))
+    fun requestHomeDayoPickPostList() = viewModelScope.launch(Dispatchers.IO) {
+        _dayoPickPostList.postValue(Resource.loading(null))
         val response = requestHomeDayoPickPostListUseCase()
         if(response.isSuccessful){
-            _postList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
+            _dayoPickPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
         } else {
-            _postList.postValue(Resource.error(response.errorBody().toString(), null))
+            _dayoPickPostList.postValue(Resource.error(response.errorBody().toString(), null))
         }
     }
 
-    fun requestHomeDayoPickPostListCategory(category: Category) = viewModelScope.launch {
+    fun requestHomeDayoPickPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
         val response = requestDayoPickPostListCategoryUseCase(category = category)
         if(response.isSuccessful) {
-            _postList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
+            _dayoPickPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
         } else {
-            _postList.postValue(Resource.error(response.errorBody().toString(), null))
+            _dayoPickPostList.postValue(Resource.error(response.errorBody().toString(), null))
         }
     }
 
-    fun requestLikePost(postId: Int) = viewModelScope.launch {
+    fun requestLikePost(postId: Int) = viewModelScope.launch(Dispatchers.IO) {
         val response = requestLikePostUseCase(CreateHeartRequest(postId = postId))
     }
 
-    fun requestUnlikePost(postId: Int) = viewModelScope.launch {
+    fun requestUnlikePost(postId: Int) = viewModelScope.launch(Dispatchers.IO) {
         val response = requestUnlikePostUseCase(postId = postId)
     }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,81 +5,83 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".presentation.fragment.home.HomeFragment">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_home_action_bar"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="?actionBarSize"
         android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0">
+
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs_actionbar_home_category"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            app:tabMode="scrollable"
-            app:tabPaddingTop="2dp"
-            app:tabPaddingBottom="4dp"
-            app:tabPaddingStart="9dp"
-            app:tabPaddingEnd="9dp"
-            app:tabTextColor="@color/gray_4_D3D2D2"
-            app:tabSelectedTextColor="@color/gray_1_313131"
+            android:layout_marginStart="11dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             app:tabIndicator="@drawable/tab_indicator_home_filter"
             app:tabIndicatorColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginStart="11dp">
+            app:tabMode="scrollable"
+            app:tabPaddingBottom="4dp"
+            app:tabPaddingEnd="9dp"
+            app:tabPaddingStart="9dp"
+            app:tabPaddingTop="2dp"
+            app:tabSelectedTextColor="@color/gray_1_313131"
+            app:tabTextColor="@color/gray_4_D3D2D2">
+
             <com.google.android.material.tabs.TabItem
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/DayoPick"/>
+                android:text="@string/DayoPick" />
+
             <com.google.android.material.tabs.TabItem
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/New" />
         </com.google.android.material.tabs.TabLayout>
+
         <ImageButton
             android:id="@+id/btn_post_search"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:background="@android:color/transparent"
+            android:paddingHorizontal="15dp"
             android:src="@drawable/ic_search"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:paddingHorizontal="15dp"/>
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@id/tabs_actionbar_home_category"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
+
         <View
             android:id="@+id/view_actionbar_horizontal_line"
             android:layout_width="match_parent"
             android:layout_height="1dp"
+            android:background="@color/gray_5_EDEDED"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:background="@color/gray_5_EDEDED"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tabs_actionbar_home_category"
+            app:layout_constraintVertical_bias="0.0" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/layout_scroll_home"
-        android:layout_width="0dp"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pager_home_post"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_home_action_bar"
+        android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/pager_home_post"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginBottom="16dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
+        app:layout_constraintTop_toBottomOf="@id/layout_home_action_bar"
+        app:layout_constraintVertical_bias="0.0" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home_dayo_pick_post_list.xml
+++ b/app/src/main/res/layout/fragment_home_dayo_pick_post_list.xml
@@ -5,153 +5,250 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.fragment.home.HomeDayoPickPostListFragment">
+        android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/layout_scroll_dayo_pick_post_list"
-            android:layout_width="wrap_content"
+        <HorizontalScrollView
+            android:id="@+id/layout_dayo_pick_post_category"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingHorizontal="19dp"
+            android:scrollbars="none"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0">
+
+            <RadioGroup
+                android:id="@+id/radiogroup_dayopick_post_category"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="14dp"
+                android:paddingBottom="20dp"
+                android:visibility="invisible"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_all"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:checked="true"
+                    android:text="@string/all"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_scheduler"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/scheduler"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_studyplanner"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/studyplanner"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_pocketbook"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/pocketbook"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_6holediary"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/sixHoleDiary"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_digital"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/digital"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_dayopick_post_category_etc"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/etc"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+            </RadioGroup>
+        </HorizontalScrollView>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_dayopick_contents_start"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.039" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_dayopick_contents_end"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.961" />
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/layout_dayopick_post_shimmer"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:paddingTop="14dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_dayopick_contents_end"
+            app:layout_constraintStart_toStartOf="@id/guideline_dayopick_contents_start"
+            app:layout_constraintTop_toTopOf="@id/layout_dayo_pick_post_category"
+            app:layout_constraintVertical_bias="0.0"
+            app:shimmer_base_color="@color/gray_3_9C9C9C"
+            app:shimmer_colored="true"
+            app:shimmer_highlight_color="@color/gray_6_F6F6F6">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="match_parent">
 
-                <HorizontalScrollView
-                    android:id="@+id/layout_dayo_pick_post_category"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingHorizontal="19dp"
-                    android:scrollbars="none"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent">
-
-                    <RadioGroup
-                        android:id="@+id/radiogroup_dayopick_post_category"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:paddingTop="14dp"
-                        android:paddingBottom="20dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent">
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_all"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:checked="true"
-                            android:text="@string/all"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_scheduler"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/scheduler"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_studyplanner"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/studyplanner"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_pocketbook"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/pocketbook"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_6holediary"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/sixHoleDiary"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_digital"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/digital"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_dayopick_post_category_etc"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/etc"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-                    </RadioGroup>
-                </HorizontalScrollView>
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_dayopick_contents_start"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.039" />
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_dayopick_contents_end"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.961" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_dayopick_post"
+                <include
+                    android:id="@+id/item_shimmer_1"
+                    layout="@layout/item_main_post_shimmer"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:overScrollMode="never"
-                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:layout_constraintEnd_toEndOf="@id/guideline_dayopick_contents_end"
-                    app:layout_constraintStart_toStartOf="@id/guideline_dayopick_contents_start"
-                    app:layout_constraintTop_toBottomOf="@id/layout_dayo_pick_post_category"
-                    app:spanCount="2"
-                    tools:listitem="@layout/item_main_post" />
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_2"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_2"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_3"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_4"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_1"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_4"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_3"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_1"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_5"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_2"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_3"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_6"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_5"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_4"
+                    app:layout_constraintVertical_bias="0.0" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.core.widget.NestedScrollView>
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_dayopick_post"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            android:visibility="invisible"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_dayopick_contents_end"
+            app:layout_constraintStart_toStartOf="@id/guideline_dayopick_contents_start"
+            app:layout_constraintTop_toBottomOf="@id/layout_dayo_pick_post_category"
+            app:layout_constraintVertical_bias="0.0"
+            app:spanCount="2"
+            tools:listitem="@layout/item_main_post" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_home_new_post_list.xml
+++ b/app/src/main/res/layout/fragment_home_new_post_list.xml
@@ -5,153 +5,250 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.fragment.home.HomeNewPostListFragment">
+        android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/layout_scroll_new_post_list"
-            android:layout_width="wrap_content"
+        <HorizontalScrollView
+            android:id="@+id/layout_new_post_category"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingHorizontal="19dp"
+            android:scrollbars="none"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0">
+
+            <RadioGroup
+                android:id="@+id/radiogroup_new_post_category"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="14dp"
+                android:paddingBottom="20dp"
+                android:visibility="invisible"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_all"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:checked="true"
+                    android:text="@string/all"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_scheduler"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/scheduler"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_studyplanner"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/studyplanner"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_pocketbook"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/pocketbook"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_6holediary"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/sixHoleDiary"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_digital"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/digital"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+
+                <RadioButton
+                    android:id="@+id/radiobutton_new_post_category_etc"
+                    android:layout_width="83dp"
+                    android:layout_height="26dp"
+                    android:background="@drawable/selector_button_home_post_category"
+                    android:button="@null"
+                    android:text="@string/etc"
+                    android:textAlignment="center"
+                    android:textColor="@drawable/selector_button_home_post_category_text"
+                    android:textSize="12dp" />
+            </RadioGroup>
+        </HorizontalScrollView>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_new_contents_start"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.039" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_new_contents_end"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.961" />
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/layout_new_post_shimmer"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:paddingTop="14dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_new_contents_end"
+            app:layout_constraintStart_toStartOf="@id/guideline_new_contents_start"
+            app:layout_constraintTop_toTopOf="@id/layout_new_post_category"
+            app:layout_constraintVertical_bias="0.0"
+            app:shimmer_base_color="@color/gray_3_9C9C9C"
+            app:shimmer_colored="true"
+            app:shimmer_highlight_color="@color/gray_6_F6F6F6">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="match_parent">
 
-                <HorizontalScrollView
-                    android:id="@+id/layout_new_post_category"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingHorizontal="19dp"
-                    android:scrollbars="none"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent">
-
-                    <RadioGroup
-                        android:id="@+id/radiogroup_new_post_category"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:paddingTop="14dp"
-                        android:paddingBottom="20dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent">
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_all"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:checked="true"
-                            android:text="@string/all"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_scheduler"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/scheduler"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_studyplanner"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/studyplanner"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_pocketbook"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/pocketbook"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_6holediary"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/sixHoleDiary"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_digital"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/digital"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-
-                        <RadioButton
-                            android:id="@+id/radiobutton_new_post_category_etc"
-                            android:layout_width="83dp"
-                            android:layout_height="26dp"
-                            android:background="@drawable/selector_button_home_post_category"
-                            android:button="@null"
-                            android:text="@string/etc"
-                            android:textAlignment="center"
-                            android:textColor="@drawable/selector_button_home_post_category_text"
-                            android:textSize="12dp" />
-                    </RadioGroup>
-                </HorizontalScrollView>
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_new_contents_start"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.039" />
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_new_contents_end"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.961" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_new_post"
+                <include
+                    android:id="@+id/item_shimmer_1"
+                    layout="@layout/item_main_post_shimmer"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:overScrollMode="never"
-                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:layout_constraintEnd_toEndOf="@id/guideline_new_contents_end"
-                    app:layout_constraintStart_toStartOf="@id/guideline_new_contents_start"
-                    app:layout_constraintTop_toBottomOf="@id/layout_new_post_category"
-                    app:spanCount="2"
-                    tools:listitem="@layout/item_main_post" />
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_2"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_2"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_3"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_4"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_1"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_4"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_3"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_1"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_5"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/item_shimmer_2"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_3"
+                    app:layout_constraintVertical_bias="0.0" />
+
+                <include
+                    android:id="@+id/item_shimmer_6"
+                    layout="@layout/item_main_post_shimmer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginHorizontal="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/item_shimmer_5"
+                    app:layout_constraintTop_toBottomOf="@id/item_shimmer_4"
+                    app:layout_constraintVertical_bias="0.0" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.core.widget.NestedScrollView>
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_new_post"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            android:visibility="invisible"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_new_contents_end"
+            app:layout_constraintStart_toStartOf="@id/guideline_new_contents_start"
+            app:layout_constraintTop_toBottomOf="@id/layout_new_post_category"
+            app:layout_constraintVertical_bias="0.0"
+            app:spanCount="2"
+            tools:listitem="@layout/item_main_post" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_main_post.xml
+++ b/app/src/main/res/layout/item_main_post.xml
@@ -12,153 +12,283 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="4dp">
+        android:layout_height="wrap_content">
 
-        <ImageView
-            android:id="@+id/img_main_post"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_contents"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/img_main_post"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:adjustViewBounds="true"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_dayo_circle_grayscale"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.0" />
+
+            <ImageButton
+                android:id="@+id/btn_main_post_like"
+                android:layout_width="38dp"
+                android:layout_height="38dp"
+                android:background="@android:color/transparent"
+                android:paddingEnd="4dp"
+                android:paddingBottom="3dp"
+                android:src="@{post.heart == true ? @drawable/ic_like_pressed : @drawable/ic_like_default}"
+                app:layout_constraintBottom_toBottomOf="@id/img_main_post"
+                app:layout_constraintEnd_toEndOf="@id/img_main_post"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toStartOf="@id/img_main_post"
+                app:layout_constraintTop_toTopOf="@id/img_main_post"
+                app:layout_constraintVertical_bias="1.0" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_post_ranking_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="11dp"
+                android:layout_marginTop="11dp"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/img_main_post"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@id/img_main_post"
+                app:layout_constraintTop_toTopOf="@id/img_main_post"
+                app:layout_constraintVertical_bias="0.0">
+
+                <ImageView
+                    android:id="@+id/img_background_post_ranking_number"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_background_post_ranking_number"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_post_ranking_number"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@color/white_FFFFFF"
+                    android:textSize="15dp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="1" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/img_main_post_user_profile"
+                android:layout_width="17dp"
+                android:layout_height="17dp"
+                android:layout_marginTop="11dp"
+                android:src="@drawable/ic_user_profile_image_empty"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/img_main_post"
+                app:layout_constraintTop_toBottomOf="@id/img_main_post"
+                app:layout_constraintVertical_bias="0.0"
+                app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
+                app:strokeColor="@color/gray_4_D3D2D2"
+                app:strokeWidth="1dp"
+                tools:src="@drawable/ic_dayo_circle_grayscale" />
+
+            <TextView
+                android:id="@+id/tv_main_post_user_nickname"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:text="@{post.nickname}"
+                android:textColor="@color/gray_1_313131"
+                android:textSize="14dp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@id/img_main_post_user_profile"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile"
+                app:layout_constraintTop_toTopOf="@id/img_main_post_user_profile"
+                tools:text="Nickname" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:layout_marginBottom="24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@id/img_main_post_user_profile"
+                app:layout_constraintTop_toBottomOf="@id/img_main_post_user_profile"
+                app:layout_constraintVertical_bias="0.0">
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/tv_main_post_like_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/gray_3_9C9C9C"
+                    android:textSize="11dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:main="@{@string/like(Integer.toString(post.heartCount))}"
+                    app:secondTextInteger="@{post.heartCount}"
+                    tools:text="좋아요 135" />
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/tv_main_post_hit_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textColor="@color/gray_3_9C9C9C"
+                    android:textSize="11dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count"
+                    app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:main="@{@string/comment(Integer.toString(post.commentCount))}"
+                    app:secondTextInteger="@{post.commentCount}"
+                    tools:text="댓글 1,230" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/layout_contents_shimmer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
+            android:visibility="visible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
-            android:src="@drawable/ic_dayo_circle_grayscale" />
+            app:shimmer_base_color="@color/gray_3_9C9C9C"
+            app:shimmer_colored="true"
+            app:shimmer_highlight_color="@color/gray_6_F6F6F6">
 
-        <ImageButton
-            android:id="@+id/btn_main_post_like"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:background="@android:color/transparent"
-            android:paddingEnd="4dp"
-            android:paddingBottom="3dp"
-            android:src="@{post.heart == true ? @drawable/ic_like_pressed : @drawable/ic_like_default}"
-            app:layout_constraintBottom_toBottomOf="@id/img_main_post"
-            app:layout_constraintEnd_toEndOf="@id/img_main_post"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="@id/img_main_post"
-            app:layout_constraintTop_toTopOf="@id/img_main_post"
-            app:layout_constraintVertical_bias="1.0" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_post_ranking_number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="11dp"
-            android:layout_marginTop="11dp"
-            android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/img_main_post"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@id/img_main_post"
-            app:layout_constraintTop_toTopOf="@id/img_main_post"
-            app:layout_constraintVertical_bias="0.0">
+                <ImageView
+                    android:id="@+id/img_main_post_shimmer"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:adjustViewBounds="true"
+                    android:background="@color/gray_3_9C9C9C"
+                    android:src="@drawable/ic_dayo_circle_grayscale"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:tint="@android:color/transparent" />
 
-            <ImageView
-                android:id="@+id/img_background_post_ranking_number"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_background_post_ranking_number"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_main_post_user_info_shimmer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="11dp"
+                    android:background="@color/gray_3_9C9C9C"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/img_main_post_shimmer"
+                    app:layout_constraintTop_toBottomOf="@id/img_main_post_shimmer"
+                    app:layout_constraintVertical_bias="0.0">
 
-            <TextView
-                android:id="@+id/tv_post_ranking_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:textColor="@color/white_FFFFFF"
-                android:textSize="15dp"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="1" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/img_main_post_user_profile_shimmer"
+                        android:layout_width="17dp"
+                        android:layout_height="17dp"
+                        android:background="@color/gray_3_9C9C9C"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintVertical_bias="0.0" />
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/img_main_post_user_profile"
-            android:layout_width="17dp"
-            android:layout_height="17dp"
-            android:layout_marginTop="11dp"
-            android:src="@drawable/ic_user_profile_image_empty"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@+id/img_main_post"
-            app:layout_constraintTop_toBottomOf="@id/img_main_post"
-            app:layout_constraintVertical_bias="0.0"
-            app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
-            app:strokeColor="@color/gray_4_D3D2D2"
-            app:strokeWidth="1dp"
-            tools:src="@drawable/ic_dayo_circle_grayscale" />
+                    <TextView
+                        android:id="@+id/tv_main_post_user_nickname_shimmer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="5dp"
+                        android:background="@color/gray_3_9C9C9C"
+                        android:text="Nickname"
+                        android:textColor="@color/gray_3_9C9C9C"
+                        android:textSize="14dp"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile_shimmer"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <TextView
-            android:id="@+id/tv_main_post_user_nickname"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
-            android:text="@{post.nickname}"
-            android:textColor="@color/gray_1_313131"
-            android:textSize="14dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@id/img_main_post_user_profile"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile"
-            app:layout_constraintTop_toTopOf="@id/img_main_post_user_profile"
-            tools:text="Nickname" />
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:layout_marginBottom="24dp"
+                    android:background="@color/gray_3_9C9C9C"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@id/layout_main_post_user_info_shimmer"
+                    app:layout_constraintTop_toBottomOf="@id/layout_main_post_user_info_shimmer"
+                    app:layout_constraintVertical_bias="0.0">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:layout_marginBottom="24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@id/img_main_post_user_profile"
-            app:layout_constraintTop_toBottomOf="@id/img_main_post_user_profile"
-            app:layout_constraintVertical_bias="0.0">
+                    <androidx.appcompat.widget.AppCompatTextView
+                        android:id="@+id/tv_main_post_like_count_shimmer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="좋아요 135"
+                        android:textColor="@color/gray_3_9C9C9C"
+                        android:textSize="11dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintVertical_bias="0.0" />
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/tv_main_post_like_count"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/gray_3_9C9C9C"
-                android:textSize="11dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                app:main="@{@string/like(Integer.toString(post.heartCount))}"
-                app:secondTextInteger="@{post.heartCount}"
-                tools:text="좋아요 135" />
-
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/tv_main_post_hit_count"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textColor="@color/gray_3_9C9C9C"
-                android:textSize="11dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count"
-                app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count"
-                app:layout_constraintVertical_bias="0.0"
-                app:main="@{@string/comment(Integer.toString(post.commentCount))}"
-                app:secondTextInteger="@{post.commentCount}"
-                tools:text="댓글 1,230" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                    <androidx.appcompat.widget.AppCompatTextView
+                        android:id="@+id/tv_main_post_hit_count_shimmer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:text="댓글 1,230"
+                        android:textColor="@color/gray_3_9C9C9C"
+                        android:textSize="11dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count_shimmer"
+                        app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count_shimmer"
+                        app:layout_constraintVertical_bias="0.0" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_main_post_shimmer.xml
+++ b/app/src/main/res/layout/item_main_post_shimmer.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="4dp">
+
+    <ImageView
+        android:id="@+id/img_main_post"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:background="@color/gray_3_9C9C9C"
+        android:src="@drawable/ic_dayo_circle_grayscale"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        app:tint="@android:color/transparent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_main_post_user_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="11dp"
+        android:background="@color/gray_3_9C9C9C"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/img_main_post"
+        app:layout_constraintTop_toBottomOf="@id/img_main_post"
+        app:layout_constraintVertical_bias="0.0">
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/img_main_post_user_profile"
+            android:layout_width="17dp"
+            android:layout_height="17dp"
+            android:background="@color/gray_3_9C9C9C"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"  />
+
+        <TextView
+            android:id="@+id/tv_main_post_user_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:background="@color/gray_3_9C9C9C"
+            android:textColor="@color/gray_3_9C9C9C"
+            android:textSize="14dp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/img_main_post_user_profile"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintTop_toTopOf="parent"
+            android:text="Nickname" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="24dp"
+        android:background="@color/gray_3_9C9C9C"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@id/layout_main_post_user_info"
+        app:layout_constraintTop_toBottomOf="@id/layout_main_post_user_info"
+        app:layout_constraintVertical_bias="0.0">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_main_post_like_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/gray_3_9C9C9C"
+            android:textSize="11dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            android:text="좋아요 135" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_main_post_hit_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textColor="@color/gray_3_9C9C9C"
+            android:textSize="11dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@id/tv_main_post_like_count"
+            app:layout_constraintTop_toTopOf="@id/tv_main_post_like_count"
+            app:layout_constraintVertical_bias="0.0"
+            android:text="댓글 1,230" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="gray_1_313131">#FF313131</color>
     <color name="gray_2_5D5D5D">#FF5D5D5D</color>
     <color name="gray_3_9C9C9C">#FF9C9C9C</color>
+    <color name="gray_3_9C9C9C_alpha_30">#4D9C9C9C</color>
     <color name="gray_4_D3D2D2">#FFD3D2D2</color>
     <color name="gray_5_EDEDED">#FFEDEDED</color>
     <color name="gray_6_F6F6F6">#FFF6F6F6</color>


### PR DESCRIPTION
## 내용
- Glide 오류에 대한 디버깅 및 GlideModule 도입
- HomePagerStateAdapter에서 발생한 오류 디버깅
- HomeFragment에 대한 DAYOPICK 과 NEW에서 공통으로 사용하던 부분 제거 및 생성
- HomeFragment에서의 이미지 로딩 최적화
- HomeFragment에서의 이미지 로딩 완료 이전 스켈레톤 UI 구현

## 작업 사항
### Build.gradle
	- GlideApp 사용을 위한 Compiler 추가
	- Shimmer 사용을 위한 라이브러리 추가
### Color
	- Alpha 0.3을 적용한 Gray3 추가
### GlideModule
	- You cannot start a load for a destroyed activity 오류 메시지에 대한 디버깅
	- 이를 위해 GlideModule 파일 생성 및 Glide 사용시 활용
	- adapter에서 Glide 사용 시, Constructor에 requestManager를 받아 이를 이용해 이미지 로드
### HomeFragment
	- Layout 일부 자잘한 수정
	- 관련 기능 구현 코드 Refactoring
	- Swipe을 통한 Tab간 이동 기능 Disable
	- 최초 HomeFragment create되는 경우에만 homeViewModel을 통해 PostList를 받아오도록 수정 및 Create되는 경우에는 무조건 전체 카테고리를 보도록 수정
	- PagerStateAdapter에 대한 refreshFragment 관련 코드에서 notify 관련 함수 오류 경고 메시지에 따른 디버깅

### PostListFragment (DAYOPICK, NEW 공통)
	- Layout에 ShimmerFrameLayout 추가하여 이미지 로딩 시 화면 구현
		- 관련 item_main_post_shimmer.xml Layout 구현 및 사용
	- Layout 수정을 통해 전체 이미지를 한번에 로딩하는 것이 아닌 보이는 부분만 이미지가 로딩될 수 있도록 구현
	- 카테고리 선택 후, BottomNavigation으로 다른 Fragment으로 이동 후, 다시 HomeFragment으로 돌아왔을 때, 카테고리 선택이 초기화되어져 있는 것으로 보이는 Bug Fix
	- 홈 화면 페이지를 로딩하거나 카테고리 변경을 하는 경우 등의 상황에서 6개 이내의 이미지가 로딩된 후 게시글 썸네일을 볼 수 있도록 처리
		- 초기 6개 이미지에 대한 서버와의 통신 완료 시, 덮어씌워져 있던 Shimmer Layout은 View.GONE 처리
		- 카테고리에 6개 이내의 이미지만 존재하는 경우에는 모두 로딩한 뒤에 Shimmer Layout을 GONE 처리
	- 카테고리 변경 시마다, Shimmer Layout이 보이도록 처리하여, 로딩 중에는 카테고리를 변경할 수 없도록 구현
		- 초기 이미지가 로딩되지 않은 상태에서 스크롤을 가능하게 하는 등의 동작을 가능토록 하는 경우, 메모리 과다 사용 방지

### Post adapter(DAYOPICK, NEW 공통)
	- 현재 보이는 이미지 이외에 용이한 이미지 로딩을 위하여 이어지는 하단의 6개의 이미지가 미리 로딩할 수 있도록 Adapter에서 preload 코드 추가
	- Glide.with~ 대신 requestManager을 도입하여 glide를 사용하여 이미지 로딩
	- 이미지가 서버에서 불러와진 후, 화면에 보이는 사이에 보여지는 placeholder 이미지 기존 DAYO Grayscale 이미지에서 Shimmer Layout에서 사용되는 배경색과 동일한 단색 이미지로 변경
	- preload된 이미지가 있는 경우에는 preload된 이미지를 사용하도록 변경
	- getItemViewType Function을 Override하여 DayoPick 게시글 카테고리 변경 시 랭킹 표시에 오류가 있었던 Bug Fix (DayoPickAdapter 만)
	- HomeDayoPickAdapter과 HomeNewAdapter을 각각 Fragment에 맞게 분리하여 사용하도록 구현

### HomeViewModel
	- HomeFragment에 포함될 Contents가 초기에 로딩되어있는 지 판단하는 구분하는 variable 추가
		- isInitLoadingDAYOPICK, isInitLoadingNew
	- 기존에 DAYO PICK과 NEW가 공유하고 있던 currentCategory variable 분리
	- 기존에 DAYO PICK과 NEW가 공유하고 있던 postList variable 분리
	- coroutine 사용 코드에 대한 Dispatcher 명시

### item_main_post
	- 각각의 썸네일에 대해서도 shimmer 적용이 가능하도록 Shimmer Layout 추가

### Post DataClass
	- Shimmer Layout 도입에 따른 미리 이미지를 로딩함에 따라 preLoadThumbnail, preLoadUserImg 추가
## 참고
- resolved: #259