### PR TITLE
#333 [feature] Create PolicyFragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signin/LoginFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signin/LoginFragment.kt
@@ -2,8 +2,15 @@ package com.daily.dayo.presentation.fragment.account.signin
 
 import android.content.ContentValues
 import android.content.Intent
-import android.graphics.Paint
+import android.graphics.Typeface
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -47,7 +54,7 @@ class LoginFragment : Fragment() {
         binding = FragmentLoginBinding.inflate(inflater, container, false)
 
         loginSuccess()
-        setTextUnderline()
+        setPolicy()
         setKakaoLoginButtonClickListener()
         setEmailLoginButtonClickListener()
         setViewPager()
@@ -102,11 +109,6 @@ class LoginFragment : Fragment() {
         binding.btnLoginEmail.setOnDebounceClickListener {
             findNavController().navigate(R.id.action_loginFragment_to_loginEmailFragment)
         }
-    }
-
-    private fun setTextUnderline() {
-        binding.tvLoginUseGuideMessage2TermsOfService.paintFlags = Paint.UNDERLINE_TEXT_FLAG
-        binding.tvLoginUseGuideMessage4Privacy.paintFlags = Paint.UNDERLINE_TEXT_FLAG
     }
 
     private fun setViewPager() {
@@ -165,5 +167,58 @@ class LoginFragment : Fragment() {
                 )
             }
         }
+    }
+
+    private fun setPolicy() {
+        var span = SpannableString(getString(R.string.login_policy_guide_message))
+        setPolicyMessage(span = span, type = "terms", text = getString(R.string.policy_terms))
+        setPolicyMessage(span = span, type = "privacy", text = getString(R.string.policy_privacy))
+        span.setSpan(
+            ForegroundColorSpan(
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.gray_4_D3D2D2
+                )
+            ),
+            0,
+            span.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        binding.tvLoginUseGuideMessage.movementMethod = LinkMovementMethod.getInstance()
+        binding.tvLoginUseGuideMessage.text = span
+    }
+
+    private fun setPolicyMessage(span: SpannableString, type: String, text: String) {
+        span.setSpan(
+            object : ClickableSpan() {
+                override fun onClick(widget: View) {
+                    with(findNavController()) {
+                        if (currentDestination?.id == R.id.LoginFragment) {
+                            currentDestination?.getAction(R.id.action_loginFragment_to_policyFragment)
+                                ?.let {
+                                    navigate(
+                                        LoginFragmentDirections.actionLoginFragmentToPolicyFragment(
+                                            informationType = type
+                                        )
+                                    )
+                                }
+                        }
+                    }
+                }
+            },
+            span.indexOf(text), span.indexOf(text) + text.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        span.setSpan(
+            StyleSpan(Typeface.BOLD),
+            span.indexOf(text),
+            span.indexOf(text) + text.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        span.setSpan(
+            UnderlineSpan(),
+            span.indexOf(text),
+            span.indexOf(text) + text.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/policy/PolicyFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/policy/PolicyFragment.kt
@@ -1,0 +1,71 @@
+package com.daily.dayo.presentation.fragment.policy
+
+import android.os.Bundle
+import android.view.KeyEvent
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebViewClient
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.daily.dayo.R
+import com.daily.dayo.common.autoCleared
+import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.databinding.FragmentPolicyBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PolicyFragment : Fragment() {
+    private var binding by autoCleared<FragmentPolicyBinding>()
+    private val args by navArgs<PolicyFragmentArgs>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentPolicyBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initActionbar()
+        showPolicy(args.informationType)
+        setWebViewBackClickListener()
+    }
+
+    private fun initActionbar() {
+        binding.btnPolicyActionBarBack.setOnDebounceClickListener {
+            findNavController().navigateUp()
+        }
+        binding.tvPolicyActionBarTitle.text =
+            if (args.informationType == "privacy") getString(R.string.policy_privacy)
+            else getString(R.string.policy_terms)
+    }
+
+    private fun showPolicy(informationType: String) {
+        with(binding.webviewPolicyContents) {
+            visibility = View.VISIBLE
+            apply {
+                webViewClient = WebViewClient()
+                settings.javaScriptEnabled = false
+            }
+            loadUrl("http://117.17.198.45:8080/$informationType.html")
+        }
+        binding.webviewPolicyContents.visibility = View.VISIBLE
+    }
+
+    private fun setWebViewBackClickListener() {
+        binding.webviewPolicyContents.setOnKeyListener(
+            View.OnKeyListener { v, keyCode, event ->
+                if (event.action !== KeyEvent.ACTION_DOWN) return@OnKeyListener true
+                if (keyCode == KeyEvent.KEYCODE_BACK) {
+                    findNavController().navigateUp()
+                    return@OnKeyListener true
+                }
+                false
+            }
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_dayo_loading.xml
+++ b/app/src/main/res/drawable/ic_dayo_loading.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="69dp"
+    android:height="11dp"
+    android:viewportWidth="69"
+    android:viewportHeight="11">
+    <path
+        android:fillColor="#23C882"
+        android:pathData="M5.5,5.5m-5.5,0a5.5,5.5 0,1 1,11 0a5.5,5.5 0,1 1,-11 0" />
+    <path
+        android:fillColor="#23C882"
+        android:pathData="M34.5,5.5m-5.5,0a5.5,5.5 0,1 1,11 0a5.5,5.5 0,1 1,-11 0" />
+    <path
+        android:fillColor="#23C882"
+        android:pathData="M63.5,5.5m-5.5,0a5.5,5.5 0,1 1,11 0a5.5,5.5 0,1 1,-11 0" />
+</vector>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -111,53 +111,10 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <TextView
-            android:id="@+id/tv_login_use_guide_message_1"
+            android:id="@+id/tv_login_use_guide_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="가입 시 DAYO의 "
-            android:textSize="12dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_login_use_guide_message_2_terms_of_service"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="이용약관"
-            android:textSize="12dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_login_use_guide_message_3"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text=" 및 "
-            android:textSize="12dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_login_use_guide_message_4_privacy"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="개인정보"
-            android:textSize="12dp"
-            android:textColor="@color/gray_3_9C9C9C"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-        <TextView
-            android:id="@+id/tv_login_use_guide_message_5"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text=" 취급방침에 동의하게 됩니다."
+            android:text="@string/login_policy_guide_message"
             android:textSize="12dp"
             android:textColor="@color/gray_3_9C9C9C"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_policy.xml
+++ b/app/src/main/res/layout/fragment_policy.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.fragment.policy.PolicyFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_policy_action_bar"
+        android:layout_width="0dp"
+        android:layout_height="?actionBarSize"
+        android:elevation="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/btn_policy_action_bar_back"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            android:paddingHorizontal="18dp"
+            android:src="@drawable/ic_back_sign"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_policy_action_bar_title"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/tv_policy_action_bar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/policy_terms"
+            android:textColor="@color/gray_1_313131"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/btn_policy_action_bar_back"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_policy_action_bar_back" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_policy_contents"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_policy_action_bar">
+
+        <WebView
+            android:id="@+id/webview_policy_contents"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="20dp" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph_login.xml
+++ b/app/src/main/res/navigation/nav_graph_login.xml
@@ -11,11 +11,25 @@
         android:label="fragment_login"
         tools:layout="@layout/fragment_login">
         <action
+            android:id="@+id/action_loginFragment_to_policyFragment"
+            app:destination="@+id/PolicyFragment"/>
+        <action
             android:id="@+id/action_loginFragment_to_loginEmailFragment"
             app:destination="@+id/LoginEmailFragment"/>
         <action
             android:id="@+id/action_loginFragment_to_signupEmailSetProfileFragment"
             app:destination="@id/SignupEmailSetProfileFragment"/>
+    </fragment>
+
+    <fragment
+        android:id="@+id/PolicyFragment"
+        android:name="com.daily.dayo.presentation.fragment.policy.PolicyFragment"
+        android:label="fragment_policy"
+        tools:layout="@layout/fragment_policy">
+        <argument
+            android:name="informationType"
+            android:defaultValue="privacy"
+            app:argType="string" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,11 @@
     <string name="login_email_alert_message_fail">이메일 주소 또는 비밀번호를 잘못 입력했어요.</string>
     <string name="login_email_forget"><u>비밀번호</u>를 잊어버렸어요</string>
     <string name="login_email_signup">아직 계정이 없으신가요? <u>회원가입</u>하기</string>
+    <string name="login_policy_guide_message">가입 시 DAYO의 이용약관 및 개인정보 취급방침에 동의하게 됩니다.</string>
+
+    <!-- Policy -->
+    <string name="policy_terms">이용약관</string>
+    <string name="policy_privacy">개인정보 취급방침</string>
 
     <!-- Home -->
     <string name="DayoPick">DAYO PICK</string>


### PR DESCRIPTION
## 내용 및 작업 사항
- 이용약관 및 개인정보처리방침 페이지를 표시할 Fragment 생성 및 Layout 설정
- LoginFragment 하단 안내메시지를 클릭하면 각각 이용약관 및 개인정보처리방침이 있는 웹으로 이동하여 보여질수 있도록 웹뷰로 보여줌
   - 이용약관 및 개인정보 처리방침 클릭 여부에 따라 하나의 Fragment를 이용해 각각 다른 페이지가 보여질 수 있도록 설정

## 참고
- resolved: #333