### PR TITLE
#295 [bug] FindAccountPasswordCheckEmail Fragment Help Message

### DIFF
--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
@@ -64,6 +64,9 @@ interface MemberApiService {
     @GET("/api/v1/members/search/{email}")
     suspend fun requestCheckEmail(@Path("email") email: String): Response<Void>
 
+    @GET("/api/v1/members/search/code/{email}")
+    suspend fun requestCheckEmailAuth(@Path("email") email: String): Response<MemberAuthCodeResponse>
+
     @POST("/api/v1/members/checkPassword")
     suspend fun requestCheckCurrentPassword(@Body body: CheckPasswordRequest): Response<Void>
 

--- a/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
@@ -68,6 +68,9 @@ class MemberRepositoryImpl @Inject constructor(
     override suspend fun requestCheckEmail(email: String): Response<Void> =
         memberApiService.requestCheckEmail(email)
 
+    override suspend fun requestCheckEmailAuth(email: String): Response<MemberAuthCodeResponse> =
+        memberApiService.requestCheckEmailAuth(email)
+
     override suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Response<Void> =
         memberApiService.requestCheckCurrentPassword(body)
 

--- a/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
@@ -34,6 +34,7 @@ interface MemberRepository {
     suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Response<Void>
     suspend fun requestLogout(): Response<Void>
     suspend fun requestCheckEmail(email: String): Response<Void>
+    suspend fun requestCheckEmailAuth(email: String): Response<MemberAuthCodeResponse>
     suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Response<Void>
     suspend fun requestChangePassword(body: ChangePasswordRequest): Response<Void>
     suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Response<Void>

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestCheckEmailAuthUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestCheckEmailAuthUseCase.kt
@@ -1,0 +1,8 @@
+package com.daily.dayo.domain.usecase.member
+
+import com.daily.dayo.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class RequestCheckEmailAuthUseCase @Inject constructor(private val memberRepository: MemberRepository) {
+    suspend operator fun invoke(email: String) = memberRepository.requestCheckEmailAuth(email)
+}

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailCertificateFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailCertificateFragment.kt
@@ -138,7 +138,7 @@ class FindAccountPasswordCheckEmailCertificateFragment : Fragment() {
 
     private fun certificateEmail() {
         // 인증번호가 담긴 이메일 최초 발송
-        loginViewModel.requestCertificateEmail(args.email)
+        loginViewModel.requestCheckEmailAuth(args.email)
 
         binding.etLoginEmailFindPasswordCertificateUserInput.addTextChangedListener(object :
             TextWatcher {

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -33,6 +33,7 @@ class AccountViewModel @Inject constructor(
     private val requestResignUseCase: RequestResignUseCase,
     private val requestLogoutUseCase: RequestLogoutUseCase,
     private val requestCheckEmailUseCase: RequestCheckEmailUseCase,
+    private val requestCheckEmailAuthUseCase: RequestCheckEmailAuthUseCase,
     private val requestCheckCurrentPasswordUseCase: RequestCheckCurrentPasswordUseCase,
     private val requestChangePasswordUseCase: RequestChangePasswordUseCase,
     private val requestSettingChangePasswordUseCase: RequestSettingChangePasswordUseCase,
@@ -174,6 +175,16 @@ class AccountViewModel @Inject constructor(
             } else {
                 _checkEmailSuccess.postValue(false)
             }
+        }
+    }
+
+    fun requestCheckEmailAuth(inputEmail: String) = viewModelScope.launch {
+        val response = requestCheckEmailAuthUseCase(inputEmail)
+        if (response.isSuccessful) {
+            _isCertificateEmailSend.postValue(true)
+            certificateEmailAuthCode.postValue(response.body()?.authCode)
+        } else {
+            _isCertificateEmailSend.postValue(false)
         }
     }
 


### PR DESCRIPTION
## 내용
1. 비밀번호 찾기시 이메일 체크하는 과정에서 인증번호 받기를 누르지 않았는데도 인증번호 메일이 발송되는 현상
2. 이메일 체크 실패 후, 다시 올바른 이메일을 입력한 뒤 화면을 누르면 누른 수 만큼 다시 체크되어 실패메시지와 성공 메시지가 계속해서 교차해서 나타나는 현상
## 작업 사항
- 백엔드와 협의하여 이메일 존재여부 확인 및 인증메일 보내기가 결합되어 있던 API를 분리 요청함에 따라, 인증코드 요청 API를 추가로 생성하여 해결
## 참고
- resolved: #295