### PR TITLE
#339 [feature] Add Sentry Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,7 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+# Sentry Properties
+sentry.properties
+
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio

--- a/.gitignore
+++ b/.gitignore
@@ -144,5 +144,6 @@ fabric.properties
 
 # Sentry Properties
 sentry.properties
+/*/sentry.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     def lifecycle_version = "2.4.0"
     def splashscreen_version = "1.0.0-beta01"
     def lottie_version = "5.0.3"
+    def sentry_version = "6.8.0"
 
     // Java language implementation Navigation
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
@@ -151,7 +152,7 @@ dependencies {
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 
     // Sentry
-    implementation 'io.sentry:sentry-android:6.6.0'
+    implementation "io.sentry:sentry-android:$sentry_version"
     implementation 'org.slf4j:slf4j-nop:1.7.25'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,21 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'androidx.navigation.safeargs.kotlin'
     id 'com.google.gms.google-services'
+    id 'io.sentry.android.gradle'
 }
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
+
+sentry {
+    setIncludeProguardMapping(true)
+    setAutoUploadProguardMapping(true)
+    setExperimentalGuardsquareSupport(false)
+    setUploadNativeSymbols(false)
+    setIncludeNativeSources(false)
+    setAutoUpload(true)
+}
 
 android {
     compileSdkVersion 31
@@ -139,6 +149,10 @@ dependencies {
 
     // Shimmer
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
+
+    // Sentry
+    implementation 'io.sentry:sentry-android:6.6.0'
+    implementation 'org.slf4j:slf4j-nop:1.7.25'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# ==================================
+# Sentry
+# ==================================
+-keepattributes SourceFile, LineNumberTable, Annotation
+-dontwarn org.slf4j.**
+-dontwarn javax.**
+-keep class io.sentry.event.* { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DAYO">
+        <meta-data android:name="io.sentry.dsn" android:value="https://260a350bb8164818836c6e59d600d262@o4504117607596032.ingest.sentry.io/4504117608579072" />
+        <!-- Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+           We recommend adjusting this value in production. -->
+        <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+        <!-- Enable user interaction tracing to capture transactions for various UI events (such as clicks or scrolls). -->
+        <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DAYO">
-        <meta-data android:name="io.sentry.dsn" android:value="https://260a350bb8164818836c6e59d600d262@o4504117607596032.ingest.sentry.io/4504117608579072" />
+        <meta-data android:name="io.sentry.dsn" android:value="https://7f03a2b5d1c24582bfca11c28231a45f@o4504230448136192.ingest.sentry.io/4504230448988160" />
         <!-- Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
            We recommend adjusting this value in production. -->
         <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />

--- a/app/src/main/resources/sentry.properties
+++ b/app/src/main/resources/sentry.properties
@@ -1,0 +1,3 @@
+defaults.project=android
+defaults.org=dayo-seoultech
+auth.token="??? Auth Token"

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
         classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'io.sentry:sentry-android-gradle-plugin:3.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,0 +1,3 @@
+defaults.project=android
+defaults.org=dayo-seoultech
+auth.token="??? Auth Token"


### PR DESCRIPTION
## 내용 및 작업사항
- 로깅을 위한 Sentry 도입
- 추후 Proguard 적용에 대비하여 Progurad rule에 Sentry 관련 라이브러리가 제외되도록 설정
- `sentry.properties`는 각 개인 계정의 Auth Token이 담겨있으므로, 최초 Push후 수정되지 않도록 `.gitignore`에 추가

## 참고
- 개발을 진행하는 경우 2개의 `sentry.properties` 파일에 자신의 AuthToken을 입력해야 정상적으로 빌드가 진행됩니다. Sentry 가입 및 팀 Join이후 아래의 링크에서 자신의 Token을 생성한 뒤 붙여넣으면 됩니다.
- https://sentry.io/settings/account/api/auth-tokens/