### PR TITLE
#270 [feature] Create Glide Loading Util

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
@@ -1,0 +1,129 @@
+package com.daily.dayo.common
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
+import com.bumptech.glide.RequestManager
+import com.bumptech.glide.request.RequestOptions
+import com.daily.dayo.R
+
+object GlideLoadUtil {
+    private const val BASE_URL_IMG = "http://117.17.198.45:8080/images/"
+
+    fun loadImageView(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        img: Bitmap,
+        imgView: ImageView,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ) {
+        requestManager.load(img)
+            .override(width, height)
+            .thumbnail(0.1f)
+            .placeholder(placeholderImg ?: R.color.gray_3_9C9C9C_alpha_30)
+            .error(errorImg ?: R.drawable.ic_dayo_circle_grayscale)
+            .priority(Priority.HIGH)
+            .centerCrop()
+            .into(imgView)
+    }
+
+    fun loadImageViewProfile(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        img: Bitmap,
+        imgView: ImageView,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ) {
+        val requestOption = RequestOptions()
+        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
+        if (errorImg != null) requestOption.error(errorImg)
+        if (placeholderImg != null && errorImg != null) {
+            requestOption.placeholder(placeholderImg)
+                .error(errorImg)
+        }
+
+        requestManager.load(img)
+            .override(width, height)
+            .apply(requestOption)
+            .centerCrop()
+            .into(imgView)
+    }
+
+    fun loadImageBackground(
+        context: Context,
+        width: Int,
+        height: Int,
+        imgName: String,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ): Bitmap {
+        val requestOption = RequestOptions()
+        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
+        if (errorImg != null) requestOption.error(errorImg)
+        if (placeholderImg != null && errorImg != null) {
+            requestOption.placeholder(placeholderImg)
+                .error(errorImg)
+        }
+
+        return Glide.with(context)
+            .asBitmap()
+            .override(width, height)
+            .load("$BASE_URL_IMG${imgName}")
+            .apply(requestOption)
+            .priority(Priority.HIGH)
+            .submit()
+            .get()
+    }
+
+    fun loadImageBackground(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        imgName: String,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ): Bitmap {
+        return requestManager.asBitmap()
+            .override(width, height)
+            .placeholder(placeholderImg ?: R.color.gray_3_9C9C9C_alpha_30)
+            .error(errorImg ?: R.drawable.ic_dayo_circle_grayscale)
+            .load("$BASE_URL_IMG${imgName}")
+            .priority(Priority.HIGH)
+            .submit()
+            .get()
+    }
+
+    fun loadImageBackgroundProfile(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        imgName: String,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ): Bitmap {
+        val requestOption = RequestOptions()
+        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
+        if (errorImg != null) requestOption.error(errorImg)
+        if (placeholderImg != null && errorImg != null) {
+            requestOption.placeholder(placeholderImg)
+                .error(errorImg)
+        }
+
+        return requestManager.asBitmap()
+            .override(width, height)
+            .load("$BASE_URL_IMG${imgName}")
+            .apply(requestOption)
+            .submit()
+            .get()
+    }
+
+    fun loadImagePreload(requestManager: RequestManager, width: Int, height: Int, imgName: String) {
+        requestManager.load("$BASE_URL_IMG${imgName}").preload(width, height)
+    }
+}

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
@@ -8,13 +8,20 @@ import androidx.navigation.Navigation
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideApp
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.databinding.ItemFollowBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.fragment.mypage.follow.FollowFragmentDirections
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class FollowListAdapter : RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
+class FollowListAdapter(private val requestManager: RequestManager) :
+    RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Follow>() {
@@ -58,11 +65,25 @@ class FollowListAdapter : RecyclerView.Adapter<FollowListAdapter.FollowListViewH
 
         fun bind(follow: Follow) {
             binding.follow = follow
-            binding.isMine = follow.memberId == DayoApplication.preferences.getCurrentUser().memberId
-
-            GlideApp.with(binding.imgFollowUserProfile.context)
-                .load("http://117.17.198.45:8080/images/" + follow.profileImg)
-                .into(binding.imgFollowUserProfile)
+            binding.isMine =
+                follow.memberId == DayoApplication.preferences.getCurrentUser().memberId
+            CoroutineScope(Dispatchers.Main).launch {
+                val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    loadImageBackground(
+                        requestManager = requestManager,
+                        width = 40,
+                        height = 40,
+                        imgName = follow.profileImg ?: ""
+                    )
+                }
+                loadImageView(
+                    requestManager = requestManager,
+                    width = 40,
+                    height = 40,
+                    img = userThumbnailImgBitmap,
+                    imgView = binding.imgFollowUserProfile
+                )
+            }
 
             setRootClickListener(follow.memberId)
             setFollowButtonClickListener(follow)
@@ -70,7 +91,9 @@ class FollowListAdapter : RecyclerView.Adapter<FollowListAdapter.FollowListViewH
 
         private fun setRootClickListener(memberId: String) {
             binding.root.setOnClickListener {
-                Navigation.findNavController(it).navigate(FollowFragmentDirections.actionFollowFragmentToProfileFragment(memberId = memberId))
+                Navigation.findNavController(it).navigate(
+                    FollowFragmentDirections.actionFollowFragmentToProfileFragment(memberId = memberId)
+                )
             }
         }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -11,9 +11,11 @@ import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.R
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImagePreload
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
+import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.databinding.ItemMainPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
@@ -66,8 +68,12 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
                 position + 6
             }
             for (i in position until endPosition) {
-                requestManager.load("http://117.17.198.45:8080/images/" + getItem(i).thumbnailImage)
-                    .preload(158, 158)
+                loadImagePreload(
+                    requestManager = requestManager,
+                    width = 158,
+                    height = 158,
+                    imgName = getItem(i).thumbnailImage ?: ""
+                )
             }
         }
     }
@@ -105,21 +111,20 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
                 val userThumbnailImgBitmap: Bitmap?
                 if (postContent.preLoadThumbnail == null) {
                     postImgBitmap = withContext(Dispatchers.IO) {
-                        requestManager.asBitmap()
-                            .override(158, 158)
-                            .placeholder(R.color.gray_3_9C9C9C_alpha_30)
-                            .error(R.drawable.ic_dayo_circle_grayscale)
-                            .load("http://117.17.198.45:8080/images/" + postContent.thumbnailImage)
-                            .priority(Priority.HIGH)
-                            .submit()
-                            .get()
+                        loadImageBackground(
+                            requestManager = requestManager,
+                            width = 158,
+                            height = 158,
+                            imgName = postContent.thumbnailImage ?: ""
+                        )
                     }
                     userThumbnailImgBitmap = withContext(Dispatchers.IO) {
-                        requestManager.asBitmap()
-                            .override(17, 17)
-                            .load("http://117.17.198.45:8080/images/" + postContent.userProfileImage)
-                            .submit()
-                            .get()
+                        loadImageBackground(
+                            requestManager = requestManager,
+                            width = 17,
+                            height = 17,
+                            imgName = postContent.userProfileImage ?: ""
+                        )
                     }
                 } else {
                     postImgBitmap = postContent.preLoadThumbnail
@@ -127,18 +132,20 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
                     postContent.preLoadThumbnail = null
                     postContent.preLoadUserImg = null
                 }
-                requestManager.load(postImgBitmap)
-                    .override(158, 158)
-                    .thumbnail(0.1f)
-                    .placeholder(R.color.gray_3_9C9C9C_alpha_30)
-                    .error(R.drawable.ic_dayo_circle_grayscale)
-                    .priority(Priority.HIGH)
-                    .centerCrop()
-                    .into(postImg)
-                requestManager.load(userThumbnailImgBitmap)
-                    .override(17, 17)
-                    .centerCrop()
-                    .into(userThumbnailImg)
+                loadImageView(
+                    requestManager = requestManager,
+                    width = 158,
+                    height = 158,
+                    img = postImgBitmap!!,
+                    imgView = postImg
+                )
+                loadImageViewProfile(
+                    requestManager = requestManager,
+                    width = 17,
+                    height = 17,
+                    img = userThumbnailImgBitmap!!,
+                    imgView = userThumbnailImg
+                )
             }.invokeOnCompletion { throwable ->
                 when (throwable) {
                     is CancellationException -> Log.e("Image Loading", "CANCELLED")

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -11,9 +11,12 @@ import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.R
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackgroundProfile
+import com.daily.dayo.common.GlideLoadUtil.loadImagePreload
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
+import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.databinding.ItemMainPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
@@ -66,8 +69,12 @@ class HomeNewAdapter(val rankingShowing: Boolean, private val requestManager: Re
                 position + 6
             }
             for (i in position until endPosition) {
-                requestManager.load("http://117.17.198.45:8080/images/" + getItem(i).thumbnailImage)
-                    .preload(158, 158)
+                loadImagePreload(
+                    requestManager = requestManager,
+                    width = 158,
+                    height = 158,
+                    imgName = getItem(i).thumbnailImage ?: ""
+                )
             }
         }
     }
@@ -99,21 +106,20 @@ class HomeNewAdapter(val rankingShowing: Boolean, private val requestManager: Re
                 val userThumbnailImgBitmap: Bitmap?
                 if (postContent.preLoadThumbnail == null) {
                     postImgBitmap = withContext(Dispatchers.IO) {
-                        requestManager.asBitmap()
-                            .override(158, 158)
-                            .placeholder(R.color.gray_3_9C9C9C_alpha_30)
-                            .error(R.drawable.ic_dayo_circle_grayscale)
-                            .load("http://117.17.198.45:8080/images/" + postContent.thumbnailImage)
-                            .priority(Priority.HIGH)
-                            .submit()
-                            .get()
+                        loadImageBackground(
+                            requestManager = requestManager,
+                            width = 158,
+                            height = 158,
+                            imgName = postContent.thumbnailImage ?: ""
+                        )
                     }
                     userThumbnailImgBitmap = withContext(Dispatchers.IO) {
-                        requestManager.asBitmap()
-                            .override(17, 17)
-                            .load("http://117.17.198.45:8080/images/" + postContent.userProfileImage)
-                            .submit()
-                            .get()
+                        loadImageBackgroundProfile(
+                            requestManager = requestManager,
+                            width = 17,
+                            height = 17,
+                            imgName = postContent.userProfileImage ?: ""
+                        )
                     }
                 } else {
                     postImgBitmap = postContent.preLoadThumbnail
@@ -121,18 +127,20 @@ class HomeNewAdapter(val rankingShowing: Boolean, private val requestManager: Re
                     postContent.preLoadThumbnail = null
                     postContent.preLoadUserImg = null
                 }
-                requestManager.load(postImgBitmap)
-                    .override(158, 158)
-                    .thumbnail(0.1f)
-                    .placeholder(R.color.gray_3_9C9C9C_alpha_30)
-                    .error(R.drawable.ic_dayo_circle_grayscale)
-                    .priority(Priority.HIGH)
-                    .centerCrop()
-                    .into(postImg)
-                requestManager.load(userThumbnailImgBitmap)
-                    .override(17, 17)
-                    .centerCrop()
-                    .into(userThumbnailImg)
+                loadImageView(
+                    requestManager = requestManager,
+                    width = 158,
+                    height = 158,
+                    img = postImgBitmap!!,
+                    imgView = postImg
+                )
+                loadImageViewProfile(
+                    requestManager = requestManager,
+                    width = 17,
+                    height = 17,
+                    img = userThumbnailImgBitmap!!,
+                    imgView = userThumbnailImg
+                )
             }.invokeOnCompletion { throwable ->
                 when (throwable) {
                     is CancellationException -> Log.e("Image Loading", "CANCELLED")

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
@@ -5,12 +5,19 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.daily.dayo.common.GlideApp
+import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.databinding.ItemPostImageSliderBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class PostImageSliderAdapter : ListAdapter<String, PostImageSliderAdapter.PostImageViewHolder>(
-    diffCallback
-) {
+class PostImageSliderAdapter(private val requestManager: RequestManager) :
+    ListAdapter<String, PostImageSliderAdapter.PostImageViewHolder>(
+        diffCallback
+    ) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<String>() {
             override fun areItemsTheSame(oldItem: String, newItem: String) =
@@ -42,9 +49,27 @@ class PostImageSliderAdapter : ListAdapter<String, PostImageSliderAdapter.PostIm
     inner class PostImageViewHolder(private val binding: ItemPostImageSliderBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bindSliderImage(imageURL: String?) {
-            GlideApp.with(binding.imgSlider.context)
-                .load("http://117.17.198.45:8080/images/" + imageURL)
-                .into(binding.imgSlider)
+            val layoutParams = ViewGroup.MarginLayoutParams(
+                ViewGroup.MarginLayoutParams.MATCH_PARENT,
+                ViewGroup.MarginLayoutParams.MATCH_PARENT
+            )
+            CoroutineScope(Dispatchers.Main).launch {
+                val postImage = withContext(Dispatchers.IO) {
+                    GlideLoadUtil.loadImageBackground(
+                        requestManager = requestManager,
+                        width = 40,
+                        height = 40,
+                        imgName = imageURL ?: ""
+                    )
+                }
+                loadImageView(
+                    requestManager = requestManager,
+                    width = layoutParams.width,
+                    height = layoutParams.width,
+                    img = postImage,
+                    imgView = binding.imgSlider
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
@@ -6,13 +6,19 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.daily.dayo.common.GlideApp
+import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.databinding.ItemProfileLikePostBinding
 import com.daily.dayo.domain.model.BookmarkPost
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class ProfileBookmarkPostListAdapter : RecyclerView.Adapter<ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>(){
+class ProfileBookmarkPostListAdapter(private val requestManager: RequestManager) :
+    RecyclerView.Adapter<ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>() {
 
-    companion object{
+    companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<BookmarkPost>() {
             override fun areItemsTheSame(oldItem: BookmarkPost, newItem: BookmarkPost) =
                 oldItem.postId == newItem.postId
@@ -25,9 +31,12 @@ class ProfileBookmarkPostListAdapter : RecyclerView.Adapter<ProfileBookmarkPostL
     private val differ = AsyncListDiffer(this, diffCallback)
     fun submitList(list: List<BookmarkPost>) = differ.submitList(list)
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ProfileBookmarkPostListViewHolder {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ProfileBookmarkPostListViewHolder {
         return ProfileBookmarkPostListViewHolder(
-            ItemProfileLikePostBinding.inflate(LayoutInflater.from(parent.context), parent,false)
+            ItemProfileLikePostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         )
     }
 
@@ -40,24 +49,44 @@ class ProfileBookmarkPostListAdapter : RecyclerView.Adapter<ProfileBookmarkPostL
         return differ.currentList.size
     }
 
-    interface OnItemClickListener{
-        fun onItemClick(v: View, bookmarkPost: BookmarkPost, pos : Int)
+    interface OnItemClickListener {
+        fun onItemClick(v: View, bookmarkPost: BookmarkPost, pos: Int)
     }
-    private var listener : OnItemClickListener? = null
-    fun setOnItemClickListener(listener : OnItemClickListener) {
+
+    private var listener: OnItemClickListener? = null
+    fun setOnItemClickListener(listener: OnItemClickListener) {
         this.listener = listener
     }
 
-    inner class ProfileBookmarkPostListViewHolder(private val binding: ItemProfileLikePostBinding): RecyclerView.ViewHolder(binding.root) {
+    inner class ProfileBookmarkPostListViewHolder(private val binding: ItemProfileLikePostBinding) :
+        RecyclerView.ViewHolder(binding.root) {
 
         fun bind(bookmarkPost: BookmarkPost) {
-            GlideApp.with(binding.imgProfileLikePost.context)
-                .load("http://117.17.198.45:8080/images/" + bookmarkPost.thumbnailImage)
-                .into(binding.imgProfileLikePost)
+            val layoutParams = ViewGroup.MarginLayoutParams(
+                ViewGroup.MarginLayoutParams.WRAP_CONTENT,
+                ViewGroup.MarginLayoutParams.WRAP_CONTENT
+            )
+
+            CoroutineScope(Dispatchers.Main).launch {
+                val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    GlideLoadUtil.loadImageBackground(
+                        requestManager = requestManager,
+                        width = layoutParams.width,
+                        height = layoutParams.width,
+                        imgName = bookmarkPost.thumbnailImage
+                    )
+                }
+                GlideLoadUtil.loadImageView(
+                    requestManager = requestManager,
+                    width = layoutParams.width,
+                    height = layoutParams.width,
+                    img = userThumbnailImgBitmap,
+                    imgView = binding.imgProfileLikePost
+                )
+            }
 
             val pos = adapterPosition
-            if(pos!= RecyclerView.NO_POSITION)
-            {
+            if (pos != RecyclerView.NO_POSITION) {
                 itemView.setOnClickListener {
                     listener?.onItemClick(itemView, bookmarkPost, pos)
                 }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
@@ -6,11 +6,17 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.daily.dayo.common.GlideApp
+import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.databinding.ItemProfileFolderBinding
 import com.daily.dayo.domain.model.Folder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class ProfileFolderListAdapter :
+class ProfileFolderListAdapter(private val requestManager: RequestManager) :
     RecyclerView.Adapter<ProfileFolderListAdapter.ProfileFolderListViewHolder>() {
 
     companion object {
@@ -54,11 +60,29 @@ class ProfileFolderListAdapter :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(folder: Folder) {
-            binding.folder = folder
-            GlideApp.with(binding.btnProfileFolderItem.context)
-                .load("http://117.17.198.45:8080/images/" + folder.thumbnailImage)
-                .into(binding.btnProfileFolderItem)
+            val layoutParams = ViewGroup.MarginLayoutParams(
+                ViewGroup.MarginLayoutParams.WRAP_CONTENT,
+                ViewGroup.MarginLayoutParams.WRAP_CONTENT
+            )
 
+            binding.folder = folder
+            CoroutineScope(Dispatchers.Main).launch {
+                val profileFolderThumbnailImage = withContext(Dispatchers.IO) {
+                    loadImageBackground(
+                        requestManager = requestManager,
+                        width = layoutParams.width,
+                        height = 163,
+                        imgName = folder.thumbnailImage
+                    )
+                }
+                loadImageView(
+                    requestManager = requestManager,
+                    width = layoutParams.width,
+                    163,
+                    img = profileFolderThumbnailImage,
+                    imgView = binding.btnProfileFolderItem
+                )
+            }
             val pos = adapterPosition
             if (pos != RecyclerView.NO_POSITION) {
                 itemView.setOnClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
@@ -6,11 +6,17 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.daily.dayo.common.GlideApp
+import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.databinding.ItemSearchResultPostBinding
 import com.daily.dayo.domain.model.Search
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class SearchTagResultPostAdapter :
+class SearchTagResultPostAdapter(private val requestManager: RequestManager) :
     ListAdapter<Search, SearchTagResultPostAdapter.SearchTagResultPostViewHolder>(
         diffCallback
     ) {
@@ -37,7 +43,8 @@ class SearchTagResultPostAdapter :
         parent: ViewGroup,
         viewType: Int,
     ): SearchTagResultPostViewHolder = SearchTagResultPostViewHolder(
-        ItemSearchResultPostBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        ItemSearchResultPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    )
 
     override fun onBindViewHolder(
         holder: SearchTagResultPostViewHolder,
@@ -53,9 +60,23 @@ class SearchTagResultPostAdapter :
     inner class SearchTagResultPostViewHolder(private val binding: ItemSearchResultPostBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(postContent: Search) {
-            GlideApp.with(binding.imgSearchResultPost.context)
-                .load("http://117.17.198.45:8080/images/" + postContent.thumbnailImage)
-                .into(binding.imgSearchResultPost)
+            CoroutineScope(Dispatchers.Main).launch {
+                val postImage = withContext(Dispatchers.IO) {
+                    loadImageBackground(
+                        requestManager = requestManager,
+                        width = 158,
+                        height = 158,
+                        imgName = postContent.thumbnailImage
+                    )
+                }
+                loadImageView(
+                    requestManager = requestManager,
+                    width = 158,
+                    height = 158,
+                    img = postImage,
+                    imgView = binding.imgSearchResultPost
+                )
+            }
 
             val pos = adapterPosition
             if (pos != RecyclerView.NO_POSITION) {

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/WriteUploadImageListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/WriteUploadImageListAdapter.kt
@@ -1,19 +1,23 @@
 package com.daily.dayo.presentation.adapter
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.daily.dayo.common.GlideApp
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.databinding.ItemWritePostUploadImageBinding
 
-class WriteUploadImageListAdapter (private val items: ArrayList<String>, val context: Context, val postId: Int) :
+class WriteUploadImageListAdapter(
+    private val items: ArrayList<String>,
+    private val requestManager: RequestManager,
+    val postId: Int
+) :
     RecyclerView.Adapter<WriteUploadImageListAdapter.WriteUploadImageListViewHolder>() {
-    interface OnItemClickListener{
+    interface OnItemClickListener {
         fun deleteUploadImageClick(pos: Int)
     }
-    private var listener: OnItemClickListener?= null
+
+    private var listener: OnItemClickListener? = null
     fun setOnItemClickListener(listener: OnItemClickListener) {
         this.listener = listener
     }
@@ -25,27 +29,30 @@ class WriteUploadImageListAdapter (private val items: ArrayList<String>, val con
         holder.bind(item)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): WriteUploadImageListViewHolder = WriteUploadImageListViewHolder (
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): WriteUploadImageListViewHolder = WriteUploadImageListViewHolder(
         ItemWritePostUploadImageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
     )
 
-    inner class WriteUploadImageListViewHolder(private val binding: ItemWritePostUploadImageBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class WriteUploadImageListViewHolder(private val binding: ItemWritePostUploadImageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(item: String) {
             with(binding.imgUpload) {
                 clipToOutline = true
-                GlideApp.with(context)
-                    .load(item)
-                    .centerCrop()
-                    .into(this)
+                requestManager.load(item).centerCrop().into(this)
             }
 
             val pos = adapterPosition
-            if(pos!= RecyclerView.NO_POSITION){
+            if (pos != RecyclerView.NO_POSITION) {
                 binding.btnImgUploadDelete.setOnClickListener {
                     listener?.deleteUploadImageClick(pos)
                 }
             }
-            if(postId != 0) { binding.btnImgUploadDelete.visibility = View.INVISIBLE }
+            if (postId != 0) {
+                binding.btnImgUploadDelete.visibility = View.INVISIBLE
+            }
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -33,8 +33,9 @@ import android.graphics.drawable.Drawable
 import android.widget.Toast
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.Navigation
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.ButtonActivation
-import com.daily.dayo.common.GlideApp
 import com.daily.dayo.presentation.viewmodel.AccountViewModel
 
 @AndroidEntryPoint
@@ -42,10 +43,16 @@ class SignupEmailSetProfileFragment : Fragment() {
     private var binding by autoCleared<FragmentSignupEmailSetProfileBinding>()
     private val loginViewModel by activityViewModels<AccountViewModel>()
     private val args by navArgs<SignupEmailSetProfileFragmentArgs>()
-    private lateinit var userProfileImageString : String
+    private lateinit var glideRequestManager: RequestManager
+    private lateinit var userProfileImageString: String
     private var imagePath: String? = null
     private val imageFileTimeFormat = SimpleDateFormat("yyyy-MM-d-HH-mm-ss", Locale.KOREA)
-    private lateinit var userProfileImageExtension : String
+    private lateinit var userProfileImageExtension: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -70,41 +77,77 @@ class SignupEmailSetProfileFragment : Fragment() {
             true
         }
     }
+
     private fun setTextEditorActionListener() {
-        binding.etSignupEmailSetProfileNickname.setOnEditorActionListener {  _, actionId, _ ->
-            when(actionId) {
+        binding.etSignupEmailSetProfileNickname.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
                     HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetProfileNickname)
                     true
-                } else -> false
+                }
+                else -> false
             }
         }
     }
 
     private fun verifyNickname() {
         binding.etSignupEmailSetProfileNickname.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 with(binding) {
-                    if(s.toString().trim().length < 2) { // 닉네임 길이 검사 1
-                        setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_length_fail_min), false)
-                        ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
-                    } else if(s.toString().trim().length > 10) { // 닉네임 길이 검사 2
-                        setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_length_fail_max), false)
-                        ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
+                    if (s.toString().trim().length < 2) { // 닉네임 길이 검사 1
+                        setEditTextTheme(
+                            getString(R.string.my_profile_edit_nickname_message_length_fail_min),
+                            false
+                        )
+                        ButtonActivation.setSignupButtonInactive(
+                            requireContext(),
+                            binding.btnSignupEmailSetProfileNext
+                        )
+                    } else if (s.toString().trim().length > 10) { // 닉네임 길이 검사 2
+                        setEditTextTheme(
+                            getString(R.string.my_profile_edit_nickname_message_length_fail_max),
+                            false
+                        )
+                        ButtonActivation.setSignupButtonInactive(
+                            requireContext(),
+                            binding.btnSignupEmailSetProfileNext
+                        )
                     } else {
-                        if(Pattern.matches("^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$", s.toString().trim())) { // 닉네임 양식 검사
-                            if(true) { // TODO : 닉네임 중복검사 통과 코드 작성
-                                setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_success), true)
-                                ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetProfileNext)
+                        if (Pattern.matches(
+                                "^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$",
+                                s.toString().trim()
+                            )
+                        ) { // 닉네임 양식 검사
+                            if (true) { // TODO : 닉네임 중복검사 통과 코드 작성
+                                setEditTextTheme(
+                                    getString(R.string.my_profile_edit_nickname_message_success),
+                                    true
+                                )
+                                ButtonActivation.setSignupButtonActive(
+                                    requireContext(),
+                                    binding.btnSignupEmailSetProfileNext
+                                )
                             } else {
-                                setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_duplicate_fail), false)
-                                ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
+                                setEditTextTheme(
+                                    getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
+                                    false
+                                )
+                                ButtonActivation.setSignupButtonInactive(
+                                    requireContext(),
+                                    binding.btnSignupEmailSetProfileNext
+                                )
                             }
                         } else {
-                            setEditTextTheme(getString(R.string.my_profile_edit_nickname_message_format_fail), false)
-                            ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetProfileNext)
+                            setEditTextTheme(
+                                getString(R.string.my_profile_edit_nickname_message_format_fail),
+                                false
+                            )
+                            ButtonActivation.setSignupButtonInactive(
+                                requireContext(),
+                                binding.btnSignupEmailSetProfileNext
+                            )
                         }
                     }
                 }
@@ -115,14 +158,16 @@ class SignupEmailSetProfileFragment : Fragment() {
     private fun setEditTextTheme(checkMessage: String?, pass: Boolean) {
         with(binding.tvSignupEmailSetProfileNicknameMessage) {
             visibility = View.VISIBLE
-            if(pass) {
+            if (pass) {
                 text = checkMessage
                 setTextColor(resources.getColor(R.color.primary_green_23C882, context?.theme))
-                binding.etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.primary_green_23C882, context?.theme)
+                binding.etSignupEmailSetProfileNickname.backgroundTintList =
+                    resources.getColorStateList(R.color.primary_green_23C882, context?.theme)
             } else {
                 text = checkMessage
                 setTextColor(resources.getColor(R.color.red_FF4545, context?.theme))
-                binding.etSignupEmailSetProfileNickname.backgroundTintList = resources.getColorStateList(R.color.red_FF4545, context?.theme)
+                binding.etSignupEmailSetProfileNickname.backgroundTintList =
+                    resources.getColorStateList(R.color.red_FF4545, context?.theme)
             }
         }
     }
@@ -145,51 +190,62 @@ class SignupEmailSetProfileFragment : Fragment() {
             findNavController().navigate(R.id.action_signupEmailSetProfileFragment_to_signupEmailSetProfileImageOptionFragment)
         }
     }
+
     private fun observeNavigationMyProfileImageCallBack() {
-        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("userProfileImageString")?.observe(viewLifecycleOwner) {
-            userProfileImageString = it
-            if(this::userProfileImageString.isInitialized){
-                if(userProfileImageString == "resetMyProfileImage") {
-                    GlideApp.with(requireContext())
-                        .load(R.drawable.ic_user_profile_image_empty)
-                        .centerCrop()
-                        .into(binding.imgSignupEmailSetProfileUserImage)
-                } else {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        GlideApp.with(requireContext())
-                            .load(userProfileImageString.toUri())
-                            .centerCrop()
-                            .into(binding.imgSignupEmailSetProfileUserImage)
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("userProfileImageString")
+            ?.observe(viewLifecycleOwner) {
+                userProfileImageString = it
+                if (this::userProfileImageString.isInitialized) {
+                    if (userProfileImageString == "resetMyProfileImage") {
+                        glideRequestManager.load(R.drawable.ic_user_profile_image_empty)
+                            .centerCrop().into(binding.imgSignupEmailSetProfileUserImage)
+                    } else {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            glideRequestManager.load(userProfileImageString.toUri()).centerCrop()
+                                .into(binding.imgSignupEmailSetProfileUserImage)
+                        }
                     }
                 }
             }
-        }
-        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("fileExtension")?.observe(viewLifecycleOwner) {
-            userProfileImageExtension = it
-        }
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("fileExtension")
+            ?.observe(viewLifecycleOwner) {
+                userProfileImageExtension = it
+            }
     }
+
     private fun setUploadImagePath(fileExtension: String) {
         // uri를 통하여 불러온 이미지를 임시로 파일로 저장할 경로로 앱 내부 캐시 디렉토리로 설정,
         // 파일 이름은 불러온 시간 사용
-        val fileName = imageFileTimeFormat.format(Date(System.currentTimeMillis())).toString() + "." + fileExtension
+        val fileName = imageFileTimeFormat.format(Date(System.currentTimeMillis()))
+            .toString() + "." + fileExtension
         val cacheDir = requireContext().cacheDir.toString()
         imagePath = "$cacheDir/$fileName"
     }
 
     fun bitmapToFile(bitmap: Bitmap?, path: String?): File? {
-        if (bitmap == null || path == null) { return null }
+        if (bitmap == null || path == null) {
+            return null
+        }
         var file = File(path)
         var out: OutputStream? = null
-        try { file.createNewFile()
+        try {
+            file.createNewFile()
             out = FileOutputStream(file)
             bitmap?.compress(Bitmap.CompressFormat.JPEG, 100, out)
-        } finally { out?.close() }
+        } finally {
+            out?.close()
+        }
         return file
     }
 
     fun Uri.toBitmap(): Bitmap {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            ImageDecoder.decodeBitmap(ImageDecoder.createSource(requireContext().contentResolver, this) )
+            ImageDecoder.decodeBitmap(
+                ImageDecoder.createSource(
+                    requireContext().contentResolver,
+                    this
+                )
+            )
         } else {
             MediaStore.Images.Media.getBitmap(requireContext().contentResolver, this)
         }
@@ -197,7 +253,11 @@ class SignupEmailSetProfileFragment : Fragment() {
 
     private fun vectorDrawableToBitmapDrawable(drawable: Drawable): Bitmap? {
         try {
-            val bitmap: Bitmap = Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+            val bitmap: Bitmap = Bitmap.createBitmap(
+                drawable.intrinsicWidth,
+                drawable.intrinsicHeight,
+                Bitmap.Config.ARGB_8888
+            )
             val canvas = Canvas(bitmap)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)
@@ -208,7 +268,7 @@ class SignupEmailSetProfileFragment : Fragment() {
         }
     }
 
-    private fun setBackClickListener(){
+    private fun setBackClickListener() {
         binding.btnSignupEmailSetProfileBack.setOnClickListener {
             findNavController().navigateUp()
         }
@@ -216,28 +276,49 @@ class SignupEmailSetProfileFragment : Fragment() {
 
     private fun setNextClickListener() {
         binding.btnSignupEmailSetProfileNext.setOnClickListener {
-            var profileImgFile: File?= null
-            if(this::userProfileImageString.isInitialized) {
+            var profileImgFile: File? = null
+            if (this::userProfileImageString.isInitialized) {
                 setUploadImagePath(userProfileImageExtension)
                 profileImgFile = bitmapToFile(userProfileImageString.toUri().toBitmap(), imagePath)
             } else { // 기본 프로필 사진으로 설정
-                val profileEmptyDrawable = resources.getDrawable(R.drawable.ic_user_profile_image_empty, context?.theme)
+                val profileEmptyDrawable =
+                    resources.getDrawable(R.drawable.ic_user_profile_image_empty, context?.theme)
                 val profileEmptyBitmap = vectorDrawableToBitmapDrawable(profileEmptyDrawable)
 
                 setUploadImagePath("png")
                 profileImgFile = bitmapToFile(profileEmptyBitmap, imagePath)
             }
-            loginViewModel.requestSignupEmail(args.email, binding.etSignupEmailSetProfileNickname.text.toString().trim(), args.password, profileImgFile)
-            Toast.makeText(requireContext(), R.string.signup_email_alert_message_loading, Toast.LENGTH_SHORT).show()
+            loginViewModel.requestSignupEmail(
+                args.email,
+                binding.etSignupEmailSetProfileNickname.text.toString().trim(),
+                args.password,
+                profileImgFile
+            )
+            Toast.makeText(
+                requireContext(),
+                R.string.signup_email_alert_message_loading,
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
+
     private fun observeSignupCallback() {
-        loginViewModel.signupSuccess.observe(viewLifecycleOwner, androidx.lifecycle.Observer {  isSuccess ->
-            if(isSuccess.getContentIfNotHandled() == true) {
-                Navigation.findNavController(requireView()).navigate(SignupEmailSetProfileFragmentDirections.actionSignupEmailSetProfileFragmentToSignupEmailCompleteFragment(binding.etSignupEmailSetProfileNickname.text.toString().trim()))
-            } else if(isSuccess.getContentIfNotHandled() == false){
-                Toast.makeText(requireContext(), R.string.signup_email_alert_message_fail_network, Toast.LENGTH_SHORT).show()
-            }
-        })
+        loginViewModel.signupSuccess.observe(
+            viewLifecycleOwner,
+            androidx.lifecycle.Observer { isSuccess ->
+                if (isSuccess.getContentIfNotHandled() == true) {
+                    Navigation.findNavController(requireView()).navigate(
+                        SignupEmailSetProfileFragmentDirections.actionSignupEmailSetProfileFragmentToSignupEmailCompleteFragment(
+                            binding.etSignupEmailSetProfileNickname.text.toString().trim()
+                        )
+                    )
+                } else if (isSuccess.getContentIfNotHandled() == false) {
+                    Toast.makeText(
+                        requireContext(),
+                        R.string.signup_email_alert_message_fail_network,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            })
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -11,6 +11,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentFeedBinding
@@ -25,6 +27,12 @@ class FeedFragment : Fragment() {
     private var binding by autoCleared<FragmentFeedBinding>()
     private val feedViewModel by activityViewModels<FeedViewModel>()
     private lateinit var feedListAdapter: FeedListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -43,7 +51,7 @@ class FeedFragment : Fragment() {
     }
 
     private fun setRvFeedListAdapter() {
-        feedListAdapter = FeedListAdapter()
+        feedListAdapter = FeedListAdapter(requestManager = glideRequestManager)
         binding.rvFeedPost.adapter = feedListAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
-import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentHomeDayoPickPostListBinding
@@ -176,21 +176,20 @@ class HomeDayoPickPostListFragment : Fragment() {
         CoroutineScope(Dispatchers.Main).launch {
             for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
                 thumbnailImgList.add(withContext(Dispatchers.IO) {
-                    Glide.with(requireContext())
-                        .asBitmap()
-                        .override(158, 158)
-                        .load("http://117.17.198.45:8080/images/" + postList[i].thumbnailImage)
-                        .priority(Priority.HIGH)
-                        .submit()
-                        .get()
+                    loadImageBackground(
+                        context = requireContext(),
+                        height = 158,
+                        width = 158,
+                        imgName = postList[i].thumbnailImage ?: ""
+                    )
                 })
                 userImgList.add(withContext(Dispatchers.IO) {
-                    Glide.with(requireContext())
-                        .asBitmap()
-                        .override(17, 17)
-                        .load("http://117.17.198.45:8080/images/" + postList[i].userProfileImage)
-                        .submit()
-                        .get()
+                    loadImageBackground(
+                        context = requireContext(),
+                        height = 17,
+                        width = 17,
+                        imgName = postList[i].userProfileImage ?: ""
+                    )
                 })
             }
         }.invokeOnCompletion { throwable ->

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
-import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
+import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentHomeNewPostListBinding
@@ -173,21 +173,20 @@ class HomeNewPostListFragment : Fragment() {
         CoroutineScope(Dispatchers.Main).launch {
             for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
                 thumbnailImgList.add(withContext(Dispatchers.IO) {
-                    Glide.with(requireContext())
-                        .asBitmap()
-                        .override(158, 158)
-                        .load("http://117.17.198.45:8080/images/" + postList[i].thumbnailImage)
-                        .priority(Priority.HIGH)
-                        .submit()
-                        .get()
+                    GlideLoadUtil.loadImageBackground(
+                        context = requireContext(),
+                        height = 158,
+                        width = 158,
+                        imgName = postList[i].thumbnailImage ?: ""
+                    )
                 })
                 userImgList.add(withContext(Dispatchers.IO) {
-                    Glide.with(requireContext())
-                        .asBitmap()
-                        .override(17, 17)
-                        .load("http://117.17.198.45:8080/images/" + postList[i].userProfileImage)
-                        .submit()
-                        .get()
+                    GlideLoadUtil.loadImageBackground(
+                        context = requireContext(),
+                        height = 17,
+                        width = 17,
+                        imgName = postList[i].userProfileImage ?: ""
+                    )
                 })
             }
         }.invokeOnCompletion { throwable ->

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
@@ -22,16 +22,22 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentFolderSettingAddBinding
 import com.daily.dayo.common.ButtonActivation
-import com.daily.dayo.common.GlideApp
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.domain.model.Category
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.presentation.viewmodel.FolderSettingViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -39,16 +45,18 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 
-class FolderEditFragment  : Fragment() {
+class FolderEditFragment : Fragment() {
     private var binding by autoCleared<FragmentFolderSettingAddBinding>()
     private val folderSettingViewModel by activityViewModels<FolderSettingViewModel>()
     private val args by navArgs<FolderEditFragmentArgs>()
-    private lateinit var initThumbnailImg:String
-    lateinit var imageUri : String
-    var thumbnailImgBitmap : Bitmap? = null
+    private lateinit var glideRequestManager: RequestManager
+    private lateinit var initThumbnailImg: String
+    lateinit var imageUri: String
+    var thumbnailImgBitmap: Bitmap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
     }
 
@@ -68,25 +76,50 @@ class FolderEditFragment  : Fragment() {
         return binding.root
     }
 
-    private fun setFolderInfoDescription(){
+    private fun setFolderInfoDescription() {
+        val layoutParams = ViewGroup.MarginLayoutParams(
+            ViewGroup.MarginLayoutParams.MATCH_PARENT,
+            ViewGroup.MarginLayoutParams.MATCH_PARENT
+        )
+
         folderSettingViewModel.requestDetailListFolder(args.folderId)
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 folderSettingViewModel.detailFolderList.observe(viewLifecycleOwner) { it ->
-                    when(it.status){
+                    when (it.status) {
                         Status.SUCCESS -> {
                             it.data?.let { folder ->
-                                binding.tvFolderSettingAddTitle.text = getString(R.string.folder_edit_title)
-                                binding.etFolderSettingAddSetTitle.text = SpannableStringBuilder(folder.name)
-                                folder.subheading?.let{subheading -> binding.etFolderSettingAddSetSubheading.text = SpannableStringBuilder(subheading)}
-                                when(folder.privacy){
-                                    Privacy.ALL -> binding.radiobuttonFolderSettingAddSetPrivateAll.isChecked = true
-                                    Privacy.ONLY_ME -> binding.radiobuttonFolderSettingAddSetPrivateOnlyMe.isChecked = true
+                                binding.tvFolderSettingAddTitle.text =
+                                    getString(R.string.folder_edit_title)
+                                binding.etFolderSettingAddSetTitle.text =
+                                    SpannableStringBuilder(folder.name)
+                                folder.subheading?.let { subheading ->
+                                    binding.etFolderSettingAddSetSubheading.text =
+                                        SpannableStringBuilder(subheading)
                                 }
-                                initThumbnailImg = "http://117.17.198.45:8080/images/" + folder.thumbnailImage
-                                GlideApp.with(binding.ivFolderSettingThumbnail.context)
-                                    .load(initThumbnailImg)
-                                    .into(binding.ivFolderSettingThumbnail)
+                                when (folder.privacy) {
+                                    Privacy.ALL -> binding.radiobuttonFolderSettingAddSetPrivateAll.isChecked =
+                                        true
+                                    Privacy.ONLY_ME -> binding.radiobuttonFolderSettingAddSetPrivateOnlyMe.isChecked =
+                                        true
+                                }
+                                CoroutineScope(Dispatchers.Main).launch {
+                                    val folderThumbnailImage = withContext(Dispatchers.IO) {
+                                        loadImageBackground(
+                                            requestManager = glideRequestManager,
+                                            width = layoutParams.width,
+                                            height = 40,
+                                            imgName = folder.thumbnailImage
+                                        )
+                                    }
+                                    loadImageView(
+                                        requestManager = glideRequestManager,
+                                        width = layoutParams.width,
+                                        height = 148,
+                                        img = folderThumbnailImage,
+                                        imgView = binding.ivFolderSettingThumbnail
+                                    )
+                                }
                             }
                         }
                     }
@@ -100,27 +133,43 @@ class FolderEditFragment  : Fragment() {
             findNavController().navigateUp()
         }
     }
+
     private fun setConfirmButtonClickListener() {
         binding.tvFolderSettingAddConfirm.setOnClickListener { it ->
             val name: String = binding.etFolderSettingAddSetTitle.text.toString()
             val subheading: String = binding.etFolderSettingAddSetSubheading.text.toString()
-            val privacy: Privacy= when(binding.radiogroupFolderSettingAddSetPrivate.checkedRadioButtonId){
-                binding.radiobuttonFolderSettingAddSetPrivateAll.id -> Privacy.ALL
-                binding.radiobuttonFolderSettingAddSetPrivateOnlyMe.id -> Privacy.ONLY_ME
-                else -> Privacy.ALL
-            }
+            val privacy: Privacy =
+                when (binding.radiogroupFolderSettingAddSetPrivate.checkedRadioButtonId) {
+                    binding.radiobuttonFolderSettingAddSetPrivateAll.id -> Privacy.ALL
+                    binding.radiobuttonFolderSettingAddSetPrivateOnlyMe.id -> Privacy.ONLY_ME
+                    else -> Privacy.ALL
+                }
 
-            if(this::imageUri.isInitialized){
+            if (this::imageUri.isInitialized) {
                 // 폴더 커버 이미지 변경
                 val thumbnailImg = thumbnailImgBitmap?.let { bitmapToFile(it) }
-                folderSettingViewModel.requestEditFolder(args.folderId,name,privacy,subheading,true, thumbnailImg)
-            }else{
+                folderSettingViewModel.requestEditFolder(
+                    args.folderId,
+                    name,
+                    privacy,
+                    subheading,
+                    true,
+                    thumbnailImg
+                )
+            } else {
                 // 폴더 커버 이미지 변경되지 않음
-                folderSettingViewModel.requestEditFolder(args.folderId,name,privacy,subheading,false, null)
+                folderSettingViewModel.requestEditFolder(
+                    args.folderId,
+                    name,
+                    privacy,
+                    subheading,
+                    false,
+                    null
+                )
             }
 
             folderSettingViewModel.editSuccess.observe(viewLifecycleOwner) {
-                if(it.getContentIfNotHandled() == true){
+                if (it.getContentIfNotHandled() == true) {
                     findNavController().navigateUp()
                 }
             }
@@ -134,36 +183,43 @@ class FolderEditFragment  : Fragment() {
     }
 
     private fun observeNavigationFolderSettingImageCallBack() {
-        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("imageUri")?.observe(viewLifecycleOwner) {
-            imageUri = it
-            if(this::imageUri.isInitialized){
-                if(imageUri == "") {
-                    GlideApp.with(requireContext())
-                        .load(R.drawable.ic_folder_thumbnail_empty)
-                        .centerCrop()
-                        .into(binding.ivFolderSettingThumbnail)
-                    thumbnailImgBitmap = null
-                } else {
-                    thumbnailImgBitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        ImageDecoder.decodeBitmap(ImageDecoder.createSource(requireContext().contentResolver, imageUri.toUri()))
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("imageUri")
+            ?.observe(viewLifecycleOwner) {
+                imageUri = it
+                if (this::imageUri.isInitialized) {
+                    if (imageUri == "") {
+                        glideRequestManager.load(R.drawable.ic_folder_thumbnail_empty).centerCrop()
+                            .into(binding.ivFolderSettingThumbnail)
+                        thumbnailImgBitmap = null
                     } else {
-                        MediaStore.Images.Media.getBitmap(requireContext().contentResolver, imageUri.toUri())
+                        thumbnailImgBitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                            ImageDecoder.decodeBitmap(
+                                ImageDecoder.createSource(
+                                    requireContext().contentResolver,
+                                    imageUri.toUri()
+                                )
+                            )
+                        } else {
+                            MediaStore.Images.Media.getBitmap(
+                                requireContext().contentResolver,
+                                imageUri.toUri()
+                            )
+                        }
+                        glideRequestManager.load(imageUri).into(binding.ivFolderSettingThumbnail)
                     }
-                    GlideApp.with(this)
-                        .load(imageUri)
-                        .into(binding.ivFolderSettingThumbnail)
                 }
             }
-        }
     }
 
     private fun bitmapToFile(bitmap: Bitmap): File {
         val imageFileTimeFormat = SimpleDateFormat("yyyy-MM-d-HH-mm-ss", Locale.KOREA)
-        val fileName = imageFileTimeFormat.format(Date(System.currentTimeMillis())).toString() + ".jpg"
+        val fileName =
+            imageFileTimeFormat.format(Date(System.currentTimeMillis())).toString() + ".jpg"
         val cacheDir = requireContext().cacheDir.toString()
         val file = File("$cacheDir/$fileName")
         var out: OutputStream? = null
-        try { file.createNewFile()
+        try {
+            file.createNewFile()
             out = FileOutputStream(file)
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
         } finally {
@@ -172,21 +228,34 @@ class FolderEditFragment  : Fragment() {
         return file
     }
 
-    private fun verifyFolderName(){
+    private fun verifyFolderName() {
         binding.etFolderSettingAddSetTitle.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 when {
                     s.toString().trim().isEmpty() -> {
-                        ButtonActivation.setTextViewConfirmButtonInactive(requireContext(), binding.tvFolderSettingAddConfirm)
+                        ButtonActivation.setTextViewConfirmButtonInactive(
+                            requireContext(),
+                            binding.tvFolderSettingAddConfirm
+                        )
                     }
                     Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", s.toString().trim()) -> {
-                        ButtonActivation.setTextViewConfirmButtonActive(requireContext(), binding.tvFolderSettingAddConfirm)
+                        ButtonActivation.setTextViewConfirmButtonActive(
+                            requireContext(),
+                            binding.tvFolderSettingAddConfirm
+                        )
                     }
                     else -> {
-                        Toast.makeText(requireContext(), getString(R.string.folder_add_message_format_fail), Toast.LENGTH_SHORT).show()
-                        ButtonActivation.setTextViewConfirmButtonInactive(requireContext(), binding.tvFolderSettingAddConfirm)
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.folder_add_message_format_fail),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        ButtonActivation.setTextViewConfirmButtonInactive(
+                            requireContext(),
+                            binding.tvFolderSettingAddConfirm
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
@@ -9,26 +9,39 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideApp
+import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentFolderBinding
 import com.daily.dayo.presentation.adapter.FolderPostListAdapter
 import com.daily.dayo.presentation.viewmodel.FolderViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class FolderFragment : Fragment(){
+class FolderFragment : Fragment() {
     private var binding by autoCleared<FragmentFolderBinding>()
     private val folderViewModel by activityViewModels<FolderViewModel>()
     private val args by navArgs<FolderFragmentArgs>()
     private lateinit var folderPostListAdapter: FolderPostListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentFolderBinding.inflate(inflater,container,false)
+        binding = FragmentFolderBinding.inflate(inflater, container, false)
         setBackButtonClickListener()
         setFolderOptionClickListener()
         setFolderDetail()
@@ -44,29 +57,53 @@ class FolderFragment : Fragment(){
 
     private fun setFolderOptionClickListener() {
         binding.btnFolderOption.setOnClickListener {
-            findNavController().navigate(FolderFragmentDirections.actionFolderFragmentToFolderOptionFragment(args.folderId))
+            findNavController().navigate(
+                FolderFragmentDirections.actionFolderFragmentToFolderOptionFragment(
+                    args.folderId
+                )
+            )
         }
     }
 
-    private fun setRvFolderPostListAdapter(){
-        folderPostListAdapter = FolderPostListAdapter()
+    private fun setRvFolderPostListAdapter() {
+        folderPostListAdapter = FolderPostListAdapter(requestManager = glideRequestManager)
         binding.rvFolderPost.adapter = folderPostListAdapter
     }
 
-    private fun setFolderDetail(){
+    private fun setFolderDetail() {
+        val layoutParams = ViewGroup.MarginLayoutParams(
+            ViewGroup.MarginLayoutParams.MATCH_PARENT,
+            ViewGroup.MarginLayoutParams.MATCH_PARENT
+        )
+
         folderViewModel.requestDetailListFolder(args.folderId)
         folderViewModel.detailFolderList.observe(viewLifecycleOwner) {
-            when(it.status){
+            when (it.status) {
                 Status.SUCCESS -> {
                     it.data?.let { folder ->
                         binding.tvFolderName.text = folder.name
                         binding.tvFolderSubheading.text = folder.subheading
                         binding.tvFolderPostCount.text = folder.postCount.toString()
-                        GlideApp.with(binding.imgFolderThumbnail.context)
-                            .load("http://117.17.198.45:8080/images/" + folder.thumbnailImage)
-                            .into(binding.imgFolderThumbnail)
+                        CoroutineScope(Dispatchers.Main).launch {
+                            val folderThumbnailImage = withContext(Dispatchers.IO) {
+                                loadImageBackground(
+                                    requestManager = glideRequestManager,
+                                    width = layoutParams.width,
+                                    height = 200,
+                                    imgName = folder.thumbnailImage
+                                )
+                            }
+                            loadImageView(
+                                requestManager = glideRequestManager,
+                                width = layoutParams.width,
+                                height = 200,
+                                img = folderThumbnailImage,
+                                imgView = binding.imgFolderThumbnail
+                            )
+                        }
                         folder.posts?.let { it1 -> folderPostListAdapter.submitList(it1) }
-                        if(folder.memberId == DayoApplication.preferences.getCurrentUser().memberId) binding.btnFolderOption.isVisible = true
+                        if (folder.memberId == DayoApplication.preferences.getCurrentUser().memberId) binding.btnFolderOption.isVisible =
+                            true
                     }
                 }
             }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.DefaultDialogConfigure
 import com.daily.dayo.common.DefaultDialogConfirm
@@ -21,6 +23,12 @@ class FollowerListFragment : Fragment(){
     private var binding by autoCleared<FragmentFollowerListBinding>()
     private val followViewModel by activityViewModels<FollowViewModel>()
     private lateinit var followerListAdapter: FollowListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -33,7 +41,7 @@ class FollowerListFragment : Fragment(){
     }
 
     private fun setRvFollowerListAdapter(){
-        followerListAdapter = FollowListAdapter()
+        followerListAdapter = FollowListAdapter(requestManager = glideRequestManager)
         binding.rvFollower.adapter = followerListAdapter
         followerListAdapter.setOnItemClickListener(object : FollowListAdapter.OnItemClickListener{
             override fun onItemClick(checkbox: CheckBox, follow: Follow, position: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.DefaultDialogConfigure
 import com.daily.dayo.common.DefaultDialogConfirm
@@ -21,6 +23,12 @@ class FollowingListFragment : Fragment() {
     private var binding by autoCleared<FragmentFollowingListBinding>()
     private val followViewModel by activityViewModels<FollowViewModel>()
     private lateinit var followingListAdapter: FollowListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -33,7 +41,7 @@ class FollowingListFragment : Fragment() {
     }
 
     private fun setRvFollowingListAdapter(){
-        followingListAdapter = FollowListAdapter()
+        followingListAdapter = FollowListAdapter(requestManager = glideRequestManager)
         binding.rvFollowing.adapter = followingListAdapter
         followingListAdapter.setOnItemClickListener(object : FollowListAdapter.OnItemClickListener{
             override fun onItemClick(checkbox: CheckBox, follow: Follow, position: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentProfileBookmarkPostListBinding
@@ -18,7 +20,12 @@ class ProfileBookmarkPostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileBookmarkPostListBinding>()
     private val profileViewModel by activityViewModels<ProfileViewModel>()
     private lateinit var profileBookmarkPostListAdapter: ProfileBookmarkPostListAdapter
+    private lateinit var glideRequestManager: RequestManager
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,7 +38,7 @@ class ProfileBookmarkPostListFragment : Fragment() {
     }
 
     private fun setRvProfileLikePostListAdapter() {
-        profileBookmarkPostListAdapter = ProfileBookmarkPostListAdapter()
+        profileBookmarkPostListAdapter = ProfileBookmarkPostListAdapter(requestManager = glideRequestManager)
         binding.rvProfileBookmarkPost.adapter = profileBookmarkPostListAdapter
         profileBookmarkPostListAdapter.setOnItemClickListener(object : ProfileBookmarkPostListAdapter.OnItemClickListener{
             override fun onItemClick(v: View, bookmarkPost: BookmarkPost, pos: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
@@ -19,6 +21,12 @@ class ProfileFolderListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileFolderListBinding>()
     private val profileViewModel by activityViewModels<ProfileViewModel>()
     private lateinit var profileFolderListAdapter: ProfileFolderListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,7 +39,7 @@ class ProfileFolderListFragment : Fragment() {
     }
 
     private fun setRvProfileFolderListAdapter() {
-        profileFolderListAdapter = ProfileFolderListAdapter()
+        profileFolderListAdapter = ProfileFolderListAdapter(requestManager = glideRequestManager)
         binding.rvProfileFolder.adapter = profileFolderListAdapter
         profileFolderListAdapter.setOnItemClickListener(object : ProfileFolderListAdapter.OnItemClickListener{
             override fun onItemClick(v: View, folder: Folder, pos: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
@@ -7,7 +7,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
-import com.daily.dayo.DayoApplication
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentProfileLikePostListBinding
@@ -19,6 +20,12 @@ class ProfileLikePostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileLikePostListBinding>()
     private val profileViewModel by activityViewModels<ProfileViewModel>()
     private lateinit var profileLikePostListAdapter: ProfileLikePostListAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,20 +38,24 @@ class ProfileLikePostListFragment : Fragment() {
     }
 
     private fun setRvProfileLikePostListAdapter() {
-        profileLikePostListAdapter = ProfileLikePostListAdapter()
+        profileLikePostListAdapter = ProfileLikePostListAdapter(requestManager = glideRequestManager)
         binding.rvProfileLikePost.adapter = profileLikePostListAdapter
-        profileLikePostListAdapter.setOnItemClickListener(object : ProfileLikePostListAdapter.OnItemClickListener{
+        profileLikePostListAdapter.setOnItemClickListener(object :
+            ProfileLikePostListAdapter.OnItemClickListener {
             override fun onItemClick(v: View, likePost: LikePost, pos: Int) {
-                findNavController().navigate(ProfileFragmentDirections.actionProfileFragmentToPostFragment(
-                    likePost.postId))
+                findNavController().navigate(
+                    ProfileFragmentDirections.actionProfileFragmentToPostFragment(
+                        likePost.postId
+                    )
+                )
             }
         })
     }
 
-    private fun setProfileLikePostList(){
+    private fun setProfileLikePostList() {
         profileViewModel.requestAllMyLikePostList()
         profileViewModel.likePostList.observe(viewLifecycleOwner) {
-            when(it.status){
+            when (it.status) {
                 Status.SUCCESS -> {
                     it.data?.let { likePostList ->
                         profileLikePostListAdapter.submitList(likePostList)

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
@@ -11,7 +11,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.daily.dayo.DayoApplication
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.HideKeyBoardUtil
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
@@ -27,6 +28,12 @@ class SearchResultFragment : Fragment() {
     private val searchViewModel by activityViewModels<SearchViewModel>()
     private val args by navArgs<SearchResultFragmentArgs>()
     private lateinit var searchTagResultPostAdapter: SearchTagResultPostAdapter
+    private lateinit var glideRequestManager: RequestManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        glideRequestManager = Glide.with(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -76,7 +83,7 @@ class SearchResultFragment : Fragment() {
     }
 
     private fun setSearchTagResultPostAdapter() {
-        searchTagResultPostAdapter = SearchTagResultPostAdapter()
+        searchTagResultPostAdapter = SearchTagResultPostAdapter(requestManager = glideRequestManager)
         binding.rvSearchResultContentsPostList.adapter = searchTagResultPostAdapter
     }
 


### PR DESCRIPTION
## 내용
- 기존 Glide를 사용시마다 URL 주소 및 기타 옵션에 대하여 설정하여 이미지뷰에 대한 일괄적인 업데이트가 불편했던 점을 개선하기 위해 공통 유틸 생성
- `GlideApp을` 사용하던 부분을 `RequestManager`로 대체
## 작업 사항
- Glide에 대한 옵션 값을 하나하나 설정해야 했던 부분들 교체
- Glide 사용시 `이미지뷰에 적용하는 Thread`와 `이미지를 로딩하는 Thread`를 분리
- override시 각 이미지뷰 크기에 맞게 Override 되도록 설정
- Util 사용이 불필요해보이는 경우 `RequestManager만` 사용하도록 함

## 참고
- 일괄적 교체로 인한 누락 및 오류 존재 가능성 존재
- #270 