### PR TITLE
#255 [feature] Notification Fragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmApiService.kt
@@ -1,0 +1,15 @@
+package com.daily.dayo.data.datasource.remote.alarm
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface AlarmApiService {
+
+    @GET("/api/v1/alarms")
+    suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse>
+
+    @POST("/api/v1/alarms/{alarmId}")
+    suspend fun requestIsCheckAlarm(@Path("alarmId") alarmId: Int): Response<Void>
+}

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmResponse.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmResponse.kt
@@ -1,0 +1,30 @@
+package com.daily.dayo.data.datasource.remote.alarm
+
+import com.daily.dayo.domain.model.Topic
+import com.google.gson.annotations.SerializedName
+
+data class ListAllAlarmResponse(
+    @SerializedName("count")
+    val count: Int,
+    @SerializedName("data")
+    val data: List<AlarmDto>
+)
+
+data class AlarmDto(
+    @SerializedName("alarmId")
+    val alarmId: Int?,
+    @SerializedName("category")
+    val category: Topic?,
+    @SerializedName("check")
+    val check: Boolean?,
+    @SerializedName("content")
+    val content: String?,
+    @SerializedName("createdTime")
+    val createdTime: String?,
+    @SerializedName("nickname")
+    val nickname: String?,
+    @SerializedName("memberId")
+    val memberId: String?,
+    @SerializedName("postId")
+    val postId: Int?
+)

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/firebase/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/firebase/FirebaseMessagingService.kt
@@ -31,20 +31,26 @@ class FirebaseMessagingService: FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
         if(remoteMessage.data.isNotEmpty()) {
             val body = remoteMessage.data["body"]
-            sendNotification(body)
+            val postId = remoteMessage.data["postId"]
+            val memberId = remoteMessage.data["memberId"]
+            sendNotification(body = body, postId = postId, memberId = memberId)
         }else if (remoteMessage.notification != null) {
             val body = remoteMessage.notification!!.body
-            sendNotification(body)
+            sendNotification(body = body, postId = null, memberId = null)
         }
     }
 
-    private fun sendNotification(body: String?){
+    private fun sendNotification(body: String?, postId: String?, memberId: String?){
         val id = System.currentTimeMillis().toInt()
 
         // notification 클릭 시 이동하는 액티비티
-        var intent = Intent(this, MainActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        val pendingIntent = PendingIntent.getActivity(this, id, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        val notiIntent = Intent(this, MainActivity::class.java)
+        notiIntent.putExtra("ExtraFragment", "Notification")
+        notiIntent.putExtra("PostId", postId)
+        notiIntent.putExtra("MemberId", memberId)
+
+        notiIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent = PendingIntent.getActivity(this, id, notiIntent, PendingIntent.FLAG_UPDATE_CURRENT)
 
         // notification channel 생성
         val CHANNEL_ID = getString(R.string.notification_channel_id)

--- a/app/src/main/java/com/daily/dayo/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/daily/dayo/data/di/ServiceModule.kt
@@ -1,5 +1,6 @@
 package com.daily.dayo.data.di
 
+import com.daily.dayo.data.datasource.remote.alarm.AlarmApiService
 import com.daily.dayo.data.datasource.remote.bookmark.BookmarkApiService
 import com.daily.dayo.data.datasource.remote.comment.CommentApiService
 import com.daily.dayo.data.datasource.remote.folder.FolderApiService
@@ -104,4 +105,13 @@ object ServiceModule {
     @Provides
     fun provideImageRepository(imageApiService: ImageApiService): ImageRepository =
         ImageRepositoryImpl(imageApiService)
+
+    @Singleton
+    @Provides
+    fun provideAlarmApiService(retrofit: Retrofit) = retrofit.create(AlarmApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideAlarmRepository(alarmApiService: AlarmApiService): AlarmRepository =
+        AlarmRepositoryImpl(alarmApiService)
 }

--- a/app/src/main/java/com/daily/dayo/data/mapper/AlarmMapper.kt
+++ b/app/src/main/java/com/daily/dayo/data/mapper/AlarmMapper.kt
@@ -1,0 +1,26 @@
+package com.daily.dayo.data.mapper
+
+import com.daily.dayo.DayoApplication
+import com.daily.dayo.common.TimeChangerUtil
+import com.daily.dayo.data.datasource.remote.alarm.AlarmDto
+import com.daily.dayo.domain.model.Notification
+
+fun AlarmDto.toNotification(): Notification {
+    val textCreatedTime = createdTime?.let {
+        TimeChangerUtil.timeChange(
+            context = DayoApplication.applicationContext(),
+            time = createdTime
+        )
+    }
+
+    return Notification(
+        alarmId = alarmId,
+        topic = category,
+        check = check,
+        content = content,
+        createdTime = textCreatedTime,
+        nickname = nickname,
+        memberId = memberId,
+        postId = postId
+    )
+}

--- a/app/src/main/java/com/daily/dayo/data/repository/AlarmRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/AlarmRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.daily.dayo.data.repository
+
+import com.daily.dayo.data.datasource.remote.alarm.AlarmApiService
+import com.daily.dayo.data.datasource.remote.alarm.ListAllAlarmResponse
+import com.daily.dayo.domain.repository.AlarmRepository
+import retrofit2.Response
+import javax.inject.Inject
+
+class AlarmRepositoryImpl @Inject constructor(
+    private val alarmApiService: AlarmApiService
+) : AlarmRepository {
+
+    override suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse> =
+        alarmApiService.requestAllAlarmList()
+
+    override suspend fun requestIsCheckAlarm(alarmId: Int): Response<Void> =
+        alarmApiService.requestIsCheckAlarm(alarmId)
+}

--- a/app/src/main/java/com/daily/dayo/domain/model/Notification.kt
+++ b/app/src/main/java/com/daily/dayo/domain/model/Notification.kt
@@ -1,5 +1,12 @@
 package com.daily.dayo.domain.model
 
 data class Notification(
-    val id: Int
+    val alarmId:Int?,
+    val topic: Topic?,
+    val check: Boolean?,
+    val content: String?,
+    val createdTime: String?,
+    val nickname: String?,
+    val memberId: String?,
+    val postId: Int?
 )

--- a/app/src/main/java/com/daily/dayo/domain/model/Topic.kt
+++ b/app/src/main/java/com/daily/dayo/domain/model/Topic.kt
@@ -1,0 +1,5 @@
+package com.daily.dayo.domain.model
+
+enum class Topic {
+    HEART, COMMENT, NOTICE, FOLLOW
+}

--- a/app/src/main/java/com/daily/dayo/domain/repository/AlarmRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/AlarmRepository.kt
@@ -1,0 +1,10 @@
+package com.daily.dayo.domain.repository
+
+import com.daily.dayo.data.datasource.remote.alarm.ListAllAlarmResponse
+import retrofit2.Response
+
+interface AlarmRepository {
+
+    suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse>
+    suspend fun requestIsCheckAlarm(alarmId: Int): Response<Void>
+}

--- a/app/src/main/java/com/daily/dayo/domain/usecase/notification/RequestAllAlarmListUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/notification/RequestAllAlarmListUseCase.kt
@@ -1,0 +1,11 @@
+package com.daily.dayo.domain.usecase.notification
+
+import com.daily.dayo.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class RequestAllAlarmListUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository
+) {
+    suspend operator fun invoke() =
+        alarmRepository.requestAllAlarmList()
+}

--- a/app/src/main/java/com/daily/dayo/domain/usecase/notification/RequestIsCheckAlarmUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/notification/RequestIsCheckAlarmUseCase.kt
@@ -1,0 +1,11 @@
+package com.daily.dayo.domain.usecase.notification
+
+import com.daily.dayo.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class RequestIsCheckAlarmUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository
+) {
+    suspend operator fun invoke(alarmId: Int) =
+        alarmRepository.requestIsCheckAlarm(alarmId)
+}

--- a/app/src/main/java/com/daily/dayo/presentation/activity/MainActivity.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/activity/MainActivity.kt
@@ -2,19 +2,15 @@ package com.daily.dayo.presentation.activity
 
 import android.graphics.Rect
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.forEach
 import androidx.navigation.NavController
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
-import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.databinding.ActivityMainBinding
-import com.daily.dayo.presentation.fragment.feed.FeedFragmentDirections
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -29,6 +25,18 @@ class MainActivity : AppCompatActivity() {
         initBottomNavigation()
         setBottomNaviVisibility()
         disableBottomNaviTooltip()
+        getNotificationData()
+    }
+
+    private fun getNotificationData(){
+        val extraFragment = intent.getStringExtra("ExtraFragment")
+        if(extraFragment!=null && extraFragment == "Notification"){
+            val postId = intent.getStringExtra("PostId")?.toInt()
+            val memberId = intent.getStringExtra("MemberId")
+            if(postId!=null) findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToPostFragment(postId = postId))
+            else if(memberId!=null) findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToProfileFragment(memberId = memberId))
+            else findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToNotificationFragment())
+        }
     }
 
     private fun initBottomNavigation() {

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
@@ -1,20 +1,33 @@
 package com.daily.dayo.presentation.adapter
 
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextPaint
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.daily.dayo.R
 import com.daily.dayo.databinding.ItemNotificationBinding
 import com.daily.dayo.domain.model.Notification
+import com.daily.dayo.domain.model.Topic
+import com.daily.dayo.presentation.fragment.notification.NotificationFragmentDirections
 
-class NotificationListAdapter : ListAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
-    diffCallback
-){
+class NotificationListAdapter :
+    ListAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
+        diffCallback
+    ) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Notification>() {
             override fun areItemsTheSame(oldItem: Notification, newItem: Notification) =
-                oldItem.id == newItem.id
+                oldItem.alarmId == newItem.alarmId
 
             override fun areContentsTheSame(oldItem: Notification, newItem: Notification): Boolean =
                 oldItem == newItem
@@ -22,7 +35,7 @@ class NotificationListAdapter : ListAdapter<Notification, NotificationListAdapte
     }
 
     interface OnItemClickListener{
-        fun notificationItemClick(pos: Int)
+        fun notificationItemClick(alarmId: Int, alarmCheck: Boolean)
     }
 
     private var listener: OnItemClickListener?= null
@@ -32,7 +45,7 @@ class NotificationListAdapter : ListAdapter<Notification, NotificationListAdapte
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotificationListViewHolder {
         return NotificationListViewHolder(
-            ItemNotificationBinding.inflate(LayoutInflater.from(parent.context), parent,false)
+            ItemNotificationBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         )
     }
 
@@ -45,11 +58,65 @@ class NotificationListAdapter : ListAdapter<Notification, NotificationListAdapte
         super.submitList(list?.let { ArrayList(it) })
     }
 
-    inner class NotificationListViewHolder(private val binding: ItemNotificationBinding): RecyclerView.ViewHolder(binding.root) {
+    inner class NotificationListViewHolder(private val binding: ItemNotificationBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(notification: Notification, position: Int) {
-            binding.tvNotificationTitle.text = "content.title"
-            binding.tvNotificationDescription.text = "content.description"
-            binding.tvNotificationTime.text = "content.time"
+            binding.notification = notification
+
+            val pos = adapterPosition
+            if (pos != RecyclerView.NO_POSITION) {
+                itemView.setOnClickListener {
+                    notification.alarmId?.let { alarmId ->
+                        listener?.notificationItemClick(alarmId = alarmId, alarmCheck = notification.check!!)
+                    }
+                }
+            }
+
+            val spanContent = SpannableStringBuilder()
+            spanContent.append(notification.nickname)
+            spanContent.setSpan(
+                object : ClickableSpan() {
+                    override fun onClick(v: View) {
+                        Navigation.findNavController(v).navigate(
+                            NotificationFragmentDirections.actionNotificationFragmentToProfileFragment(
+                                memberId = notification.memberId
+                            )
+                        )
+                    }
+
+                    override fun updateDrawState(textPaint: TextPaint) {
+                        textPaint.color = ContextCompat.getColor(binding.tvNotificationTitle.context, R.color.gray_1_313131)
+                        textPaint.isUnderlineText = false
+                        textPaint.typeface = Typeface.DEFAULT_BOLD
+                    }
+                }, 0, notification.nickname?.length ?: 0, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spanContent.append(notification.content)
+            binding.tvNotificationTitle.movementMethod = LinkMovementMethod.getInstance()
+            binding.tvNotificationTitle.text = spanContent
+
+            binding.root.setOnClickListener {
+                when (notification.topic) {
+                    Topic.COMMENT, Topic.HEART ->
+                        notification.postId?.let { postId ->
+                            Navigation.findNavController(it).navigate(
+                                NotificationFragmentDirections.actionNotificationFragmentToPostFragment(
+                                    postId = postId
+                                )
+                            )
+                        }
+                    Topic.FOLLOW ->
+                        Navigation.findNavController(it).navigate(
+                            NotificationFragmentDirections.actionNotificationFragmentToProfileFragment(
+                                memberId = notification.memberId
+                            )
+                        )
+                    Topic.NOTICE -> {
+
+                    }
+                    else -> {}
+                }
+            }
         }
+
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
@@ -1,19 +1,23 @@
 package com.daily.dayo.presentation.fragment.notification
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.daily.dayo.common.Status
+import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentNotificationBinding
 import com.daily.dayo.presentation.adapter.NotificationListAdapter
-import com.daily.dayo.common.autoCleared
+import com.daily.dayo.presentation.viewmodel.NotificationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class NotificationFragment : Fragment() {
     private var binding by autoCleared<FragmentNotificationBinding>()
+    private val notificationViewModel by viewModels<NotificationViewModel>()
     private lateinit var notificationAdapter: NotificationListAdapter
 
     override fun onCreateView(
@@ -21,14 +25,53 @@ class NotificationFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentNotificationBinding.inflate(inflater, container, false)
-        setCommentListAdapter()
-
         return binding.root
     }
 
-    private fun setCommentListAdapter() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setNotificationListAdapter()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setAlarmList()
+    }
+
+    private fun setNotificationListAdapter() {
         notificationAdapter = NotificationListAdapter()
         binding.rvNotificationList.layoutManager = LinearLayoutManager(requireContext())
         binding.rvNotificationList.adapter = notificationAdapter
+        notificationAdapter.setOnItemClickListener(object :
+            NotificationListAdapter.OnItemClickListener {
+            override fun notificationItemClick(alarmId: Int, alarmCheck: Boolean) {
+                if (!alarmCheck) {
+                    notificationViewModel.requestIsCheckAlarm(alarmId = alarmId)
+                }
+            }
+        })
+    }
+
+    private fun setAlarmList() {
+        notificationViewModel.requestAllAlarmList()
+        notificationViewModel.alarmList.observe(viewLifecycleOwner) {
+            when (it.status) {
+                Status.SUCCESS -> {
+                    it.data?.let { alarmList ->
+                        notificationAdapter.submitList(alarmList.toMutableList())
+                        for (alarm in alarmList) {
+                            if (alarm.check == true) break
+                            alarm.alarmId?.let { alarmId ->
+                                notificationViewModel.requestIsCheckAlarm(alarmId = alarmId)
+                            }
+                        }
+                    }
+                }
+                Status.LOADING -> {
+                }
+                Status.ERROR -> {
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/NotificationViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/NotificationViewModel.kt
@@ -1,0 +1,38 @@
+package com.daily.dayo.presentation.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daily.dayo.common.Resource
+import com.daily.dayo.data.mapper.toNotification
+import com.daily.dayo.domain.model.Notification
+import com.daily.dayo.domain.usecase.notification.RequestAllAlarmListUseCase
+import com.daily.dayo.domain.usecase.notification.RequestIsCheckAlarmUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor(
+    private val requestAllAlarmListUseCase: RequestAllAlarmListUseCase,
+    private val requestIsCheckAlarmUseCase: RequestIsCheckAlarmUseCase
+) : ViewModel() {
+
+    private val _alarmList = MutableLiveData<Resource<List<Notification>>>()
+    val alarmList: LiveData<Resource<List<Notification>>> get() = _alarmList
+
+    fun requestAllAlarmList() = viewModelScope.launch {
+        _alarmList.postValue(Resource.loading(null))
+        val response = requestAllAlarmListUseCase()
+        if (response.isSuccessful) {
+            _alarmList.postValue(Resource.success(response.body()?.data?.map { it.toNotification() }))
+        } else {
+            _alarmList.postValue(Resource.error(response.errorBody().toString(), null))
+        }
+    }
+
+    fun requestIsCheckAlarm(alarmId: Int) = viewModelScope.launch {
+        requestIsCheckAlarmUseCase(alarmId)
+    }
+}

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -2,82 +2,93 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
+        <import type="android.view.View" />
         <variable
-            name="notificationTime"
-            type="String" />
+            name="notification"
+            type="com.daily.dayo.domain.model.Notification" />
     </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_notification"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:paddingHorizontal="18dp"
             android:paddingTop="22dp"
             android:paddingBottom="21dp"
-            android:paddingHorizontal="18dp">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_notification_contents"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                app:layout_constraintTop_toTopOf="parent"
+                android:layout_marginEnd="15dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/img_notification_unread"
-                android:layout_marginEnd="15dp">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
                 <TextView
                     android:id="@+id/tv_notification_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textSize="14dp"
-                    android:textColor="@color/gray_1_313131"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
                     android:layout_marginEnd="15dp"
-                    tools:text="조재영바보님이 회원님의 게시글을 좋아해요."/>
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="14dp"
+                    android:bufferType="spannable"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="조재영님이 회원님의 게시글을 좋아해요." />
+
                 <TextView
                     android:id="@+id/tv_notification_description"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:visibility="visible"
-                    android:textSize="13dp"
-                    android:textColor="@color/gray_2_5D5D5D"
-                    app:layout_constraintTop_toBottomOf="@id/tv_notification_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_notification_title"
                     android:layout_marginTop="9dp"
-                    tools:text="어떤 부분들이 업데이트 됐을까용!"/>
+                    android:textColor="@color/gray_2_5D5D5D"
+                    android:textSize="13dp"
+                    android:visibility="gone"
+                    app:layout_constraintStart_toStartOf="@id/tv_notification_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_notification_title"
+                    tools:text="어떤 부분들이 업데이트 됐을까용!" />
+
                 <TextView
                     android:id="@+id/tv_notification_time"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{notificationTime}"
-                    android:textSize="12dp"
-                    android:textColor="@color/gray_3_9C9C9C"
-                    app:layout_constraintTop_toBottomOf="@id/tv_notification_description"
-                    app:layout_constraintStart_toStartOf="@id/tv_notification_title"
                     android:layout_marginTop="14dp"
+                    android:text="@{notification.createdTime}"
+                    android:textColor="@color/gray_3_9C9C9C"
+                    android:textSize="12dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_notification_description"
                     tools:text="2일 전" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <ImageView
                 android:id="@+id/img_notification_unread"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/ic_unread"
-                android:visibility="visible"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                android:visibility="@{notification.check? View.GONE : View.VISIBLE}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
+
         <View
             android:id="@+id/view_feed_post_horizontal_line"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/gray_5_EDEDED"
-            app:layout_constraintTop_toBottomOf="@id/layout_notification"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/layout_notification" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -392,5 +392,8 @@
         <action
             android:id="@+id/action_notificationFragment_to_profileFragment"
             app:destination="@id/ProfileFragment" />
+        <action
+            android:id="@+id/action_notificationFragment_to_postFragment"
+            app:destination="@id/PostFragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -18,10 +18,13 @@
             app:destination="@id/WriteFragment" />
         <action
             android:id="@+id/action_homeFragment_to_profileFragment"
-            app:destination="@+id/ProfileFragment"/>
+            app:destination="@+id/ProfileFragment" />
         <action
             android:id="@+id/action_homeFragment_to_searchFragment"
-            app:destination="@+id/SearchFragment"/>
+            app:destination="@+id/SearchFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_notificationFragment"
+            app:destination="@+id/NotificationFragment" />
     </fragment>
 
     <fragment
@@ -42,7 +45,7 @@
         tools:layout="@layout/fragment_search_result">
         <argument
             android:name="searchKeyword"
-            app:argType="string"/>
+            app:argType="string" />
         <action
             android:id="@+id/action_searchResultFragment_to_postFragment"
             app:destination="@+id/PostFragment" />
@@ -61,16 +64,16 @@
             app:destination="@id/WriteFragment" />
         <action
             android:id="@+id/action_feedFragment_to_profileFragment"
-            app:destination="@+id/ProfileFragment"/>
+            app:destination="@+id/ProfileFragment" />
         <action
             android:id="@+id/action_feedFragment_to_postFragment"
-            app:destination="@+id/PostFragment"/>
+            app:destination="@+id/PostFragment" />
         <action
             android:id="@+id/action_feedFragment_to_postOptionFragment"
-            app:destination="@id/PostOptionFragment"/>
+            app:destination="@id/PostOptionFragment" />
         <action
             android:id="@+id/action_FeedFragment_to_postOptionMineFragment"
-            app:destination="@id/PostOptionMineFragment"/>
+            app:destination="@id/PostOptionMineFragment" />
     </fragment>
 
     <fragment
@@ -80,26 +83,25 @@
         tools:layout="@layout/fragment_write">
         <argument
             android:name="postId"
-            app:argType="integer"
-            android:defaultValue="0"/>
+            android:defaultValue="0"
+            app:argType="integer" />
         <action
             android:id="@+id/action_writeFragment_to_writeOptionFragment"
-            app:destination="@id/WriteOptionFragment"/>
+            app:destination="@id/WriteOptionFragment" />
         <action
             android:id="@+id/action_writeFragment_to_postFragment"
             app:destination="@id/PostFragment"
             app:popUpTo="@id/WriteFragment"
-            app:popUpToInclusive="true"/>
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_writeFragment_to_writeImageOptionFragment"
-            app:destination="@id/WriteImageOptionFragment"/>
+            app:destination="@id/WriteImageOptionFragment" />
     </fragment>
     <dialog
         android:id="@+id/WriteImageOptionFragment"
         android:name="com.daily.dayo.presentation.fragment.write.WriteImageOptionFragment"
         android:label="fragment_write_image_option"
-        tools:layout="@layout/fragment_write_image_option">
-    </dialog>
+        tools:layout="@layout/fragment_write_image_option"></dialog>
 
     <dialog
         android:id="@+id/WriteOptionFragment"
@@ -118,8 +120,7 @@
         android:id="@+id/WriteTagFragment"
         android:name="com.daily.dayo.presentation.fragment.write.WriteTagFragment"
         android:label="fragment_write_tag"
-        tools:layout="@layout/fragment_write_tag">
-    </fragment>
+        tools:layout="@layout/fragment_write_tag"></fragment>
 
     <fragment
         android:id="@+id/WriteFolderFragment"
@@ -135,8 +136,7 @@
         android:id="@+id/FolderAddFragment"
         android:name="com.daily.dayo.presentation.fragment.write.WriteFolderAddFragment"
         android:label="fragment_write_add"
-        tools:layout="@layout/fragment_write_folder_add">
-    </fragment>
+        tools:layout="@layout/fragment_write_folder_add"></fragment>
 
     <fragment
         android:id="@+id/PostFragment"
@@ -148,16 +148,16 @@
             app:argType="integer" />
         <action
             android:id="@+id/action_postFragment_to_postOptionFragment"
-            app:destination="@id/PostOptionFragment"/>
+            app:destination="@id/PostOptionFragment" />
         <action
             android:id="@+id/action_postFragment_to_postOptionMineFragment"
-            app:destination="@id/PostOptionMineFragment"/>
+            app:destination="@id/PostOptionMineFragment" />
         <action
             android:id="@+id/action_postFragment_to_searchResultFragment"
-            app:destination="@id/SearchResultFragment"/>
+            app:destination="@id/SearchResultFragment" />
         <action
             android:id="@+id/action_postFragment_to_profileFragment"
-            app:destination="@+id/ProfileFragment"/>
+            app:destination="@+id/ProfileFragment" />
     </fragment>
     <dialog
         android:id="@+id/PostOptionFragment"
@@ -169,7 +169,7 @@
             app:argType="integer" />
         <action
             android:id="@+id/action_postOptionFragment_to_postReportFragment"
-            app:destination="@id/PostReportFragment"/>
+            app:destination="@id/PostReportFragment" />
     </dialog>
 
     <fragment
@@ -194,7 +194,7 @@
             android:id="@+id/action_postOptionMineFragment_to_HomeFragment"
             app:destination="@+id/HomeFragment"
             app:popUpTo="@id/PostFragment"
-            app:popUpToInclusive="true"/>
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_postOptionMineFragment_to_writeFragment"
             app:destination="@id/WriteFragment"
@@ -209,9 +209,9 @@
         tools:layout="@layout/fragment_profile">
         <argument
             android:name="memberId"
-            app:argType="string"
             android:defaultValue="@null"
-            app:nullable="true"/>
+            app:argType="string"
+            app:nullable="true" />
         <action
             android:id="@+id/action_profileFragment_to_writeFragment"
             app:destination="@id/WriteFragment" />
@@ -223,16 +223,16 @@
             app:destination="@id/ProfileEditFragment" />
         <action
             android:id="@+id/action_profileFragment_to_profileOptionFragment"
-            app:destination="@id/ProfileOptionFragment"/>
+            app:destination="@id/ProfileOptionFragment" />
         <action
             android:id="@+id/action_profileFragment_to_folderFragment"
-            app:destination="@+id/FolderFragment"/>
+            app:destination="@+id/FolderFragment" />
         <action
             android:id="@+id/action_profileFragment_to_homeFragment"
-            app:destination="@+id/HomeFragment"/>
+            app:destination="@+id/HomeFragment" />
         <action
             android:id="@+id/action_profileFragment_to_postFragment"
-            app:destination="@+id/PostFragment"/>
+            app:destination="@+id/PostFragment" />
     </fragment>
 
     <fragment
@@ -261,7 +261,7 @@
             app:argType="integer" />
         <action
             android:id="@+id/action_folderEditFragment_to_folderSettingAddImageOptionFragment"
-            app:destination="@id/FolderSettingEditImageOptionFragment"/>
+            app:destination="@id/FolderSettingEditImageOptionFragment" />
     </fragment>
 
     <dialog
@@ -277,7 +277,7 @@
             app:destination="@+id/ProfileFragment" />
         <action
             android:id="@+id/action_folderOptionFragment_to_folderEditFragment"
-            app:destination="@+id/FolderEditFragment"/>
+            app:destination="@+id/FolderEditFragment" />
     </dialog>
 
     <dialog
@@ -290,10 +290,10 @@
             app:destination="@id/FolderSettingFragment" />
         <action
             android:id="@+id/action_profileOptionFragment_to_profileEditFragment"
-            app:destination="@+id/ProfileEditFragment"/>
+            app:destination="@+id/ProfileEditFragment" />
         <action
             android:id="@+id/action_profileOptionFragment_to_settingFragment"
-            app:destination="@+id/SettingFragment"/>
+            app:destination="@+id/SettingFragment" />
     </dialog>
 
     <fragment
@@ -313,22 +313,21 @@
         android:id="@+id/SettingNotificationFragment"
         android:name="com.daily.dayo.presentation.fragment.setting.notification.SettingNotificationFragment"
         android:label="fragment_withdraw"
-        tools:layout="@layout/fragment_setting_notification">
-    </fragment>
+        tools:layout="@layout/fragment_setting_notification"></fragment>
 
     <fragment
         android:id="@+id/WithdrawFragment"
         android:name="com.daily.dayo.presentation.fragment.setting.withdraw.WithdrawFragment"
         android:label="fragment_withdraw"
-        tools:layout="@layout/fragment_withdraw">
-    </fragment>
+        tools:layout="@layout/fragment_withdraw"></fragment>
 
     <fragment
         android:id="@+id/FolderSettingFragment"
         android:name="com.daily.dayo.presentation.fragment.mypage.folder.FolderSettingFragment"
         android:label="fragment_folder_setting"
         tools:layout="@layout/fragment_folder_setting">
-        <action android:id="@+id/action_folderSettingFragment_to_folderSettingAddFragment"
+        <action
+            android:id="@+id/action_folderSettingFragment_to_folderSettingAddFragment"
             app:destination="@id/FolderSettingAddFragment" />
     </fragment>
 
@@ -336,7 +335,8 @@
         android:id="@+id/FolderSettingAddFragment"
         android:name="com.daily.dayo.presentation.fragment.mypage.folder.FolderSettingAddFragment"
         tools:layout="@layout/fragment_folder_setting_add">
-        <action android:id="@+id/action_folderSettingAddFragment_to_folderSettingAddImageOptionFragment"
+        <action
+            android:id="@+id/action_folderSettingAddFragment_to_folderSettingAddImageOptionFragment"
             app:destination="@id/FolderSettingEditImageOptionFragment" />
 
     </fragment>
@@ -345,8 +345,7 @@
         android:id="@+id/FolderSettingEditImageOptionFragment"
         android:name="com.daily.dayo.presentation.fragment.mypage.folder.FolderSettingEditImageOptionFragment"
         android:label="fragment_folder_setting_edit_image_option"
-        tools:layout="@layout/fragment_folder_setting_edit_image_option">
-    </dialog>
+        tools:layout="@layout/fragment_folder_setting_edit_image_option"></dialog>
 
     <fragment
         android:id="@+id/ProfileEditFragment"
@@ -355,15 +354,14 @@
         tools:layout="@layout/fragment_profile_edit">
         <action
             android:id="@+id/action_profileEditFragment_to_profileEditImageOptionFragment"
-            app:destination="@id/ProfileEditImageOptionFragment"/>
+            app:destination="@id/ProfileEditImageOptionFragment" />
     </fragment>
 
     <dialog
         android:id="@+id/ProfileEditImageOptionFragment"
         android:name="com.daily.dayo.presentation.fragment.mypage.profile.ProfileEditImageOptionFragment"
         android:label="fragment_my_profile_edit_image_option"
-        tools:layout="@layout/fragment_profile_edit_image_option">
-    </dialog>
+        tools:layout="@layout/fragment_profile_edit_image_option"></dialog>
 
     <fragment
         android:id="@+id/FollowFragment"
@@ -372,13 +370,13 @@
         tools:layout="@layout/fragment_follow">
         <argument
             android:name="memberId"
-            app:argType="string"/>
+            app:argType="string" />
         <argument
             android:name="nickname"
-            app:argType="string"/>
+            app:argType="string" />
         <action
             android:id="@+id/action_followFragment_to_profileFragment"
-            app:destination="@+id/ProfileFragment"/>
+            app:destination="@+id/ProfileFragment" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,7 +219,7 @@
     <string name="setting_notification_notice">공지 알림</string>
     <string name="setting_notification_notice_explanation">앱에서 보내는 공지사항 알림을 받아요.</string>
     <string name="setting_notification_reaction">반응 알림</string>
-    <string name="notification_channel_id">Reaction</string>
+    <string name="notification_channel_id">REACTION</string>
     <string name="notification_channel_name">반응 알림</string>
     <string name="notification_topic_notice">NOTICE</string>
 


### PR DESCRIPTION
## Notification Fragment
+ 알림 종류에 따라 아이템 출력
+ 읽음 여부 확인
  + Notification Fragment로 이동 시 읽지 않은 메시지는 모두 읽음 처리함
  + 예외 상황을 대비하여 읽지 않은 알림 아이템을 클릭하는 경우 읽음 처리함
+ 텍스트 중 닉네임 클릭 시 프로필로 이동
+ 알림 아이템 클릭 시 관련 게시글 혹은 프로필로 이동

## FCM Notification 클릭 시 동작
+ MainActivity로 이동 후 알림 메세지에 담겨있는 데이터에 따라 동작
  + 팔로우 데이터인 경우 팔로우한 유저의 프로필로 이동 
  + 좋아요, 댓글 데이터인 경우 알림에 해당하는 게시글 페이지로 이동
  + 예외 상황으로 데이터가 없는 경우 알림 페이지로 이동
+ 현재 foreground에서의 동작 처리는 완료했지만, background 데이터 처리는 back-end측과 협의 필요 