### PR TITLE
#290 [bug] Fix Adding Tag Error, Edit Post Error, Image Upload Count Error, Remove the Do not post empty settings

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/ListLiveData.kt
+++ b/app/src/main/java/com/daily/dayo/common/ListLiveData.kt
@@ -27,6 +27,10 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
         }
     }
 
+    fun size(): Int {
+        return value?.size ?: 0
+    }
+
     fun replaceAll(list: List<T>) {
         val items: ArrayList<T> = arrayListOf()
         items.addAll(list)

--- a/app/src/main/java/com/daily/dayo/common/ReplaceUnicode.kt
+++ b/app/src/main/java/com/daily/dayo/common/ReplaceUnicode.kt
@@ -1,0 +1,33 @@
+package com.daily.dayo.common
+
+object ReplaceUnicode {
+    fun replaceBlankText(originalText: String): String {
+        var editedText = originalText
+        editedText = editedText.replace( " ", "")
+        editedText = editedText.replace( "\u00A0", "")
+        editedText = editedText.replace( "\u2000", "")
+        editedText = editedText.replace( "\u2001", "")
+        editedText = editedText.replace( "\u2002", "")
+        editedText = editedText.replace( "\u2003", "")
+        editedText = editedText.replace( "\u2004", "")
+        editedText = editedText.replace( "\u2005", "")
+        editedText = editedText.replace( "\u2006", "")
+        editedText = editedText.replace( "\u200b", "")
+        return editedText
+    }
+    fun trimBlankText(originalText: String): String {
+        var editedText = originalText
+        editedText = editedText.trim()
+        editedText = editedText.trim(' ')
+        editedText = editedText.trim('\u00A0')
+        editedText = editedText.trim('\u2000')
+        editedText = editedText.trim('\u2001')
+        editedText = editedText.trim('\u2002')
+        editedText = editedText.trim('\u2003')
+        editedText = editedText.trim('\u2004')
+        editedText = editedText.trim('\u2005')
+        editedText = editedText.trim('\u2006')
+        editedText = editedText.trim('\u200b')
+        return editedText
+    }
+}

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/post/PostResponse.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/post/PostResponse.kt
@@ -12,14 +12,8 @@ data class ListFeedResponse(
 )
 
 data class EditPostResponse(
-    @SerializedName("category")
-    val category: Category,
-    @SerializedName("contents")
-    val contents : String,
-    @SerializedName("folderId")
-    val folderId : Int,
-    @SerializedName("hashtags")
-    val hashtags : List<String>
+    @SerializedName("postId")
+    val postId: Int
 )
 
 data class CreatePostResponse (

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
@@ -34,6 +34,7 @@ import com.daily.dayo.common.Event
 import com.daily.dayo.common.GlideApp
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.RadioGridGroup
+import com.daily.dayo.common.ReplaceUnicode
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.databinding.FragmentWriteBinding
 import com.daily.dayo.domain.model.Category
@@ -57,7 +58,6 @@ class WriteFragment : Fragment() {
     private lateinit var glideRequestManager: RequestManager
 
     private var isCategorySelected: Boolean = false
-    private var isContentsFilled: Boolean = false
     private var isImageUploaded: Boolean = false
     private var isLoadedEditPost: Boolean = false
 
@@ -132,11 +132,7 @@ class WriteFragment : Fragment() {
                             R.string.write_post_upload_alert_message_edittext_length_fail_max,
                             Toast.LENGTH_SHORT
                         ).show()
-                    } else if (s.toString().isEmpty()) {
-                        isContentsFilled = false
-                        setUploadButtonActivation()
                     } else {
-                        isContentsFilled = true
                         setUploadButtonActivation()
                     }
                 }
@@ -162,7 +158,6 @@ class WriteFragment : Fragment() {
                             Observer { isSuccess ->
                                 if (isSuccess.getContentIfNotHandled() == true) {
                                     isCategorySelected = true
-                                    isContentsFilled = true
                                     isImageUploaded = true
 
                                     writeViewModel.writeCurrentPostDetail.value?.getContentIfNotHandled()
@@ -322,15 +317,6 @@ class WriteFragment : Fragment() {
                     Toast.LENGTH_SHORT
                 ).show()
             }
-        } else if (!isContentsFilled) {
-            binding.btnWritePostUpload.isSelected = false
-            binding.btnWritePostUpload.setOnClickListener {
-                Toast.makeText(
-                    requireContext(),
-                    R.string.write_post_upload_alert_message_empty_content,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
         } else if (!isImageUploaded) {
             binding.btnWritePostUpload.isSelected = false
             binding.btnWritePostUpload.setOnClickListener {
@@ -346,10 +332,9 @@ class WriteFragment : Fragment() {
             binding.btnWritePostUpload.setOnClickListener {
                 writeViewModel.postId.value = args.postId
                 writeViewModel.postCategory.value = selectedCategoryName
-                writeViewModel.postContents.value = binding.etWriteDetail.text.toString()
-                writeViewModel.postImageUriList.observe(viewLifecycleOwner) {
-                    Log.e("dayo", "write upload:${it}")
-                }
+                writeViewModel.postContents.value =
+                    ReplaceUnicode.trimBlankText(binding.etWriteDetail.text.toString())
+                        .ifEmpty { "" }
                 findNavController().navigate(WriteFragmentDirections.actionWriteFragmentToWriteOptionFragment())
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
@@ -28,6 +28,7 @@ import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.math.min
 
 @AndroidEntryPoint
 class WriteImageOptionFragment : DialogFragment() {
@@ -102,27 +103,35 @@ class WriteImageOptionFragment : DialogFragment() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
             if (activityResult.resultCode == Activity.RESULT_OK) {
                 val data: Intent? = activityResult.data
-
+                val remainingNum = 5 - writeViewModel.postImageUriList.size()
                 if (data?.clipData != null) { //사진 여러 개 선택 시
                     val count = data.clipData!!.itemCount
-                    if (count > 5) {
+                    if (count > remainingNum) {
                         Toast.makeText(
                             requireContext(),
                             getString(R.string.write_post_upload_alert_message_image_fail_max),
                             Toast.LENGTH_SHORT
                         ).show()
                     }
-                    for (i in 0 until count) {
+                    for (i in 0 until min(count, remainingNum)) { // 이전 선택 사진을 포함해 선택 사진의 총 갯수가 5개 이하면 count를, 초과하면 remainingNumber을 선택
                         val imageUri = data.clipData!!.getItemAt(i).uri
                         writeViewModel.postImageUriList.add(imageUri.toString())
                     }
                     findNavController().popBackStack()
                 } else { // 단일 선택
                     data?.data?.let { uri ->
-                        val imageUri: Uri? = data.data
-                        if (imageUri != null) {
-                            writeViewModel.postImageUriList.add(imageUri.toString())
-                            findNavController().popBackStack()
+                        if (remainingNum <= 0) {
+                            Toast.makeText(
+                                requireContext(),
+                                getString(R.string.write_post_upload_alert_message_image_fail_max),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            val imageUri: Uri? = data.data
+                            if (imageUri != null) {
+                                writeViewModel.postImageUriList.add(imageUri.toString())
+                                findNavController().popBackStack()
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -72,6 +72,7 @@ class WriteViewModel @Inject constructor(
         postFolderId: Int,
         postTags: Array<String>
     ) = viewModelScope.launch {
+        _writeSuccess.postValue(Event(false))
         val response = requestUploadPostUseCase(
             category = postCategory,
             contents = postContents,
@@ -94,6 +95,7 @@ class WriteViewModel @Inject constructor(
         postFolderId: Int,
         postTags: Array<String>
     ) = viewModelScope.launch {
+        _writeEditSuccess.postValue(Event(false))
         val response = requestEditPostUseCase(
             postId = postId,
             EditPostRequest(
@@ -104,7 +106,7 @@ class WriteViewModel @Inject constructor(
             )
         )
         if (response.isSuccessful) {
-            _writePostId.postValue(response.body()?.let { Event(it.folderId) } as Event<Int>)
+            _writePostId.postValue(response.body()?.let { Event(it.postId) })
             _writeEditSuccess.postValue(Event(true))
         } else {
             _writeEditSuccess.postValue(Event(false))


### PR DESCRIPTION
## 내용
+ 기존태그 입력시 태그 중간에 빈칸 입력이 가능했던 현상 수정
+ 중복된 태그 추가 불가 설정
+ 태그가 수정된 경우에만 태그 페이지에서 확인 버튼이 활성화 되도록 설정
- 태그 입력후 확인 버튼을 눌러 글 작성화면으로 돌아갈 때 일시적으로 태그의 갯수가 2배가 되는 현상 수정
   - 태그 4개 이상 입력시 8개 제한 에러 메시지가 나오면서 태그 저장이 정상적으로 되지 않는 현상 수정
- 기존 글 수정 저장 및 완료후, 수정한 게시글로 이동할 때 수정한 내용이 즉시 반영되지 않는 것으로 보이는 현상 수정
- 이미지 업로드 시, 5개 이하의 이미지를 선택했을 때 이미지 카운팅 에러로 인해 정상적으로 이미지가 올라가지 않는 현상 수정
- 기존에 글 업로드시, 내용을 작성하지 않은 채로 글 작성을 막았던 조건 제거

## 작업 사항
### 태그 추가
- 태그 추가시, 입력된 String에 존재하는 모든 공백 제거후 추가되도록 설정
- 태그 추가시, 빈 태그와 중복태그는 추가되지 않고 태그 입력칸만 비워지도록 설정
- 기존 태그가 0개인 경우에만 비활성화되던 확인 버튼을 0개인 경우에도 활성화되며, 태그 리스트가 그전에 입력했던 태그 리스트와 동일하지 않은 경우에만 확인 버튼이 활성화되도록 설정
- 태그 입력 완료후 저장하는 경우, 기존에 ViewModel에 저장되어있던 ListLiveData가 아닌 새로운 ListLiveData를 만들어 추가하여 저장하도록 설정
- 태그 입력 페이지에서 소프트 키보드 영역이 아닌 다른 영역을 클릭하면 키보드가 내려갈 수 있도록 설정
### 게시글 업로드 및 수정
- 기존 글 수정시 응답 DTO가 잘못 설정되어있던 부분 수정
- 이미지 업로드시, 이미지 5개 제한을 고려해서 현재 업로드 가능 갯수와 현재 업로드하고자 하는 이미지의 갯수를 비교하여 작은 갯수만큼만 추가되도록 설정
- 기존에 글 작성시, 글 내용이 빈칸이면 업로드 버튼을 누를 수 없었던 조건 제거 및 관련 제한 조건 코드들 삭제
- 글 작성시 글의 첫 글자와 마지막 글자 사이를 제외한 공백들을 모두 제거하도록 설정

## 참고
- resolved: #290