### PR TITLE
#349 [feature] Handling exceptions in network communication

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/Resource.kt
+++ b/app/src/main/java/com/daily/dayo/common/Resource.kt
@@ -1,20 +1,62 @@
 package com.daily.dayo.common
 
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import retrofit2.Response
+import java.net.URLDecoder
+
 data class Resource<out T>(
-    val status: Status, val data: T?, val message:String?
-){
+    val status: Status, val data: T?, val message: String?, val exception: Exception?
+) {
     // create some utility files to retrieve data inside other package.
     // These classes will be used to wrap our data to be used in a generic way into our UI.
     // 사용할 데이터를 Wrapping하여 Success, error, loading 판단
-    companion object{
-        fun <T> success(data:T?): Resource<T> {
-            return Resource(Status.SUCCESS, data, null)
+    companion object {
+        fun <T> success(data: T?): Resource<T> {
+            return Resource(Status.SUCCESS, data, null, null)
         }
-        fun <T> error(msg:String, data:T?): Resource<T> {
-            return Resource(Status.ERROR, data, msg)
+
+        fun <T> error(msg: String, data: T?): Resource<T> {
+            return Resource(Status.ERROR, data, msg, null)
         }
-        fun <T> loading(data:T?): Resource<T> {
-            return Resource(Status.LOADING, data, null)
+
+        fun <T> error(code: String, msg: String): Resource<T> {
+            val resource = Resource(
+                Status.API_ERROR,
+                null,
+                "${URLDecoder.decode(code, "UTF-8")}:${URLDecoder.decode(msg, "UTF-8")}",
+                null
+            )
+            // TODO 응답 코드에 따라서 Sentry CaptureMessage 예외처리 필요
+            Sentry.captureMessage("[API ERROR] $resource",SentryLevel.ERROR)
+            return resource
+        }
+
+        fun <T> error(exception: Exception?): Resource<T> =
+            Resource(Status.ERROR, null, null, exception)
+
+        fun <T> loading(data: T?): Resource<T> {
+            return Resource(Status.LOADING, data, null, null)
         }
     }
 }
+
+fun <T> Response<T>.toResource(): Resource<T> {
+    return if (this.isSuccessful) {
+        Resource.success(this.body())
+    } else {
+        val code = this.code()
+        val message = this.message() ?: ""
+        Resource.error(
+            URLDecoder.decode(code.toString(), "UTF-8"),
+            URLDecoder.decode(message, "UTF-8")
+        )
+    }
+}
+
+suspend fun <T> setExceptionHandling(requestApi: suspend () -> Response<T>): Resource<T> =
+    try {
+        requestApi.invoke().toResource()
+    } catch (e: Exception) {
+        Resource.error(e)
+    }

--- a/app/src/main/java/com/daily/dayo/common/Resource.kt
+++ b/app/src/main/java/com/daily/dayo/common/Resource.kt
@@ -1,62 +1,20 @@
 package com.daily.dayo.common
 
-import io.sentry.Sentry
-import io.sentry.SentryLevel
-import retrofit2.Response
-import java.net.URLDecoder
-
 data class Resource<out T>(
-    val status: Status, val data: T?, val message: String?, val exception: Exception?
-) {
+    val status: Status, val data: T?, val message:String?
+){
     // create some utility files to retrieve data inside other package.
     // These classes will be used to wrap our data to be used in a generic way into our UI.
     // 사용할 데이터를 Wrapping하여 Success, error, loading 판단
-    companion object {
-        fun <T> success(data: T?): Resource<T> {
-            return Resource(Status.SUCCESS, data, null, null)
+    companion object{
+        fun <T> success(data:T?): Resource<T> {
+            return Resource(Status.SUCCESS, data, null)
         }
-
-        fun <T> error(msg: String, data: T?): Resource<T> {
-            return Resource(Status.ERROR, data, msg, null)
+        fun <T> error(msg:String, data:T?): Resource<T> {
+            return Resource(Status.ERROR, data, msg)
         }
-
-        fun <T> error(code: String, msg: String): Resource<T> {
-            val resource = Resource(
-                Status.API_ERROR,
-                null,
-                "${URLDecoder.decode(code, "UTF-8")}:${URLDecoder.decode(msg, "UTF-8")}",
-                null
-            )
-            // TODO 응답 코드에 따라서 Sentry CaptureMessage 예외처리 필요
-            Sentry.captureMessage("[API ERROR] $resource",SentryLevel.ERROR)
-            return resource
-        }
-
-        fun <T> error(exception: Exception?): Resource<T> =
-            Resource(Status.ERROR, null, null, exception)
-
-        fun <T> loading(data: T?): Resource<T> {
-            return Resource(Status.LOADING, data, null, null)
+        fun <T> loading(data:T?): Resource<T> {
+            return Resource(Status.LOADING, data, null)
         }
     }
 }
-
-fun <T> Response<T>.toResource(): Resource<T> {
-    return if (this.isSuccessful) {
-        Resource.success(this.body())
-    } else {
-        val code = this.code()
-        val message = this.message() ?: ""
-        Resource.error(
-            URLDecoder.decode(code.toString(), "UTF-8"),
-            URLDecoder.decode(message, "UTF-8")
-        )
-    }
-}
-
-suspend fun <T> setExceptionHandling(requestApi: suspend () -> Response<T>): Resource<T> =
-    try {
-        requestApi.invoke().toResource()
-    } catch (e: Exception) {
-        Resource.error(e)
-    }

--- a/app/src/main/java/com/daily/dayo/common/Status.kt
+++ b/app/src/main/java/com/daily/dayo/common/Status.kt
@@ -2,7 +2,6 @@ package com.daily.dayo.common
 
 enum class Status {
     SUCCESS,
-    API_ERROR,
     ERROR,
     LOADING
 }

--- a/app/src/main/java/com/daily/dayo/common/Status.kt
+++ b/app/src/main/java/com/daily/dayo/common/Status.kt
@@ -2,6 +2,7 @@ package com.daily.dayo.common
 
 enum class Status {
     SUCCESS,
+    API_ERROR,
     ERROR,
     LOADING
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/alarm/AlarmApiService.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.data.datasource.remote.alarm
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -8,8 +8,8 @@ import retrofit2.http.Path
 interface AlarmApiService {
 
     @GET("/api/v1/alarms")
-    suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse>
+    suspend fun requestAllAlarmList(): NetworkResponse<ListAllAlarmResponse>
 
     @POST("/api/v1/alarms/{alarmId}")
-    suspend fun requestIsCheckAlarm(@Path("alarmId") alarmId: Int): Response<Void>
+    suspend fun requestIsCheckAlarm(@Path("alarmId") alarmId: Int): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/block/BlockApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/block/BlockApiService.kt
@@ -1,11 +1,11 @@
 package com.daily.dayo.data.datasource.remote.block
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface BlockApiService {
 
     @POST("/api/v1/block")
-    suspend fun requestBlockMember(@Body body: BlockRequest): Response<Void>
+    suspend fun requestBlockMember(@Body body: BlockRequest): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/bookmark/BookmarkApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/bookmark/BookmarkApiService.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.data.datasource.remote.bookmark
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -9,11 +9,11 @@ import retrofit2.http.Path
 interface BookmarkApiService {
 
     @POST("/api/v1/bookmark")
-    suspend fun requestBookmarkPost(@Body body: CreateBookmarkRequest): Response<CreateBookmarkResponse>
+    suspend fun requestBookmarkPost(@Body body: CreateBookmarkRequest): NetworkResponse<CreateBookmarkResponse>
 
     @POST("/api/v1/bookmark/delete/{postId}")
-    suspend fun requestDeleteBookmarkPost(@Path("postId") postId: Int): Response<Void>
+    suspend fun requestDeleteBookmarkPost(@Path("postId") postId: Int): NetworkResponse<Void>
 
     @GET("/api/v1/bookmark/list")
-    suspend fun requestAllMyBookmarkPostList(): Response<ListAllMyBookmarkPostResponse>
+    suspend fun requestAllMyBookmarkPostList(): NetworkResponse<ListAllMyBookmarkPostResponse>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/comment/CommentApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/comment/CommentApiService.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.data.datasource.remote.comment
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -9,11 +9,11 @@ import retrofit2.http.Path
 interface CommentApiService {
 
     @POST("/api/v1/comments")
-    suspend fun requestCreatePostComment(@Body body: CreateCommentRequest): Response<CreateCommentResponse>
+    suspend fun requestCreatePostComment(@Body body: CreateCommentRequest): NetworkResponse<CreateCommentResponse>
 
     @GET("/api/v1/comments/{postId}")
-    suspend fun requestPostComment(@Path("postId") postId: Int): Response<ListAllCommentResponse>
+    suspend fun requestPostComment(@Path("postId") postId: Int): NetworkResponse<ListAllCommentResponse>
 
     @POST("/api/v1/comments/delete/{commentId}")
-    suspend fun requestDeletePostComment(@Path("commentId") commentId: Int): Response<Void>
+    suspend fun requestDeletePostComment(@Path("commentId") commentId: Int): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/folder/FolderApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/folder/FolderApiService.kt
@@ -1,7 +1,7 @@
 package com.daily.dayo.data.datasource.remote.folder
 
+import com.daily.dayo.domain.model.NetworkResponse
 import okhttp3.MultipartBody
-import retrofit2.Response
 import retrofit2.http.*
 
 interface FolderApiService {
@@ -13,7 +13,7 @@ interface FolderApiService {
         @Part("privacy") privacy: String,
         @Part("subheading") subheading: String?,
         @Part thumbnailImage: MultipartBody.Part?
-    ): Response<CreateFolderResponse>
+    ): NetworkResponse<CreateFolderResponse>
 
     @Multipart
     @POST("/api/v1/folders/patch")
@@ -24,23 +24,23 @@ interface FolderApiService {
         @Part("subheading") subheading: String?,
         @Part("isFileChange") isFileChange: Boolean,
         @Part thumbnailImage: MultipartBody.Part?
-    ): Response<EditFolderResponse>
+    ): NetworkResponse<EditFolderResponse>
 
     @GET("/api/v1/folders/list/{memberId}")
-    suspend fun requestAllFolderList(@Path("memberId") memberId: String): Response<ListAllFolderResponse>
+    suspend fun requestAllFolderList(@Path("memberId") memberId: String): NetworkResponse<ListAllFolderResponse>
 
     @GET("/api/v1/folders/my")
-    suspend fun requestAllMyFolderList(): Response<ListAllMyFolderResponse>
+    suspend fun requestAllMyFolderList(): NetworkResponse<ListAllMyFolderResponse>
 
     @POST("/api/v1/folders/inPost")
-    suspend fun requestCreateFolderInPost(@Body body: CreateFolderInPostRequest): Response<CreateFolderInPostResponse>
+    suspend fun requestCreateFolderInPost(@Body body: CreateFolderInPostRequest): NetworkResponse<CreateFolderInPostResponse>
 
     @GET("/api/v1/folders/{folderId}")
-    suspend fun requestDetailListFolder(@Path("folderId") folderId: Int): Response<DetailFolderResponse>
+    suspend fun requestDetailListFolder(@Path("folderId") folderId: Int): NetworkResponse<DetailFolderResponse>
 
     @POST("/api/v1/folders/delete/{folderId}")
-    suspend fun requestDeleteFolder(@Path("folderId") folderId: Int): Response<Void>
+    suspend fun requestDeleteFolder(@Path("folderId") folderId: Int): NetworkResponse<Void>
 
     @POST("/api/v1/folders/order")
-    suspend fun requestOrderFolder(@Body body: List<EditOrderDto>): Response<Void>
+    suspend fun requestOrderFolder(@Body body: List<EditOrderDto>): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/follow/FollowApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/follow/FollowApiService.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.data.datasource.remote.follow
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -9,17 +9,17 @@ import retrofit2.http.Path
 interface FollowApiService {
 
     @POST("/api/v1/follow")
-    suspend fun requestCreateFollow(@Body body: CreateFollowRequest): Response<CreateFollowResponse>
+    suspend fun requestCreateFollow(@Body body: CreateFollowRequest): NetworkResponse<CreateFollowResponse>
 
     @POST("/api/v1/follow/delete/{followerId}")
-    suspend fun requestDeleteFollow(@Path("followerId") followerId: String): Response<Void>
+    suspend fun requestDeleteFollow(@Path("followerId") followerId: String): NetworkResponse<Void>
 
     @GET("/api/v1/follow/follower/list/{memberId}")
-    suspend fun requestListAllFollower(@Path("memberId") memberId: String): Response<ListAllFollowerResponse>
+    suspend fun requestListAllFollower(@Path("memberId") memberId: String): NetworkResponse<ListAllFollowerResponse>
 
     @GET("/api/v1/follow/following/list/{memberId}")
-    suspend fun requestListAllFollowing(@Path("memberId") memberId: String): Response<ListAllFollowingResponse>
+    suspend fun requestListAllFollowing(@Path("memberId") memberId: String): NetworkResponse<ListAllFollowingResponse>
 
     @POST("/api/v1/follow/up")
-    suspend fun requestCreateFollowUp(@Body body: CreateFollowUpRequest): Response<CreateFollowUpResponse>
+    suspend fun requestCreateFollowUp(@Body body: CreateFollowUpRequest): NetworkResponse<CreateFollowUpResponse>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/heart/HeartApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/heart/HeartApiService.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.data.datasource.remote.heart
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -9,11 +9,11 @@ import retrofit2.http.Path
 interface HeartApiService {
 
     @POST("/api/v1/heart")
-    suspend fun requestLikePost(@Body body: CreateHeartRequest): Response<CreateHeartResponse>
+    suspend fun requestLikePost(@Body body: CreateHeartRequest): NetworkResponse<CreateHeartResponse>
 
     @POST("/api/v1/heart/delete/{postId}")
-    suspend fun requestUnlikePost(@Path("postId") postId: Int): Response<Void>
+    suspend fun requestUnlikePost(@Path("postId") postId: Int): NetworkResponse<Void>
 
     @GET("/api/v1/heart/list")
-    suspend fun requestAllMyLikePostList(): Response<ListAllMyHeartPostResponse>
+    suspend fun requestAllMyLikePostList(): NetworkResponse<ListAllMyHeartPostResponse>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/image/ImageApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/image/ImageApiService.kt
@@ -1,11 +1,11 @@
 package com.daily.dayo.data.datasource.remote.image
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface ImageApiService {
 
     @GET("/images/{filename}")
-    suspend fun requestDownloadImage(@Path("filename") filename: String): Response<Void>
+    suspend fun requestDownloadImage(@Path("filename") filename: String): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
@@ -1,7 +1,7 @@
 package com.daily.dayo.data.datasource.remote.member
 
+import com.daily.dayo.domain.model.NetworkResponse
 import okhttp3.MultipartBody
-import retrofit2.Response
 import retrofit2.http.*
 
 interface MemberApiService {
@@ -13,7 +13,7 @@ interface MemberApiService {
         @Part("nickname") nickname: String,
         @Part("password") password: String,
         @Part profileImg: MultipartBody.Part
-    ): Response<MemberSignupResponse>
+    ): NetworkResponse<MemberSignupResponse>
 
     @Multipart
     @POST("/api/v1/members/update/profile")
@@ -21,59 +21,59 @@ interface MemberApiService {
         @Part("nickname") nickname: String?,
         @Part profileImg: MultipartBody.Part?,
         @Part("onBasicProfileImg") onBasicProfileImg: Boolean
-    ): Response<Void>
+    ): NetworkResponse<Void>
 
     @POST("/api/v1/members/kakaoOAuth")
-    suspend fun requestLoginKakao(@Body body: MemberOAuthRequest): Response<MemberOAuthResponse>
+    suspend fun requestLoginKakao(@Body body: MemberOAuthRequest): NetworkResponse<MemberOAuthResponse>
 
     @POST("/api/v1/members/signIn")
-    suspend fun requestLoginEmail(@Body body: MemberSignInRequest): Response<MemberSignInResponse>
+    suspend fun requestLoginEmail(@Body body: MemberSignInRequest): NetworkResponse<MemberSignInResponse>
 
     @GET("/api/v1/members/myInfo")
-    suspend fun requestMemberInfo(): Response<MemberInfoResponse>
+    suspend fun requestMemberInfo(): NetworkResponse<MemberInfoResponse>
 
     @GET("/api/v1/members/duplicate/email/{email}")
-    suspend fun requestCheckEmailDuplicate(@Path("email") email: String): Response<Void>
+    suspend fun requestCheckEmailDuplicate(@Path("email") email: String): NetworkResponse<Void>
 
     @GET("/api/v1/members/signUp/{email}")
-    suspend fun requestCertificateEmail(@Path("email") email: String): Response<MemberAuthCodeResponse>
+    suspend fun requestCertificateEmail(@Path("email") email: String): NetworkResponse<MemberAuthCodeResponse>
 
     @GET("/api/v1/members/refresh")
-    suspend fun requestRefreshToken(): Response<RefreshTokenResponse>
+    suspend fun requestRefreshToken(): NetworkResponse<RefreshTokenResponse>
 
     @POST("/api/v1/members")
-    suspend fun requestDeviceToken(@Body body: DeviceTokenRequest): Response<Void>
+    suspend fun requestDeviceToken(@Body body: DeviceTokenRequest): NetworkResponse<Void>
 
     @GET("/api/v1/members/profile/my")
-    suspend fun requestMyProfile(): Response<MemberMyProfileResponse>
+    suspend fun requestMyProfile(): NetworkResponse<MemberMyProfileResponse>
 
     @GET("/api/v1/members/profile/other/{memberId}")
-    suspend fun requestOtherProfile(@Path("memberId") memberId: String): Response<MemberOtherProfileResponse>
+    suspend fun requestOtherProfile(@Path("memberId") memberId: String): NetworkResponse<MemberOtherProfileResponse>
 
     @POST("/api/v1/members/resign")
-    suspend fun requestResign(@Query("content") content: String): Response<Void>
+    suspend fun requestResign(@Query("content") content: String): NetworkResponse<Void>
 
     @GET("/api/v1/members/receiveAlarm")
-    suspend fun requestReceiveAlarm(): Response<ReceiveAlarmResponse>
+    suspend fun requestReceiveAlarm(): NetworkResponse<ReceiveAlarmResponse>
 
     @POST("/api/v1/members/changeReceiveAlarm")
-    suspend fun requestChangeReceiveAlarm(@Body body: ChangeReceiveAlarmRequest): Response<Void>
+    suspend fun requestChangeReceiveAlarm(@Body body: ChangeReceiveAlarmRequest): NetworkResponse<Void>
 
     @POST("/api/v1/members/logout")
-    suspend fun requestLogout(): Response<Void>
+    suspend fun requestLogout(): NetworkResponse<Void>
 
     @GET("/api/v1/members/search/{email}")
-    suspend fun requestCheckEmail(@Path("email") email: String): Response<Void>
+    suspend fun requestCheckEmail(@Path("email") email: String): NetworkResponse<Void>
 
     @GET("/api/v1/members/search/code/{email}")
-    suspend fun requestCheckEmailAuth(@Path("email") email: String): Response<MemberAuthCodeResponse>
+    suspend fun requestCheckEmailAuth(@Path("email") email: String): NetworkResponse<MemberAuthCodeResponse>
 
     @POST("/api/v1/members/checkPassword")
-    suspend fun requestCheckCurrentPassword(@Body body: CheckPasswordRequest): Response<Void>
+    suspend fun requestCheckCurrentPassword(@Body body: CheckPasswordRequest): NetworkResponse<Void>
 
     @POST("/api/v1/members/changePassword")
-    suspend fun requestChangePassword(@Body body: ChangePasswordRequest): Response<Void>
+    suspend fun requestChangePassword(@Body body: ChangePasswordRequest): NetworkResponse<Void>
 
     @POST("/api/v1/members/setting/changePassword")
-    suspend fun requestSettingChangePassword(@Body body: ChangePasswordRequest): Response<Void>
+    suspend fun requestSettingChangePassword(@Body body: ChangePasswordRequest): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/post/PostApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/post/PostApiService.kt
@@ -1,8 +1,8 @@
 package com.daily.dayo.data.datasource.remote.post
 
 import com.daily.dayo.domain.model.Category
+import com.daily.dayo.domain.model.NetworkResponse
 import okhttp3.MultipartBody
-import retrofit2.Response
 import retrofit2.http.*
 
 interface PostApiService {
@@ -15,32 +15,32 @@ interface PostApiService {
         @Part files: List<MultipartBody.Part>,
         @Part("folderId") folderId: Int,
         @Part("tags") tags: Array<String>
-    ): Response<CreatePostResponse>
+    ): NetworkResponse<CreatePostResponse>
 
     @POST("/api/v1/posts/{postId}/edit")
     suspend fun requestEditPost(
         @Path("postId") postId: Int,
         @Body body: EditPostRequest
-    ): Response<EditPostResponse>
+    ): NetworkResponse<EditPostResponse>
 
     @GET("/api/v1/posts")
-    suspend fun requestNewPostList(): Response<ListAllPostResponse>
+    suspend fun requestNewPostList(): NetworkResponse<ListAllPostResponse>
 
     @GET("/api/v1/posts/category/{category}")
-    suspend fun requestNewPostListCategory(@Path("category") category: Category): Response<ListCategoryPostResponse>
+    suspend fun requestNewPostListCategory(@Path("category") category: Category): NetworkResponse<ListCategoryPostResponse>
 
     @GET("/api/v1/posts/dayopick/all")
-    suspend fun requestDayoPickPostList(): Response<DayoPickPostListResponse>
+    suspend fun requestDayoPickPostList(): NetworkResponse<DayoPickPostListResponse>
 
     @GET("/api/v1/posts/dayopick/{category}")
-    suspend fun requestDayoPickPostListCategory(@Path("category") category: Category): Response<DayoPickPostListResponse>
+    suspend fun requestDayoPickPostListCategory(@Path("category") category: Category): NetworkResponse<DayoPickPostListResponse>
 
     @GET("/api/v1/posts/{postId}")
-    suspend fun requestPostDetail(@Path("postId") postId: Int): Response<DetailPostResponse>
+    suspend fun requestPostDetail(@Path("postId") postId: Int): NetworkResponse<DetailPostResponse>
 
     @POST("/api/v1/posts/delete/{postId}")
-    suspend fun requestDeletePost(@Path("postId") postId: Int): Response<Void>
+    suspend fun requestDeletePost(@Path("postId") postId: Int): NetworkResponse<Void>
 
     @GET("/api/v1/posts/feed/list")
-    suspend fun requestFeedList(): Response<ListFeedResponse>
+    suspend fun requestFeedList(): NetworkResponse<ListFeedResponse>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/report/ReportApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/report/ReportApiService.kt
@@ -1,14 +1,14 @@
 package com.daily.dayo.data.datasource.remote.report
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface ReportApiService {
 
     @POST("/api/v1/reports/member")
-    suspend fun requestSaveMemberReport(@Body body: CreateReportMemberRequest): Response<Void>
+    suspend fun requestSaveMemberReport(@Body body: CreateReportMemberRequest): NetworkResponse<Void>
 
     @POST("/api/v1/reports/post")
-    suspend fun requestSavePostReport(@Body body: CreateReportPostRequest): Response<Void>
+    suspend fun requestSavePostReport(@Body body: CreateReportPostRequest): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseAdapter.kt
@@ -1,0 +1,16 @@
+package com.daily.dayo.data.datasource.remote.retrofit.factory
+
+import com.daily.dayo.domain.model.NetworkResponse
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class NetworkResponseAdapter<T> (
+    private val successType: Type,
+) : CallAdapter<T, Call<NetworkResponse<T>>> { // 여기서 <앞, 뒤>에 넣어준 것에 따라
+
+    override fun responseType(): Type = successType
+    override fun adapt(call: Call<T>): Call<NetworkResponse<T>> { // in(Call<앞>) out(Call<뒤>)의 타입이 정해짐
+        return NetworkResponseCall(call) // 얘는 Custom으로 구현한 클래스 아래에서 작성해줄것
+    }
+}

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseAdapterFactory.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseAdapterFactory.kt
@@ -1,0 +1,34 @@
+package com.daily.dayo.data.datasource.remote.retrofit.factory
+
+import com.daily.dayo.domain.model.NetworkResponse
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class NetworkResponseAdapterFactory: CallAdapter.Factory() {
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (Call::class.java != getRawType(returnType))
+            return null
+
+        check(returnType is ParameterizedType) {
+            "return type must be parameterized as Call<NetworkResponse<<Foo>> or Call<NetworkResponse<out Foo>>"
+        }
+
+        val responseType = getParameterUpperBound(0, returnType)
+        if (getRawType(responseType) != NetworkResponse::class.java)
+            return null
+
+        check(responseType is ParameterizedType) {
+            "Response must be parameterized as NetworkResponse<Foo> or NetworkResponse<out Foo>"
+        }
+
+        val successBodyType = getParameterUpperBound(0, responseType)
+        return NetworkResponseAdapter<Any>(successBodyType)
+    }
+}

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseCall.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/retrofit/factory/NetworkResponseCall.kt
@@ -1,0 +1,83 @@
+package com.daily.dayo.data.datasource.remote.retrofit.factory
+
+import com.daily.dayo.domain.model.NetworkResponse
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+
+internal class NetworkResponseCall<T>(
+    private val delegate: Call<T>,
+): Call<NetworkResponse<T>> {
+
+    override fun enqueue(callback: Callback<NetworkResponse<T>>) {
+        return delegate.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                val body = response.body()
+                val code = response.code()
+                val error = response.errorBody()
+
+                if (response.isSuccessful) {
+                    if (body != null) {
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.Success(body))
+                        )
+                    } else {
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.UnknownError(null))
+                        )
+                    }
+                } else {
+                    val errorBody = when {
+                        error == null -> null
+                        error.contentLength() == 0L -> null
+                        else -> try {
+                            error
+                        } catch (exception: Exception) {
+                            null
+                        }
+                    }
+
+                    if (errorBody != null) {
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.ApiError(code, errorBody.toString()))
+                        )
+                    } else {
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.UnknownError(null))
+                        )
+                    }
+                }
+            }
+
+            override fun onFailure(call: Call<T>, throwable: Throwable) {
+                val networkResponse = when (throwable) {
+                    is IOException -> NetworkResponse.NetworkError(throwable)
+                    else -> NetworkResponse.UnknownError(throwable)
+                }
+                callback.onResponse(this@NetworkResponseCall, Response.success(networkResponse))
+            }
+        })
+    }
+
+    override fun isExecuted() = delegate.isExecuted
+
+    override fun clone() = NetworkResponseCall(delegate.clone())
+
+    override fun isCanceled() = delegate.isCanceled
+
+    override fun cancel() = delegate.cancel()
+
+    override fun execute(): Response<NetworkResponse<T>> {
+        throw UnsupportedOperationException("NetworkResponseCall doesn't support execute")
+    }
+
+    override fun request(): Request = delegate.request()
+    override fun timeout(): Timeout = delegate.timeout()
+}

--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/search/SearchApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/search/SearchApiService.kt
@@ -1,11 +1,11 @@
 package com.daily.dayo.data.datasource.remote.search
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface SearchApiService {
 
     @GET("/api/v1/search")
-    suspend fun requestSearchTag(@Query("tag") tag: String): Response<SearchResultResponse>
+    suspend fun requestSearchTag(@Query("tag") tag: String): NetworkResponse<SearchResultResponse>
 }

--- a/app/src/main/java/com/daily/dayo/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/daily/dayo/data/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.daily.dayo.data.di
 
 import com.daily.dayo.BuildConfig
 import com.daily.dayo.DayoApplication
+import com.daily.dayo.data.datasource.remote.retrofit.factory.NetworkResponseAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -67,6 +68,7 @@ object NetworkModule {
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl("http://117.17.198.45:8080")
+            .addCallAdapterFactory(NetworkResponseAdapterFactory())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(gsonConverterFactory)
             .client(okHttpClient)

--- a/app/src/main/java/com/daily/dayo/data/repository/AlarmRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/AlarmRepositoryImpl.kt
@@ -2,17 +2,17 @@ package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.alarm.AlarmApiService
 import com.daily.dayo.data.datasource.remote.alarm.ListAllAlarmResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.AlarmRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class AlarmRepositoryImpl @Inject constructor(
     private val alarmApiService: AlarmApiService
 ) : AlarmRepository {
 
-    override suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse> =
+    override suspend fun requestAllAlarmList(): NetworkResponse<ListAllAlarmResponse> =
         alarmApiService.requestAllAlarmList()
 
-    override suspend fun requestIsCheckAlarm(alarmId: Int): Response<Void> =
+    override suspend fun requestIsCheckAlarm(alarmId: Int): NetworkResponse<Void> =
         alarmApiService.requestIsCheckAlarm(alarmId)
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/BlockRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/BlockRepositoryImpl.kt
@@ -2,14 +2,14 @@ package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.block.BlockApiService
 import com.daily.dayo.data.datasource.remote.block.BlockRequest
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.BlockRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class BlockRepositoryImpl @Inject constructor(
     private val blockApiService: BlockApiService
 ) : BlockRepository {
 
-    override suspend fun requestBlockMember(memberId: String): Response<Void> =
+    override suspend fun requestBlockMember(memberId: String): NetworkResponse<Void> =
         blockApiService.requestBlockMember(BlockRequest(memberId = memberId))
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/BookmarkRepositoryImpl.kt
@@ -4,20 +4,20 @@ import com.daily.dayo.data.datasource.remote.bookmark.BookmarkApiService
 import com.daily.dayo.data.datasource.remote.bookmark.CreateBookmarkRequest
 import com.daily.dayo.data.datasource.remote.bookmark.CreateBookmarkResponse
 import com.daily.dayo.data.datasource.remote.bookmark.ListAllMyBookmarkPostResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.BookmarkRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class BookmarkRepositoryImpl @Inject constructor(
     private val bookmarkApiService: BookmarkApiService
 ) : BookmarkRepository {
 
-    override suspend fun requestBookmarkPost(body: CreateBookmarkRequest): Response<CreateBookmarkResponse> =
+    override suspend fun requestBookmarkPost(body: CreateBookmarkRequest): NetworkResponse<CreateBookmarkResponse> =
         bookmarkApiService.requestBookmarkPost(body)
 
-    override suspend fun requestDeleteBookmarkPost(postId: Int): Response<Void> =
+    override suspend fun requestDeleteBookmarkPost(postId: Int): NetworkResponse<Void> =
         bookmarkApiService.requestDeleteBookmarkPost(postId)
 
-    override suspend fun requestAllMyBookmarkPostList(): Response<ListAllMyBookmarkPostResponse> =
+    override suspend fun requestAllMyBookmarkPostList(): NetworkResponse<ListAllMyBookmarkPostResponse> =
         bookmarkApiService.requestAllMyBookmarkPostList()
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/CommentRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/CommentRepositoryImpl.kt
@@ -4,20 +4,20 @@ import com.daily.dayo.data.datasource.remote.comment.CommentApiService
 import com.daily.dayo.data.datasource.remote.comment.CreateCommentRequest
 import com.daily.dayo.data.datasource.remote.comment.CreateCommentResponse
 import com.daily.dayo.data.datasource.remote.comment.ListAllCommentResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.CommentRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class CommentRepositoryImpl @Inject constructor(
     private val commentApiService: CommentApiService
 ) : CommentRepository {
 
-    override suspend fun requestPostComment(postId: Int): Response<ListAllCommentResponse> =
+    override suspend fun requestPostComment(postId: Int): NetworkResponse<ListAllCommentResponse> =
         commentApiService.requestPostComment(postId)
 
-    override suspend fun requestCreatePostComment(body: CreateCommentRequest): Response<CreateCommentResponse> =
+    override suspend fun requestCreatePostComment(body: CreateCommentRequest): NetworkResponse<CreateCommentResponse> =
         commentApiService.requestCreatePostComment(body)
 
-    override suspend fun requestDeletePostComment(commentId: Int): Response<Void> =
+    override suspend fun requestDeletePostComment(commentId: Int): NetworkResponse<Void> =
         commentApiService.requestDeletePostComment(commentId)
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/FolderRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.folder.*
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.domain.repository.FolderRepository
 import okhttp3.MultipartBody
-import retrofit2.Response
 import javax.inject.Inject
 
 class FolderRepositoryImpl @Inject constructor(
@@ -16,7 +16,7 @@ class FolderRepositoryImpl @Inject constructor(
         privacy: Privacy,
         subheading: String?,
         thumbnailImage: MultipartBody.Part?
-    ): Response<CreateFolderResponse> =
+    ): NetworkResponse<CreateFolderResponse> =
         folderApiService.requestCreateFolder(name, privacy.name, subheading, thumbnailImage)
 
     override suspend fun requestEditFolder(
@@ -26,7 +26,7 @@ class FolderRepositoryImpl @Inject constructor(
         subheading: String?,
         isFileChange: Boolean,
         thumbnailImage: MultipartBody.Part?
-    ): Response<EditFolderResponse> =
+    ): NetworkResponse<EditFolderResponse> =
         folderApiService.requestEditFolder(
             folderId,
             name,
@@ -36,21 +36,21 @@ class FolderRepositoryImpl @Inject constructor(
             thumbnailImage
         )
 
-    override suspend fun requestAllMyFolderList(): Response<ListAllMyFolderResponse> =
+    override suspend fun requestAllMyFolderList(): NetworkResponse<ListAllMyFolderResponse> =
         folderApiService.requestAllMyFolderList()
 
-    override suspend fun requestAllFolderList(memberId: String): Response<ListAllFolderResponse> =
+    override suspend fun requestAllFolderList(memberId: String): NetworkResponse<ListAllFolderResponse> =
         folderApiService.requestAllFolderList(memberId)
 
-    override suspend fun requestCreateFolderInPost(body: CreateFolderInPostRequest): Response<CreateFolderInPostResponse> =
+    override suspend fun requestCreateFolderInPost(body: CreateFolderInPostRequest): NetworkResponse<CreateFolderInPostResponse> =
         folderApiService.requestCreateFolderInPost(body)
 
-    override suspend fun requestDeleteFolder(folderId: Int): Response<Void> =
+    override suspend fun requestDeleteFolder(folderId: Int): NetworkResponse<Void> =
         folderApiService.requestDeleteFolder(folderId)
 
-    override suspend fun requestDetailListFolder(folderId: Int): Response<DetailFolderResponse> =
+    override suspend fun requestDetailListFolder(folderId: Int): NetworkResponse<DetailFolderResponse> =
         folderApiService.requestDetailListFolder(folderId)
 
-    override suspend fun requestOrderFolder(body: List<EditOrderDto>): Response<Void> =
+    override suspend fun requestOrderFolder(body: List<EditOrderDto>): NetworkResponse<Void> =
         folderApiService.requestOrderFolder(body)
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/FollowRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/FollowRepositoryImpl.kt
@@ -1,27 +1,27 @@
 package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.follow.*
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.FollowRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class FollowRepositoryImpl @Inject constructor(
     private val followApiService: FollowApiService
 ) : FollowRepository {
 
-    override suspend fun requestCreateFollow(body: CreateFollowRequest): Response<CreateFollowResponse> =
+    override suspend fun requestCreateFollow(body: CreateFollowRequest): NetworkResponse<CreateFollowResponse> =
         followApiService.requestCreateFollow(body)
 
-    override suspend fun requestDeleteFollow(followerId: String): Response<Void> =
+    override suspend fun requestDeleteFollow(followerId: String): NetworkResponse<Void> =
         followApiService.requestDeleteFollow(followerId)
 
-    override suspend fun requestListAllFollower(memberId: String): Response<ListAllFollowerResponse> =
+    override suspend fun requestListAllFollower(memberId: String): NetworkResponse<ListAllFollowerResponse> =
         followApiService.requestListAllFollower(memberId)
 
-    override suspend fun requestListAllFollowing(memberId: String): Response<ListAllFollowingResponse> =
+    override suspend fun requestListAllFollowing(memberId: String): NetworkResponse<ListAllFollowingResponse> =
         followApiService.requestListAllFollowing(memberId)
 
-    override suspend fun requestCreateFollowUp(body: CreateFollowUpRequest): Response<CreateFollowUpResponse> =
+    override suspend fun requestCreateFollowUp(body: CreateFollowUpRequest): NetworkResponse<CreateFollowUpResponse> =
         followApiService.requestCreateFollowUp(body)
 
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/HeartRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/HeartRepositoryImpl.kt
@@ -4,20 +4,20 @@ import com.daily.dayo.data.datasource.remote.heart.CreateHeartRequest
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartResponse
 import com.daily.dayo.data.datasource.remote.heart.HeartApiService
 import com.daily.dayo.data.datasource.remote.heart.ListAllMyHeartPostResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.HeartRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class HeartRepositoryImpl @Inject constructor(
     private val heartApiService: HeartApiService
 ) : HeartRepository {
 
-    override suspend fun requestLikePost(body: CreateHeartRequest): Response<CreateHeartResponse> =
+    override suspend fun requestLikePost(body: CreateHeartRequest): NetworkResponse<CreateHeartResponse> =
         heartApiService.requestLikePost(body)
 
-    override suspend fun requestUnlikePost(postId: Int): Response<Void> =
+    override suspend fun requestUnlikePost(postId: Int): NetworkResponse<Void> =
         heartApiService.requestUnlikePost(postId)
 
-    override suspend fun requestAllMyLikePostList(): Response<ListAllMyHeartPostResponse> =
+    override suspend fun requestAllMyLikePostList(): NetworkResponse<ListAllMyHeartPostResponse> =
         heartApiService.requestAllMyLikePostList()
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/ImageRepositoryImpl.kt
@@ -1,14 +1,14 @@
 package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.image.ImageApiService
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.ImageRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class ImageRepositoryImpl @Inject constructor(
     private val imageApiService: ImageApiService
 ) : ImageRepository {
 
-    override suspend fun requestDownloadImage(filename: String): Response<Void> =
+    override suspend fun requestDownloadImage(filename: String): NetworkResponse<Void> =
         imageApiService.requestDownloadImage(filename)
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
@@ -1,9 +1,8 @@
 package com.daily.dayo.data.repository
 
-import com.daily.dayo.common.Resource
-import com.daily.dayo.common.setExceptionHandling
 import com.daily.dayo.data.datasource.remote.firebase.FirebaseMessagingService
 import com.daily.dayo.data.datasource.remote.member.*
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MultipartBody
 import javax.inject.Inject
@@ -17,80 +16,74 @@ class MemberRepositoryImpl @Inject constructor(
         nickname: String,
         password: String,
         profileImg: MultipartBody.Part
-    ): Resource<MemberSignupResponse> =
-        setExceptionHandling {
-            memberApiService.requestSignupEmail(
-                email,
-                nickname,
-                password,
-                profileImg
-            )
-        }
+    ): NetworkResponse<MemberSignupResponse> =
+        memberApiService.requestSignupEmail(
+            email,
+            nickname,
+            password,
+            profileImg
+        )
 
     override suspend fun requestUpdateMyProfile(
         nickname: String?,
         profileImg: MultipartBody.Part?,
         onBasicProfileImg: Boolean
-    ): Resource<Void> =
-        setExceptionHandling { memberApiService.requestUpdateMyProfile(
-            nickname,
-            profileImg,
-            onBasicProfileImg
-        ) }
+    ): NetworkResponse<Void> =
+        memberApiService.requestUpdateMyProfile(nickname, profileImg, onBasicProfileImg)
 
-    override suspend fun requestLoginKakao(body: MemberOAuthRequest): Resource<MemberOAuthResponse> =
-        setExceptionHandling { memberApiService.requestLoginKakao(body) }
+    override suspend fun requestLoginKakao(body: MemberOAuthRequest): NetworkResponse<MemberOAuthResponse> =
+        memberApiService.requestLoginKakao(body)
 
-    override suspend fun requestLoginEmail(body: MemberSignInRequest): Resource<MemberSignInResponse> =
-        setExceptionHandling { memberApiService.requestLoginEmail(body) }
+    override suspend fun requestLoginEmail(body: MemberSignInRequest): NetworkResponse<MemberSignInResponse> =
+        memberApiService.requestLoginEmail(body)
 
-    override suspend fun requestMemberInfo(): Resource<MemberInfoResponse> =
-        setExceptionHandling { memberApiService.requestMemberInfo() }
+    override suspend fun requestMemberInfo(): NetworkResponse<MemberInfoResponse> =
+        memberApiService.requestMemberInfo()
 
-    override suspend fun requestCheckEmailDuplicate(email: String): Resource<Void> =
-        setExceptionHandling { memberApiService.requestCheckEmailDuplicate(email) }
+    override suspend fun requestCheckEmailDuplicate(email: String): NetworkResponse<Void> =
+        memberApiService.requestCheckEmailDuplicate(email)
 
-    override suspend fun requestCertificateEmail(email: String): Resource<MemberAuthCodeResponse> =
-        setExceptionHandling { memberApiService.requestCertificateEmail(email) }
+    override suspend fun requestCertificateEmail(email: String): NetworkResponse<MemberAuthCodeResponse> =
+        memberApiService.requestCertificateEmail(email)
 
-    override suspend fun requestRefreshToken(): Resource<RefreshTokenResponse> =
-        setExceptionHandling { memberApiService.requestRefreshToken() }
+    override suspend fun requestRefreshToken(): NetworkResponse<RefreshTokenResponse> =
+        memberApiService.requestRefreshToken()
 
-    override suspend fun requestDeviceToken(body: DeviceTokenRequest): Resource<Void> =
-        setExceptionHandling { memberApiService.requestDeviceToken(body) }
+    override suspend fun requestDeviceToken(body: DeviceTokenRequest): NetworkResponse<Void> =
+        memberApiService.requestDeviceToken(body)
 
-    override suspend fun requestMyProfile(): Resource<MemberMyProfileResponse> =
-        setExceptionHandling { memberApiService.requestMyProfile() }
+    override suspend fun requestMyProfile(): NetworkResponse<MemberMyProfileResponse> =
+        memberApiService.requestMyProfile()
 
-    override suspend fun requestOtherProfile(memberId: String): Resource<MemberOtherProfileResponse> =
-        setExceptionHandling { memberApiService.requestOtherProfile(memberId) }
+    override suspend fun requestOtherProfile(memberId: String): NetworkResponse<MemberOtherProfileResponse> =
+        memberApiService.requestOtherProfile(memberId)
 
-    override suspend fun requestResign(content: String): Resource<Void> =
-        setExceptionHandling { memberApiService.requestResign(content) }
+    override suspend fun requestResign(content: String): NetworkResponse<Void> =
+        memberApiService.requestResign(content)
 
-    override suspend fun requestReceiveAlarm(): Resource<ReceiveAlarmResponse> =
-        setExceptionHandling { memberApiService.requestReceiveAlarm() }
+    override suspend fun requestReceiveAlarm(): NetworkResponse<ReceiveAlarmResponse> =
+        memberApiService.requestReceiveAlarm()
 
-    override suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Resource<Void> =
-        setExceptionHandling { memberApiService.requestChangeReceiveAlarm(body) }
+    override suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): NetworkResponse<Void> =
+        memberApiService.requestChangeReceiveAlarm(body)
 
-    override suspend fun requestLogout(): Resource<Void> =
-        setExceptionHandling { memberApiService.requestLogout() }
+    override suspend fun requestLogout(): NetworkResponse<Void> =
+        memberApiService.requestLogout()
 
-    override suspend fun requestCheckEmail(email: String): Resource<Void> =
-        setExceptionHandling { memberApiService.requestCheckEmail(email) }
+    override suspend fun requestCheckEmail(email: String): NetworkResponse<Void> =
+        memberApiService.requestCheckEmail(email)
 
-    override suspend fun requestCheckEmailAuth(email: String): Resource<MemberAuthCodeResponse> =
-        setExceptionHandling { memberApiService.requestCheckEmailAuth(email) }
+    override suspend fun requestCheckEmailAuth(email: String): NetworkResponse<MemberAuthCodeResponse> =
+        memberApiService.requestCheckEmailAuth(email)
 
-    override suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Resource<Void> =
-        setExceptionHandling { memberApiService.requestCheckCurrentPassword(body) }
+    override suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): NetworkResponse<Void> =
+        memberApiService.requestCheckCurrentPassword(body)
 
-    override suspend fun requestChangePassword(body: ChangePasswordRequest): Resource<Void> =
-        setExceptionHandling { memberApiService.requestChangePassword(body) }
+    override suspend fun requestChangePassword(body: ChangePasswordRequest): NetworkResponse<Void> =
+        memberApiService.requestChangePassword(body)
 
-    override suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Resource<Void> =
-        setExceptionHandling { memberApiService.requestSettingChangePassword(body) }
+    override suspend fun requestSettingChangePassword(body: ChangePasswordRequest): NetworkResponse<Void> =
+        memberApiService.requestSettingChangePassword(body)
 
     // Firebase Messaging Service
     override suspend fun getCurrentFcmToken(): String =

--- a/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
@@ -1,10 +1,11 @@
 package com.daily.dayo.data.repository
 
+import com.daily.dayo.common.Resource
+import com.daily.dayo.common.setExceptionHandling
 import com.daily.dayo.data.datasource.remote.firebase.FirebaseMessagingService
 import com.daily.dayo.data.datasource.remote.member.*
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MultipartBody
-import retrofit2.Response
 import javax.inject.Inject
 
 class MemberRepositoryImpl @Inject constructor(
@@ -16,69 +17,80 @@ class MemberRepositoryImpl @Inject constructor(
         nickname: String,
         password: String,
         profileImg: MultipartBody.Part
-    ): Response<MemberSignupResponse> =
-        memberApiService.requestSignupEmail(email, nickname, password, profileImg)
+    ): Resource<MemberSignupResponse> =
+        setExceptionHandling {
+            memberApiService.requestSignupEmail(
+                email,
+                nickname,
+                password,
+                profileImg
+            )
+        }
 
     override suspend fun requestUpdateMyProfile(
         nickname: String?,
         profileImg: MultipartBody.Part?,
         onBasicProfileImg: Boolean
-    ): Response<Void> =
-        memberApiService.requestUpdateMyProfile(nickname, profileImg, onBasicProfileImg)
+    ): Resource<Void> =
+        setExceptionHandling { memberApiService.requestUpdateMyProfile(
+            nickname,
+            profileImg,
+            onBasicProfileImg
+        ) }
 
-    override suspend fun requestLoginKakao(body: MemberOAuthRequest): Response<MemberOAuthResponse> =
-        memberApiService.requestLoginKakao(body)
+    override suspend fun requestLoginKakao(body: MemberOAuthRequest): Resource<MemberOAuthResponse> =
+        setExceptionHandling { memberApiService.requestLoginKakao(body) }
 
-    override suspend fun requestLoginEmail(body: MemberSignInRequest): Response<MemberSignInResponse> =
-        memberApiService.requestLoginEmail(body)
+    override suspend fun requestLoginEmail(body: MemberSignInRequest): Resource<MemberSignInResponse> =
+        setExceptionHandling { memberApiService.requestLoginEmail(body) }
 
-    override suspend fun requestMemberInfo(): Response<MemberInfoResponse> =
-        memberApiService.requestMemberInfo()
+    override suspend fun requestMemberInfo(): Resource<MemberInfoResponse> =
+        setExceptionHandling { memberApiService.requestMemberInfo() }
 
-    override suspend fun requestCheckEmailDuplicate(email: String): Response<Void> =
-        memberApiService.requestCheckEmailDuplicate(email)
+    override suspend fun requestCheckEmailDuplicate(email: String): Resource<Void> =
+        setExceptionHandling { memberApiService.requestCheckEmailDuplicate(email) }
 
-    override suspend fun requestCertificateEmail(email: String): Response<MemberAuthCodeResponse> =
-        memberApiService.requestCertificateEmail(email)
+    override suspend fun requestCertificateEmail(email: String): Resource<MemberAuthCodeResponse> =
+        setExceptionHandling { memberApiService.requestCertificateEmail(email) }
 
-    override suspend fun requestRefreshToken(): Response<RefreshTokenResponse> =
-        memberApiService.requestRefreshToken()
+    override suspend fun requestRefreshToken(): Resource<RefreshTokenResponse> =
+        setExceptionHandling { memberApiService.requestRefreshToken() }
 
-    override suspend fun requestDeviceToken(body: DeviceTokenRequest): Response<Void> =
-        memberApiService.requestDeviceToken(body)
+    override suspend fun requestDeviceToken(body: DeviceTokenRequest): Resource<Void> =
+        setExceptionHandling { memberApiService.requestDeviceToken(body) }
 
-    override suspend fun requestMyProfile(): Response<MemberMyProfileResponse> =
-        memberApiService.requestMyProfile()
+    override suspend fun requestMyProfile(): Resource<MemberMyProfileResponse> =
+        setExceptionHandling { memberApiService.requestMyProfile() }
 
-    override suspend fun requestOtherProfile(memberId: String): Response<MemberOtherProfileResponse> =
-        memberApiService.requestOtherProfile(memberId)
+    override suspend fun requestOtherProfile(memberId: String): Resource<MemberOtherProfileResponse> =
+        setExceptionHandling { memberApiService.requestOtherProfile(memberId) }
 
-    override suspend fun requestResign(content: String): Response<Void> =
-        memberApiService.requestResign(content)
+    override suspend fun requestResign(content: String): Resource<Void> =
+        setExceptionHandling { memberApiService.requestResign(content) }
 
-    override suspend fun requestReceiveAlarm(): Response<ReceiveAlarmResponse> =
-        memberApiService.requestReceiveAlarm()
+    override suspend fun requestReceiveAlarm(): Resource<ReceiveAlarmResponse> =
+        setExceptionHandling { memberApiService.requestReceiveAlarm() }
 
-    override suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Response<Void> =
-        memberApiService.requestChangeReceiveAlarm(body)
+    override suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Resource<Void> =
+        setExceptionHandling { memberApiService.requestChangeReceiveAlarm(body) }
 
-    override suspend fun requestLogout(): Response<Void> =
-        memberApiService.requestLogout()
+    override suspend fun requestLogout(): Resource<Void> =
+        setExceptionHandling { memberApiService.requestLogout() }
 
-    override suspend fun requestCheckEmail(email: String): Response<Void> =
-        memberApiService.requestCheckEmail(email)
+    override suspend fun requestCheckEmail(email: String): Resource<Void> =
+        setExceptionHandling { memberApiService.requestCheckEmail(email) }
 
-    override suspend fun requestCheckEmailAuth(email: String): Response<MemberAuthCodeResponse> =
-        memberApiService.requestCheckEmailAuth(email)
+    override suspend fun requestCheckEmailAuth(email: String): Resource<MemberAuthCodeResponse> =
+        setExceptionHandling { memberApiService.requestCheckEmailAuth(email) }
 
-    override suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Response<Void> =
-        memberApiService.requestCheckCurrentPassword(body)
+    override suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Resource<Void> =
+        setExceptionHandling { memberApiService.requestCheckCurrentPassword(body) }
 
-    override suspend fun requestChangePassword(body: ChangePasswordRequest): Response<Void> =
-        memberApiService.requestChangePassword(body)
+    override suspend fun requestChangePassword(body: ChangePasswordRequest): Resource<Void> =
+        setExceptionHandling { memberApiService.requestChangePassword(body) }
 
-    override suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Response<Void> =
-        memberApiService.requestSettingChangePassword(body)
+    override suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Resource<Void> =
+        setExceptionHandling { memberApiService.requestSettingChangePassword(body) }
 
     // Firebase Messaging Service
     override suspend fun getCurrentFcmToken(): String =

--- a/app/src/main/java/com/daily/dayo/data/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/PostRepositoryImpl.kt
@@ -2,9 +2,9 @@ package com.daily.dayo.data.repository
 
 import com.daily.dayo.data.datasource.remote.post.*
 import com.daily.dayo.domain.model.Category
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.PostRepository
 import okhttp3.MultipartBody
-import retrofit2.Response
 import javax.inject.Inject
 
 class PostRepositoryImpl @Inject constructor(
@@ -17,32 +17,32 @@ class PostRepositoryImpl @Inject constructor(
         files: List<MultipartBody.Part>,
         folderId: Int,
         tags: Array<String>
-    ): Response<CreatePostResponse> =
+    ): NetworkResponse<CreatePostResponse> =
         postApiService.requestUploadPost(category.name, contents, files, folderId, tags)
 
     override suspend fun requestEditPost(
         postId: Int,
         request: EditPostRequest
-    ): Response<EditPostResponse> = postApiService.requestEditPost(postId, request)
+    ): NetworkResponse<EditPostResponse> = postApiService.requestEditPost(postId, request)
 
-    override suspend fun requestNewPostList(): Response<ListAllPostResponse> =
+    override suspend fun requestNewPostList(): NetworkResponse<ListAllPostResponse> =
         postApiService.requestNewPostList()
 
-    override suspend fun requestNewPostListCategory(category: Category): Response<ListCategoryPostResponse> =
+    override suspend fun requestNewPostListCategory(category: Category): NetworkResponse<ListCategoryPostResponse> =
         postApiService.requestNewPostListCategory(category)
 
-    override suspend fun requestDayoPickPostList(): Response<DayoPickPostListResponse> =
+    override suspend fun requestDayoPickPostList(): NetworkResponse<DayoPickPostListResponse> =
         postApiService.requestDayoPickPostList()
 
-    override suspend fun requestDayoPickPostListCategory(category: Category): Response<DayoPickPostListResponse> =
+    override suspend fun requestDayoPickPostListCategory(category: Category): NetworkResponse<DayoPickPostListResponse> =
         postApiService.requestDayoPickPostListCategory(category)
 
-    override suspend fun requestFeedList(): Response<ListFeedResponse> =
+    override suspend fun requestFeedList(): NetworkResponse<ListFeedResponse> =
         postApiService.requestFeedList()
 
-    override suspend fun requestPostDetail(postId: Int): Response<DetailPostResponse> =
+    override suspend fun requestPostDetail(postId: Int): NetworkResponse<DetailPostResponse> =
         postApiService.requestPostDetail(postId)
 
-    override suspend fun requestDeletePost(postId: Int): Response<Void> =
+    override suspend fun requestDeletePost(postId: Int): NetworkResponse<Void> =
         postApiService.requestDeletePost(postId)
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/ReportRepositoryImpl.kt
@@ -3,18 +3,18 @@ package com.daily.dayo.data.repository
 import com.daily.dayo.data.datasource.remote.report.CreateReportMemberRequest
 import com.daily.dayo.data.datasource.remote.report.CreateReportPostRequest
 import com.daily.dayo.data.datasource.remote.report.ReportApiService
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.ReportRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class ReportRepositoryImpl @Inject constructor(
     private val reportApiService: ReportApiService
 ) : ReportRepository {
 
-    override suspend fun requestSaveMemberReport(body: CreateReportMemberRequest): Response<Void> =
+    override suspend fun requestSaveMemberReport(body: CreateReportMemberRequest): NetworkResponse<Void> =
         reportApiService.requestSaveMemberReport(body)
 
-    override suspend fun requestSavePostReport(body: CreateReportPostRequest): Response<Void> =
+    override suspend fun requestSavePostReport(body: CreateReportPostRequest): NetworkResponse<Void> =
         reportApiService.requestSavePostReport(body)
 
 }

--- a/app/src/main/java/com/daily/dayo/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/SearchRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.daily.dayo.data.repository
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.data.datasource.remote.search.SearchApiService
 import com.daily.dayo.data.datasource.remote.search.SearchResultResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.SearchRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class SearchRepositoryImpl @Inject constructor(
@@ -14,10 +14,10 @@ class SearchRepositoryImpl @Inject constructor(
     override fun requestSearchKeywordRecentList(): ArrayList<String> =
         DayoApplication.preferences.getSearchKeywordRecent()
 
-    override suspend fun requestSearchTag(tag: String): Response<SearchResultResponse> =
+    override suspend fun requestSearchTag(tag: String): NetworkResponse<SearchResultResponse> =
         searchApiService.requestSearchTag(tag)
 
-    override suspend fun requestSearchKeyword(keyword: String): Response<SearchResultResponse> {
+    override suspend fun requestSearchKeyword(keyword: String): NetworkResponse<SearchResultResponse> {
         val initialSearchTagList = requestSearchKeywordRecentList()
         if (initialSearchTagList.contains(keyword)) { // 검색한 적 있는 경우 최신화를 위하여 삭제하고 추가
             initialSearchTagList.remove(keyword)

--- a/app/src/main/java/com/daily/dayo/domain/model/NetworkResponse.kt
+++ b/app/src/main/java/com/daily/dayo/domain/model/NetworkResponse.kt
@@ -1,0 +1,13 @@
+package com.daily.dayo.domain.model
+
+import java.io.IOException
+
+sealed class NetworkResponse<out T> {
+    data class Success<T: Any>(val body: T?): NetworkResponse<T>()
+
+    data class ApiError(val code: Int, val error: String?) : NetworkResponse<Nothing>()
+
+    data class NetworkError(val exception: IOException) : NetworkResponse<Nothing>()
+
+    data class UnknownError(val throwable: Throwable?) : NetworkResponse<Nothing>()
+}

--- a/app/src/main/java/com/daily/dayo/domain/repository/AlarmRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/AlarmRepository.kt
@@ -1,10 +1,10 @@
 package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.alarm.ListAllAlarmResponse
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface AlarmRepository {
 
-    suspend fun requestAllAlarmList(): Response<ListAllAlarmResponse>
-    suspend fun requestIsCheckAlarm(alarmId: Int): Response<Void>
+    suspend fun requestAllAlarmList(): NetworkResponse<ListAllAlarmResponse>
+    suspend fun requestIsCheckAlarm(alarmId: Int): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/BlockRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/BlockRepository.kt
@@ -1,7 +1,7 @@
 package com.daily.dayo.domain.repository
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface BlockRepository {
-    suspend fun requestBlockMember(memberId: String): Response<Void>
+    suspend fun requestBlockMember(memberId: String): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/BookmarkRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/BookmarkRepository.kt
@@ -3,11 +3,11 @@ package com.daily.dayo.domain.repository
 import com.daily.dayo.data.datasource.remote.bookmark.CreateBookmarkRequest
 import com.daily.dayo.data.datasource.remote.bookmark.CreateBookmarkResponse
 import com.daily.dayo.data.datasource.remote.bookmark.ListAllMyBookmarkPostResponse
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface BookmarkRepository {
     
-    suspend fun requestBookmarkPost(body: CreateBookmarkRequest): Response<CreateBookmarkResponse>
-    suspend fun requestDeleteBookmarkPost(postId: Int): Response<Void>
-    suspend fun requestAllMyBookmarkPostList(): Response<ListAllMyBookmarkPostResponse>
+    suspend fun requestBookmarkPost(body: CreateBookmarkRequest): NetworkResponse<CreateBookmarkResponse>
+    suspend fun requestDeleteBookmarkPost(postId: Int): NetworkResponse<Void>
+    suspend fun requestAllMyBookmarkPostList(): NetworkResponse<ListAllMyBookmarkPostResponse>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/CommentRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/CommentRepository.kt
@@ -3,11 +3,11 @@ package com.daily.dayo.domain.repository
 import com.daily.dayo.data.datasource.remote.comment.CreateCommentRequest
 import com.daily.dayo.data.datasource.remote.comment.CreateCommentResponse
 import com.daily.dayo.data.datasource.remote.comment.ListAllCommentResponse
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface CommentRepository {
 
-    suspend fun requestCreatePostComment(body: CreateCommentRequest): Response<CreateCommentResponse>
-    suspend fun requestPostComment(postId: Int): Response<ListAllCommentResponse>
-    suspend fun requestDeletePostComment(commentId: Int): Response<Void>
+    suspend fun requestCreatePostComment(body: CreateCommentRequest): NetworkResponse<CreateCommentResponse>
+    suspend fun requestPostComment(postId: Int): NetworkResponse<ListAllCommentResponse>
+    suspend fun requestDeletePostComment(commentId: Int): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/FolderRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/FolderRepository.kt
@@ -1,9 +1,9 @@
 package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.folder.*
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Privacy
 import okhttp3.MultipartBody
-import retrofit2.Response
 
 interface FolderRepository {
 
@@ -12,7 +12,7 @@ interface FolderRepository {
         privacy: Privacy,
         subheading: String?,
         thumbnailImage: MultipartBody.Part?
-    ): Response<CreateFolderResponse>
+    ): NetworkResponse<CreateFolderResponse>
 
     suspend fun requestEditFolder(
         folderId: Int,
@@ -21,12 +21,12 @@ interface FolderRepository {
         subheading: String?,
         isFileChange: Boolean,
         thumbnailImage: MultipartBody.Part?
-    ): Response<EditFolderResponse>
+    ): NetworkResponse<EditFolderResponse>
 
-    suspend fun requestAllMyFolderList(): Response<ListAllMyFolderResponse>
-    suspend fun requestAllFolderList(memberId: String): Response<ListAllFolderResponse>
-    suspend fun requestCreateFolderInPost(body: CreateFolderInPostRequest): Response<CreateFolderInPostResponse>
-    suspend fun requestDeleteFolder(folderId: Int): Response<Void>
-    suspend fun requestDetailListFolder(folderId: Int): Response<DetailFolderResponse>
-    suspend fun requestOrderFolder(body: List<EditOrderDto>): Response<Void>
+    suspend fun requestAllMyFolderList(): NetworkResponse<ListAllMyFolderResponse>
+    suspend fun requestAllFolderList(memberId: String): NetworkResponse<ListAllFolderResponse>
+    suspend fun requestCreateFolderInPost(body: CreateFolderInPostRequest): NetworkResponse<CreateFolderInPostResponse>
+    suspend fun requestDeleteFolder(folderId: Int): NetworkResponse<Void>
+    suspend fun requestDetailListFolder(folderId: Int): NetworkResponse<DetailFolderResponse>
+    suspend fun requestOrderFolder(body: List<EditOrderDto>): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/FollowRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/FollowRepository.kt
@@ -1,13 +1,13 @@
 package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.follow.*
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface FollowRepository {
 
-    suspend fun requestCreateFollow(body: CreateFollowRequest): Response<CreateFollowResponse>
-    suspend fun requestDeleteFollow(followerId: String): Response<Void>
-    suspend fun requestListAllFollower(memberId: String): Response<ListAllFollowerResponse>
-    suspend fun requestListAllFollowing(memberId: String): Response<ListAllFollowingResponse>
-    suspend fun requestCreateFollowUp(body: CreateFollowUpRequest): Response<CreateFollowUpResponse>
+    suspend fun requestCreateFollow(body: CreateFollowRequest): NetworkResponse<CreateFollowResponse>
+    suspend fun requestDeleteFollow(followerId: String): NetworkResponse<Void>
+    suspend fun requestListAllFollower(memberId: String): NetworkResponse<ListAllFollowerResponse>
+    suspend fun requestListAllFollowing(memberId: String): NetworkResponse<ListAllFollowingResponse>
+    suspend fun requestCreateFollowUp(body: CreateFollowUpRequest): NetworkResponse<CreateFollowUpResponse>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/HeartRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/HeartRepository.kt
@@ -3,11 +3,11 @@ package com.daily.dayo.domain.repository
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartRequest
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartResponse
 import com.daily.dayo.data.datasource.remote.heart.ListAllMyHeartPostResponse
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface HeartRepository {
 
-    suspend fun requestLikePost(body: CreateHeartRequest): Response<CreateHeartResponse>
-    suspend fun requestUnlikePost(postId: Int): Response<Void>
-    suspend fun requestAllMyLikePostList(): Response<ListAllMyHeartPostResponse>
+    suspend fun requestLikePost(body: CreateHeartRequest): NetworkResponse<CreateHeartResponse>
+    suspend fun requestUnlikePost(postId: Int): NetworkResponse<Void>
+    suspend fun requestAllMyLikePostList(): NetworkResponse<ListAllMyHeartPostResponse>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/ImageRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/ImageRepository.kt
@@ -1,8 +1,8 @@
 package com.daily.dayo.domain.repository
 
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface ImageRepository {
 
-    suspend fun requestDownloadImage(filename: String): Response<Void>
+    suspend fun requestDownloadImage(filename: String): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
@@ -1,9 +1,8 @@
 package com.daily.dayo.domain.repository
 
-import com.daily.dayo.common.Resource
 import com.daily.dayo.data.datasource.remote.member.*
+import com.daily.dayo.domain.model.NetworkResponse
 import okhttp3.MultipartBody
-import retrofit2.Response
 
 interface MemberRepository {
 
@@ -12,32 +11,32 @@ interface MemberRepository {
         nickname: String,
         password: String,
         profileImg: MultipartBody.Part
-    ): Resource<MemberSignupResponse>
+    ): NetworkResponse<MemberSignupResponse>
 
     suspend fun requestUpdateMyProfile(
         nickname: String?,
         profileImg: MultipartBody.Part?,
         onBasicProfileImg: Boolean
-    ): Resource<Void>
+    ): NetworkResponse<Void>
 
-    suspend fun requestLoginKakao(body: MemberOAuthRequest): Resource<MemberOAuthResponse>
-    suspend fun requestLoginEmail(body: MemberSignInRequest): Resource<MemberSignInResponse>
-    suspend fun requestMemberInfo(): Resource<MemberInfoResponse>
-    suspend fun requestCheckEmailDuplicate(email: String): Resource<Void>
-    suspend fun requestCertificateEmail(email: String): Resource<MemberAuthCodeResponse>
-    suspend fun requestRefreshToken(): Resource<RefreshTokenResponse>
-    suspend fun requestDeviceToken(body: DeviceTokenRequest): Resource<Void>
-    suspend fun requestMyProfile(): Resource<MemberMyProfileResponse>
-    suspend fun requestOtherProfile(memberId: String): Resource<MemberOtherProfileResponse>
-    suspend fun requestResign(content: String): Resource<Void>
-    suspend fun requestReceiveAlarm(): Resource<ReceiveAlarmResponse>
-    suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Resource<Void>
-    suspend fun requestLogout(): Resource<Void>
-    suspend fun requestCheckEmail(email: String): Resource<Void>
-    suspend fun requestCheckEmailAuth(email: String): Resource<MemberAuthCodeResponse>
-    suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Resource<Void>
-    suspend fun requestChangePassword(body: ChangePasswordRequest): Resource<Void>
-    suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Resource<Void>
+    suspend fun requestLoginKakao(body: MemberOAuthRequest): NetworkResponse<MemberOAuthResponse>
+    suspend fun requestLoginEmail(body: MemberSignInRequest): NetworkResponse<MemberSignInResponse>
+    suspend fun requestMemberInfo(): NetworkResponse<MemberInfoResponse>
+    suspend fun requestCheckEmailDuplicate(email: String): NetworkResponse<Void>
+    suspend fun requestCertificateEmail(email: String): NetworkResponse<MemberAuthCodeResponse>
+    suspend fun requestRefreshToken(): NetworkResponse<RefreshTokenResponse>
+    suspend fun requestDeviceToken(body: DeviceTokenRequest): NetworkResponse<Void>
+    suspend fun requestMyProfile(): NetworkResponse<MemberMyProfileResponse>
+    suspend fun requestOtherProfile(memberId: String): NetworkResponse<MemberOtherProfileResponse>
+    suspend fun requestResign(content: String): NetworkResponse<Void>
+    suspend fun requestReceiveAlarm(): NetworkResponse<ReceiveAlarmResponse>
+    suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): NetworkResponse<Void>
+    suspend fun requestLogout(): NetworkResponse<Void>
+    suspend fun requestCheckEmail(email: String): NetworkResponse<Void>
+    suspend fun requestCheckEmailAuth(email: String): NetworkResponse<MemberAuthCodeResponse>
+    suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): NetworkResponse<Void>
+    suspend fun requestChangePassword(body: ChangePasswordRequest): NetworkResponse<Void>
+    suspend fun requestSettingChangePassword(body: ChangePasswordRequest): NetworkResponse<Void>
 
     // Firebase Messaging Service
     suspend fun getCurrentFcmToken(): String

--- a/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
@@ -1,5 +1,6 @@
 package com.daily.dayo.domain.repository
 
+import com.daily.dayo.common.Resource
 import com.daily.dayo.data.datasource.remote.member.*
 import okhttp3.MultipartBody
 import retrofit2.Response
@@ -11,32 +12,32 @@ interface MemberRepository {
         nickname: String,
         password: String,
         profileImg: MultipartBody.Part
-    ): Response<MemberSignupResponse>
+    ): Resource<MemberSignupResponse>
 
     suspend fun requestUpdateMyProfile(
         nickname: String?,
         profileImg: MultipartBody.Part?,
         onBasicProfileImg: Boolean
-    ): Response<Void>
+    ): Resource<Void>
 
-    suspend fun requestLoginKakao(body: MemberOAuthRequest): Response<MemberOAuthResponse>
-    suspend fun requestLoginEmail(body: MemberSignInRequest): Response<MemberSignInResponse>
-    suspend fun requestMemberInfo(): Response<MemberInfoResponse>
-    suspend fun requestCheckEmailDuplicate(email: String): Response<Void>
-    suspend fun requestCertificateEmail(email: String): Response<MemberAuthCodeResponse>
-    suspend fun requestRefreshToken(): Response<RefreshTokenResponse>
-    suspend fun requestDeviceToken(body: DeviceTokenRequest): Response<Void>
-    suspend fun requestMyProfile(): Response<MemberMyProfileResponse>
-    suspend fun requestOtherProfile(memberId: String): Response<MemberOtherProfileResponse>
-    suspend fun requestResign(content: String): Response<Void>
-    suspend fun requestReceiveAlarm(): Response<ReceiveAlarmResponse>
-    suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Response<Void>
-    suspend fun requestLogout(): Response<Void>
-    suspend fun requestCheckEmail(email: String): Response<Void>
-    suspend fun requestCheckEmailAuth(email: String): Response<MemberAuthCodeResponse>
-    suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Response<Void>
-    suspend fun requestChangePassword(body: ChangePasswordRequest): Response<Void>
-    suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Response<Void>
+    suspend fun requestLoginKakao(body: MemberOAuthRequest): Resource<MemberOAuthResponse>
+    suspend fun requestLoginEmail(body: MemberSignInRequest): Resource<MemberSignInResponse>
+    suspend fun requestMemberInfo(): Resource<MemberInfoResponse>
+    suspend fun requestCheckEmailDuplicate(email: String): Resource<Void>
+    suspend fun requestCertificateEmail(email: String): Resource<MemberAuthCodeResponse>
+    suspend fun requestRefreshToken(): Resource<RefreshTokenResponse>
+    suspend fun requestDeviceToken(body: DeviceTokenRequest): Resource<Void>
+    suspend fun requestMyProfile(): Resource<MemberMyProfileResponse>
+    suspend fun requestOtherProfile(memberId: String): Resource<MemberOtherProfileResponse>
+    suspend fun requestResign(content: String): Resource<Void>
+    suspend fun requestReceiveAlarm(): Resource<ReceiveAlarmResponse>
+    suspend fun requestChangeReceiveAlarm(body: ChangeReceiveAlarmRequest): Resource<Void>
+    suspend fun requestLogout(): Resource<Void>
+    suspend fun requestCheckEmail(email: String): Resource<Void>
+    suspend fun requestCheckEmailAuth(email: String): Resource<MemberAuthCodeResponse>
+    suspend fun requestCheckCurrentPassword(body: CheckPasswordRequest): Resource<Void>
+    suspend fun requestChangePassword(body: ChangePasswordRequest): Resource<Void>
+    suspend fun requestSettingChangePassword(body: ChangePasswordRequest): Resource<Void>
 
     // Firebase Messaging Service
     suspend fun getCurrentFcmToken(): String

--- a/app/src/main/java/com/daily/dayo/domain/repository/PostRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/PostRepository.kt
@@ -2,8 +2,8 @@ package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.post.*
 import com.daily.dayo.domain.model.Category
+import com.daily.dayo.domain.model.NetworkResponse
 import okhttp3.MultipartBody
-import retrofit2.Response
 
 interface PostRepository {
 
@@ -13,14 +13,14 @@ interface PostRepository {
         files: List<MultipartBody.Part>,
         folderId: Int,
         tags: Array<String>
-    ): Response<CreatePostResponse>
+    ): NetworkResponse<CreatePostResponse>
 
-    suspend fun requestNewPostList(): Response<ListAllPostResponse>
-    suspend fun requestNewPostListCategory(category: Category): Response<ListCategoryPostResponse>
-    suspend fun requestDayoPickPostList(): Response<DayoPickPostListResponse>
-    suspend fun requestDayoPickPostListCategory(category: Category): Response<DayoPickPostListResponse>
-    suspend fun requestFeedList(): Response<ListFeedResponse>
-    suspend fun requestPostDetail(postId: Int): Response<DetailPostResponse>
-    suspend fun requestDeletePost(postId: Int): Response<Void>
-    suspend fun requestEditPost(postId: Int, request: EditPostRequest): Response<EditPostResponse>
+    suspend fun requestNewPostList(): NetworkResponse<ListAllPostResponse>
+    suspend fun requestNewPostListCategory(category: Category): NetworkResponse<ListCategoryPostResponse>
+    suspend fun requestDayoPickPostList(): NetworkResponse<DayoPickPostListResponse>
+    suspend fun requestDayoPickPostListCategory(category: Category): NetworkResponse<DayoPickPostListResponse>
+    suspend fun requestFeedList(): NetworkResponse<ListFeedResponse>
+    suspend fun requestPostDetail(postId: Int): NetworkResponse<DetailPostResponse>
+    suspend fun requestDeletePost(postId: Int): NetworkResponse<Void>
+    suspend fun requestEditPost(postId: Int, request: EditPostRequest): NetworkResponse<EditPostResponse>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/ReportRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/ReportRepository.kt
@@ -2,10 +2,10 @@ package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.report.CreateReportMemberRequest
 import com.daily.dayo.data.datasource.remote.report.CreateReportPostRequest
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface ReportRepository {
 
-    suspend fun requestSaveMemberReport(body: CreateReportMemberRequest): Response<Void>
-    suspend fun requestSavePostReport(body: CreateReportPostRequest): Response<Void>
+    suspend fun requestSaveMemberReport(body: CreateReportMemberRequest): NetworkResponse<Void>
+    suspend fun requestSavePostReport(body: CreateReportPostRequest): NetworkResponse<Void>
 }

--- a/app/src/main/java/com/daily/dayo/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/SearchRepository.kt
@@ -1,12 +1,12 @@
 package com.daily.dayo.domain.repository
 
 import com.daily.dayo.data.datasource.remote.search.SearchResultResponse
-import retrofit2.Response
+import com.daily.dayo.domain.model.NetworkResponse
 
 interface SearchRepository {
 
-    suspend fun requestSearchTag(tag: String): Response<SearchResultResponse>
-    suspend fun requestSearchKeyword(keyword: String): Response<SearchResultResponse>
+    suspend fun requestSearchTag(tag: String): NetworkResponse<SearchResultResponse>
+    suspend fun requestSearchKeyword(keyword: String): NetworkResponse<SearchResultResponse>
     fun requestSearchKeywordRecentList(): ArrayList<String>
     fun clearSearchKeywordRecent()
     fun deleteSearchKeywordRecent(keyword: String)

--- a/app/src/main/java/com/daily/dayo/domain/usecase/folder/RequestCreateFolderUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/folder/RequestCreateFolderUseCase.kt
@@ -1,12 +1,12 @@
 package com.daily.dayo.domain.usecase.folder
 
 import com.daily.dayo.data.datasource.remote.folder.CreateFolderResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.domain.repository.FolderRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
@@ -18,7 +18,7 @@ class RequestCreateFolderUseCase @Inject constructor(
         privacy: Privacy,
         subheading: String?,
         thumbnailImg: File?
-    ): Response<CreateFolderResponse> {
+    ): NetworkResponse<CreateFolderResponse> {
         val requestThumbnailImage : MultipartBody.Part? = if(thumbnailImg!=null) {
             MultipartBody.Part.createFormData("thumbnailImage",thumbnailImg.name, RequestBody.create("image/*".toMediaTypeOrNull(),thumbnailImg) )
         } else null

--- a/app/src/main/java/com/daily/dayo/domain/usecase/folder/RequestEditFolderUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/folder/RequestEditFolderUseCase.kt
@@ -1,12 +1,12 @@
 package com.daily.dayo.domain.usecase.folder
 
 import com.daily.dayo.data.datasource.remote.folder.EditFolderResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.domain.repository.FolderRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
@@ -20,7 +20,7 @@ class RequestEditFolderUseCase @Inject constructor(
         subheading: String?,
         isFileChange: Boolean,
         thumbnailImg: File?
-    ): Response<EditFolderResponse> {
+    ): NetworkResponse<EditFolderResponse> {
         val requestThumbnailImage: MultipartBody.Part? = if (thumbnailImg != null)
             MultipartBody.Part.createFormData(
                 "thumbnailImage",

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
@@ -1,11 +1,11 @@
 package com.daily.dayo.domain.usecase.member
 
+import com.daily.dayo.common.Resource
 import com.daily.dayo.data.datasource.remote.member.MemberSignupResponse
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
@@ -17,7 +17,7 @@ class RequestSignUpEmailUseCase @Inject constructor(
         nickname: String,
         password: String,
         profileImg: File?
-    ): Response<MemberSignupResponse> {
+    ): Resource<MemberSignupResponse> {
         val uploadFile: MultipartBody.Part
         val fileNameDivideList: List<String> = profileImg.toString().split("/")
         val requestBodyFile: RequestBody =

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
@@ -1,7 +1,7 @@
 package com.daily.dayo.domain.usecase.member
 
-import com.daily.dayo.common.Resource
 import com.daily.dayo.data.datasource.remote.member.MemberSignupResponse
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -17,7 +17,7 @@ class RequestSignUpEmailUseCase @Inject constructor(
         nickname: String,
         password: String,
         profileImg: File?
-    ): Resource<MemberSignupResponse> {
+    ): NetworkResponse<MemberSignupResponse> {
         val uploadFile: MultipartBody.Part
         val fileNameDivideList: List<String> = profileImg.toString().split("/")
         val requestBodyFile: RequestBody =

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestUpdateMyProfileUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestUpdateMyProfileUseCase.kt
@@ -1,6 +1,6 @@
 package com.daily.dayo.domain.usecase.member
 
-import com.daily.dayo.common.Resource
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -15,7 +15,7 @@ class RequestUpdateMyProfileUseCase @Inject constructor(
         nickname: String?,
         profileImg: File?,
         onBasicProfileImg: Boolean
-    ): Resource<Void> {
+    ): NetworkResponse<Void> {
         val requestProfileImage: MultipartBody.Part? = if (profileImg != null)
             MultipartBody.Part.createFormData(
                 "profileImg",

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestUpdateMyProfileUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestUpdateMyProfileUseCase.kt
@@ -1,10 +1,10 @@
 package com.daily.dayo.domain.usecase.member
 
+import com.daily.dayo.common.Resource
 import com.daily.dayo.domain.repository.MemberRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
@@ -15,7 +15,7 @@ class RequestUpdateMyProfileUseCase @Inject constructor(
         nickname: String?,
         profileImg: File?,
         onBasicProfileImg: Boolean
-    ): Response<Void> {
+    ): Resource<Void> {
         val requestProfileImage: MultipartBody.Part? = if (profileImg != null)
             MultipartBody.Part.createFormData(
                 "profileImg",

--- a/app/src/main/java/com/daily/dayo/domain/usecase/post/RequestUploadPostUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/post/RequestUploadPostUseCase.kt
@@ -2,11 +2,11 @@ package com.daily.dayo.domain.usecase.post
 
 import com.daily.dayo.data.datasource.remote.post.CreatePostResponse
 import com.daily.dayo.domain.model.Category
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.PostRepository
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
@@ -19,7 +19,7 @@ class RequestUploadPostUseCase @Inject constructor(
         files: Array<File>,
         folderId: Int,
         tags: Array<String>
-    ): Response<CreatePostResponse> {
+    ): NetworkResponse<CreatePostResponse> {
         val uploadFiles: ArrayList<MultipartBody.Part> = ArrayList()
         for (i in files.indices) {
             val imageFile = files.get(i)

--- a/app/src/main/java/com/daily/dayo/domain/usecase/report/RequestSaveMemberReportUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/report/RequestSaveMemberReportUseCase.kt
@@ -1,13 +1,13 @@
 package com.daily.dayo.domain.usecase.report
 
 import com.daily.dayo.data.datasource.remote.report.CreateReportMemberRequest
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.repository.ReportRepository
-import retrofit2.Response
 import javax.inject.Inject
 
 class RequestSaveMemberReportUseCase @Inject constructor(
     private val reportRepository: ReportRepository
 ) {
-    suspend operator fun invoke(body: CreateReportMemberRequest): Response<Void> =
+    suspend operator fun invoke(body: CreateReportMemberRequest): NetworkResponse<Void> =
         reportRepository.requestSaveMemberReport(body)
 }

--- a/app/src/main/java/com/daily/dayo/presentation/activity/LoginActivity.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/activity/LoginActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.ViewTreeObserver
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -27,7 +28,8 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
+        observeNetworkException()
+        observeApiException()
         autoLogin()
         loginSuccess()
         setSplash()
@@ -89,5 +91,20 @@ class LoginActivity : AppCompatActivity() {
                 }
             }
         )
+    }
+
+    private fun observeNetworkException() {
+        loginViewModel.isErrorExceptionOccurred.observe(this) { isOccurred ->
+            if (isOccurred.getContentIfNotHandled() == true) {
+                Toast.makeText(this, "네트워크 연결 상태가 불안정합니다", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun observeApiException() {
+        loginViewModel.isApiErrorExceptionOccurred.observe(this) { isOccurred ->
+            if (isOccurred.getContentIfNotHandled() == true)
+                Toast.makeText(this, "서버와의 연결상태가 좋지 않습니다", Toast.LENGTH_SHORT).show()
+        }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -118,29 +118,25 @@ class ProfileEditFragment : Fragment() {
     private fun initMyProfile() {
         profileSettingViewModel.requestProfile(memberId = DayoApplication.preferences.getCurrentUser().memberId!!)
         profileSettingViewModel.profileInfo.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    it.data?.let { profile ->
-                        CoroutineScope(Dispatchers.Main).launch {
-                            val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                                GlideLoadUtil.loadImageBackgroundProfile(
-                                    requestManager = glideRequestManager,
-                                    width = 100,
-                                    height = 100,
-                                    imgName = profile.profileImg
-                                )
-                            }
-                            GlideLoadUtil.loadImageViewProfile(
-                                requestManager = glideRequestManager,
-                                width = 100,
-                                height = 100,
-                                img = userProfileThumbnailImage,
-                                imgView = binding.imgProfileEditUserImage
-                            )
-                        }
-                        binding.etProfileEditNickname.setText(profile.nickname)
+            it?.let { profile ->
+                CoroutineScope(Dispatchers.Main).launch {
+                    val userProfileThumbnailImage = withContext(Dispatchers.IO) {
+                        GlideLoadUtil.loadImageBackgroundProfile(
+                            requestManager = glideRequestManager,
+                            width = 100,
+                            height = 100,
+                            imgName = profile.profileImg
+                        )
                     }
+                    GlideLoadUtil.loadImageViewProfile(
+                        requestManager = glideRequestManager,
+                        width = 100,
+                        height = 100,
+                        img = userProfileThumbnailImage,
+                        imgView = binding.imgProfileEditUserImage
+                    )
                 }
+                binding.etProfileEditNickname.setText(profile.nickname)
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
@@ -104,37 +104,33 @@ class ProfileFragment : Fragment() {
     private fun setProfileDescription() {
         profileViewModel.requestProfile(memberId = profileViewModel.profileMemberId)
         profileViewModel.profileInfo.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    it.data?.let { profile ->
-                        binding.profile = profile
-                        CoroutineScope(Dispatchers.Main).launch {
-                            val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                                loadImageBackgroundProfile(
-                                    requestManager = glideRequestManager,
-                                    width = 70, height = 70, imgName = profile.profileImg
-                                )
-                            }
-                            loadImageViewProfile(
-                                requestManager = glideRequestManager,
-                                width = 70,
-                                height = 70,
-                                img = userProfileThumbnailImage,
-                                imgView = binding.imgProfileUserProfile
-                            )
-                        }
-
-                        setFollowButtonClickListener(follow = profile.follow)
-                        setFollowerCountButtonClickListener(
-                            memberId = profile.memberId,
-                            nickname = profile.nickname
-                        )
-                        setFollowingCountButtonClickListener(
-                            memberId = profile.memberId,
-                            nickname = profile.nickname
+            it?.let { profile ->
+                binding.profile = profile
+                CoroutineScope(Dispatchers.Main).launch {
+                    val userProfileThumbnailImage = withContext(Dispatchers.IO) {
+                        loadImageBackgroundProfile(
+                            requestManager = glideRequestManager,
+                            width = 70, height = 70, imgName = profile.profileImg
                         )
                     }
+                    loadImageViewProfile(
+                        requestManager = glideRequestManager,
+                        width = 70,
+                        height = 70,
+                        img = userProfileThumbnailImage,
+                        imgView = binding.imgProfileUserProfile
+                    )
                 }
+
+                setFollowButtonClickListener(follow = profile.follow)
+                setFollowerCountButtonClickListener(
+                    memberId = profile.memberId,
+                    nickname = profile.nickname
+                )
+                setFollowingCountButtonClickListener(
+                    memberId = profile.memberId,
+                    nickname = profile.nickname
+                )
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -6,9 +6,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.Event
+import com.daily.dayo.common.Status
 import com.daily.dayo.data.datasource.remote.member.*
 import com.daily.dayo.domain.usecase.member.*
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -68,77 +71,149 @@ class AccountViewModel @Inject constructor(
     private val _changePasswordSuccess = MutableLiveData<Boolean>()
     val changePasswordSuccess get() = _changePasswordSuccess
 
+    private val _isErrorExceptionOccurred = MutableLiveData<Event<Boolean>>()
+    val isErrorExceptionOccurred get() = _isErrorExceptionOccurred
+
+    private val _isApiErrorExceptionOccurred = MutableLiveData<Event<Boolean>>()
+    val isApiErrorExceptionOccurred get() = _isApiErrorExceptionOccurred
+
     fun requestLoginKakao(accessToken: String) = viewModelScope.launch {
-        val response = requestLoginKakaoUseCase(MemberOAuthRequest(accessToken = accessToken))
-        if (response.isSuccessful) {
-            DayoApplication.preferences.saveCurrentUser(response.body())
-            coroutineScope {
-                requestMemberInfo()
-                _loginSuccess.postValue(Event(true))
+        requestLoginKakaoUseCase(MemberOAuthRequest(accessToken = accessToken)).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    DayoApplication.preferences.saveCurrentUser(ApiResponse.data)
+                    coroutineScope {
+                        requestMemberInfo()
+                        _loginSuccess.postValue(Event(true))
+                    }
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
             }
-        } else {
-            _loginSuccess.postValue(Event(false))
         }
     }
 
     fun requestLoginEmail(email: String, password: String) = viewModelScope.launch {
-        requestLoginEmailUseCase(MemberSignInRequest(email = email, password = password)).let {
-            if (it.isSuccessful) {
-                DayoApplication.preferences.saveCurrentUser(it.body())
-                requestMemberInfo()
-                _loginSuccess.postValue(Event(true))
-            } else {
-                _loginSuccess.postValue(Event(false))
+        requestLoginEmailUseCase(MemberSignInRequest(email = email, password = password)).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    DayoApplication.preferences.saveCurrentUser(ApiResponse.data)
+                    requestMemberInfo()
+                    _loginSuccess.postValue(Event(true))
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
             }
         }
     }
 
     fun requestRefreshToken() = viewModelScope.launch {
-        requestRefreshTokenUseCase().let {
-            if (it.isSuccessful) {
-                it.body()?.let { response ->
-                    DayoApplication.preferences.setAccessToken(response.accessToken)
+        requestRefreshTokenUseCase().let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    ApiResponse.data?.let { response ->
+                        DayoApplication.preferences.setAccessToken(response.accessToken)
+                    }
+                    requestMemberInfo()
+                    _loginSuccess.postValue(Event(true))
                 }
-                requestMemberInfo()
-                _loginSuccess.postValue(Event(true))
-            } else
-                _loginSuccess.postValue(Event(false))
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _loginSuccess.postValue(Event(false))
+                }
+            }
         }
     }
 
     private suspend fun requestMemberInfo() {
-        val response = requestMemberInfoUseCase()
-        if (response.isSuccessful) {
-            DayoApplication.preferences.saveCurrentUser(response.body())
+        requestMemberInfoUseCase().let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    DayoApplication.preferences.saveCurrentUser(ApiResponse.data)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                }
+                else -> { }
+            }
         }
     }
 
     fun requestSignupEmail(email: String, nickname: String, password: String, profileImg: File?) =
         viewModelScope.launch(Dispatchers.IO) {
-            val response = requestSignUpEmailUseCase(email, nickname, password, profileImg)
-            if (response.isSuccessful) {
-                _signupSuccess.postValue(Event(true))
-            } else {
-                _signupSuccess.postValue(Event(false))
+            requestSignUpEmailUseCase(email, nickname, password, profileImg).let {  ApiResponse ->
+                when (ApiResponse.status) {
+                    Status.SUCCESS -> {
+                        _signupSuccess.postValue(Event(true))
+                    }
+                    Status.ERROR -> {
+                        _isErrorExceptionOccurred.postValue(Event(true))
+                        _signupSuccess.postValue(Event(false))
+                    }
+                    Status.API_ERROR -> {
+                        _isApiErrorExceptionOccurred.postValue(Event(true))
+                        _signupSuccess.postValue(Event(false))
+                    }
+                    else -> {}
+                }
             }
         }
 
     fun requestCheckEmailDuplicate(email: String) = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestCheckEmailDuplicateUseCase(email)
-        if (response.isSuccessful) {
-            _isEmailDuplicate.postValue(true)
-        } else {
-            _isEmailDuplicate.postValue(false)
+        requestCheckEmailDuplicateUseCase(email).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _isEmailDuplicate.postValue(true)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _isEmailDuplicate.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _isEmailDuplicate.postValue(false)
+                }
+                else -> {}
+            }
         }
     }
 
     fun requestCertificateEmail(email: String) = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestCertificateEmailUseCase(email)
-        if (response.isSuccessful) {
-            _isCertificateEmailSend.postValue(true)
-            certificateEmailAuthCode.postValue(response.body()?.authCode)
-        } else {
-            _isCertificateEmailSend.postValue(false)
+        requestCertificateEmailUseCase(email).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _isCertificateEmailSend.postValue(true)
+                    certificateEmailAuthCode.postValue(ApiResponse.data?.authCode)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _isCertificateEmailSend.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _isCertificateEmailSend.postValue(false)
+                }
+                else -> {}
+            }
         }
     }
 
@@ -151,50 +226,97 @@ class AccountViewModel @Inject constructor(
     }
 
     fun requestWithdraw(content: String) = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestResignUseCase(content)
-        if (response.isSuccessful) {
-            _withdrawSuccess.postValue(Event(true))
-        } else {
-            _withdrawSuccess.postValue(Event(false))
+        requestResignUseCase(content).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _withdrawSuccess.postValue(Event(true))
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _withdrawSuccess.postValue(Event(false))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _withdrawSuccess.postValue(Event(false))
+                }
+                else -> {}
+            }
         }
     }
 
     fun requestLogout() = viewModelScope.launch {
-        requestLogoutUseCase().let {
-            if (it.isSuccessful) {
-                _logoutSuccess.postValue(Event(true))
-            } else {
-                _logoutSuccess.postValue(Event(false))
+        requestLogoutUseCase().let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _logoutSuccess.postValue(Event(true))
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _logoutSuccess.postValue(Event(false))
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _logoutSuccess.postValue(Event(false))
+                }
+                else -> {}
             }
         }
     }
 
     fun requestCheckEmail(inputEmail: String) = viewModelScope.launch {
-        requestCheckEmailUseCase(email = inputEmail).let {
-            if (it.isSuccessful) {
-                _checkEmailSuccess.postValue(true)
-            } else {
-                _checkEmailSuccess.postValue(false)
+        requestCheckEmailUseCase(email = inputEmail).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _checkEmailSuccess.postValue(true)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _checkEmailSuccess.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _checkEmailSuccess.postValue(false)
+                }
+                else -> {}
             }
         }
     }
 
     fun requestCheckEmailAuth(inputEmail: String) = viewModelScope.launch {
-        val response = requestCheckEmailAuthUseCase(inputEmail)
-        if (response.isSuccessful) {
-            _isCertificateEmailSend.postValue(true)
-            certificateEmailAuthCode.postValue(response.body()?.authCode)
-        } else {
-            _isCertificateEmailSend.postValue(false)
+        requestCheckEmailAuthUseCase(inputEmail).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _isCertificateEmailSend.postValue(true)
+                    certificateEmailAuthCode.postValue(ApiResponse.data?.authCode)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _isCertificateEmailSend.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _isCertificateEmailSend.postValue(false)
+                }
+                else -> {}
+            }
         }
     }
 
     fun requestCheckCurrentPassword(inputPassword: String) = viewModelScope.launch {
-        requestCheckCurrentPasswordUseCase(CheckPasswordRequest(password = inputPassword)).let {
-            if (it.isSuccessful) {
-                _checkCurrentPasswordSuccess.postValue(true)
-            } else {
-                _checkCurrentPasswordSuccess.postValue(false)
+        requestCheckCurrentPasswordUseCase(CheckPasswordRequest(password = inputPassword)).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _checkCurrentPasswordSuccess.postValue(true)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _checkCurrentPasswordSuccess.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _checkCurrentPasswordSuccess.postValue(false)
+                }
+                else -> {}
             }
         }
     }
@@ -205,11 +327,20 @@ class AccountViewModel @Inject constructor(
                 email = email,
                 password = newPassword
             )
-        ).let {
-            if (it.isSuccessful) {
-                _changePasswordSuccess.postValue(true)
-            } else {
-                _changePasswordSuccess.postValue(false)
+        ).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _changePasswordSuccess.postValue(true)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _changePasswordSuccess.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _changePasswordSuccess.postValue(false)
+                }
+                else -> {}
             }
         }
     }
@@ -220,11 +351,20 @@ class AccountViewModel @Inject constructor(
                 email = DayoApplication.preferences.getCurrentUser().email!!,
                 password = newPassword
             )
-        ).let {
-            if (it.isSuccessful) {
-                _changePasswordSuccess.postValue(true)
-            } else {
-                _changePasswordSuccess.postValue(false)
+        ).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _changePasswordSuccess.postValue(true)
+                }
+                Status.ERROR -> {
+                    _isErrorExceptionOccurred.postValue(Event(true))
+                    _changePasswordSuccess.postValue(false)
+                }
+                Status.API_ERROR -> {
+                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    _changePasswordSuccess.postValue(false)
+                }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/FeedViewModel.kt
@@ -10,6 +10,7 @@ import com.daily.dayo.data.datasource.remote.bookmark.CreateBookmarkResponse
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartRequest
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartResponse
 import com.daily.dayo.data.mapper.toPost
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.domain.usecase.bookmark.RequestBookmarkPostUseCase
 import com.daily.dayo.domain.usecase.bookmark.RequestDeleteBookmarkPostUseCase
@@ -40,20 +41,23 @@ class FeedViewModel @Inject constructor(
 
     fun requestFeedList() = viewModelScope.launch {
         _feedList.postValue(Resource.loading(null))
-        val response = requestFeedListUseCase()
-        if (response.isSuccessful) {
-            _feedList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
-        } else {
-            _feedList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestFeedListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _feedList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
+                is NetworkResponse.NetworkError -> { _feedList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _feedList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _feedList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestLikePost(postId: Int) = viewModelScope.launch {
-        requestLikePostUseCase(CreateHeartRequest(postId = postId)).let {
-            if (it.isSuccessful) {
-                _postLiked.postValue(Resource.success(it.body()))
-            } else {
-                _postLiked.postValue(Resource.error(it.errorBody().toString(), null))
+        requestLikePostUseCase(CreateHeartRequest(postId = postId))?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _postLiked.postValue(Resource.success(ApiResponse.body)) }
+                is NetworkResponse.NetworkError -> { _postLiked.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _postLiked.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _postLiked.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
             }
         }
     }
@@ -63,11 +67,12 @@ class FeedViewModel @Inject constructor(
     }
 
     fun requestBookmarkPost(postId: Int) = viewModelScope.launch {
-        requestBookmarkPostUseCase(CreateBookmarkRequest(postId = postId)).let {
-            if (it.isSuccessful) {
-                _postBookmarked.postValue(Resource.success(it.body()))
-            } else {
-                _postBookmarked.postValue(Resource.error(it.errorBody().toString(), null))
+        requestBookmarkPostUseCase(CreateBookmarkRequest(postId = postId)).let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _postBookmarked.postValue(Resource.success(ApiResponse.body)) }
+                is NetworkResponse.NetworkError -> { _postBookmarked.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _postBookmarked.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _postBookmarked.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/FolderSettingViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/FolderSettingViewModel.kt
@@ -10,6 +10,7 @@ import com.daily.dayo.data.mapper.toEditOrderDto
 import com.daily.dayo.data.mapper.toFolder
 import com.daily.dayo.domain.model.Folder
 import com.daily.dayo.domain.model.FolderOrder
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.domain.usecase.folder.*
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -49,64 +50,64 @@ class FolderSettingViewModel @Inject constructor(
     val detailFolderList: LiveData<Resource<Folder>> get() = _detailFolderList
 
     fun requestCreateFolder(name: String, privacy: Privacy, subheading: String?, thumbnailImg: File?) = viewModelScope.launch {
-        requestCreateFolderUseCase(name = name, privacy = privacy, subheading = subheading, thumbnailImg = thumbnailImg).let {
-            if (it.isSuccessful) {
-                _folderAddSuccess.postValue(Event(true))
-            } else {
-                _folderAddSuccess.postValue(Event(false))
+        requestCreateFolderUseCase(name = name, privacy = privacy, subheading = subheading, thumbnailImg = thumbnailImg)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _folderAddSuccess.postValue(Event(true)) }
+                else -> { _folderAddSuccess.postValue(Event(false)) }
             }
         }
     }
 
     fun requestEditFolder(folderId: Int, name: String, privacy: Privacy, subheading: String?, isFileChange: Boolean, thumbnailImage: File?) = viewModelScope.launch {
-        requestEditFolderUseCase(folderId = folderId, name = name, privacy = privacy, subheading = subheading, isFileChange = isFileChange, thumbnailImage).let {
-            if (it.isSuccessful) {
-                _editSuccess.postValue(Event(true))
-            } else {
-                _editSuccess.postValue(Event(false))
+        requestEditFolderUseCase(folderId = folderId, name = name, privacy = privacy, subheading = subheading, isFileChange = isFileChange, thumbnailImage)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _editSuccess.postValue(Event(true)) }
+                else -> { _editSuccess.postValue(Event(false)) }
             }
         }
     }
 
     fun requestDeleteFolder(folderId: Int) = viewModelScope.launch {
-        requestDeleteFolderUseCase(folderId = folderId).let {
-            if (it.isSuccessful) {
-                _deleteSuccess.postValue(Event(true))
-            } else {
-                _deleteSuccess.postValue(Event(false))
+        requestDeleteFolderUseCase(folderId = folderId)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _deleteSuccess.postValue(Event(true)) }
+                else -> { _deleteSuccess.postValue(Event(false)) }
             }
         }
     }
 
     fun requestDetailListFolder(folderId: Int) = viewModelScope.launch {
         _detailFolderList.postValue(Resource.loading(null))
-        requestDetailListFolderUseCase(folderId = folderId).let {
-            if (it.isSuccessful) {
-                _detailFolderList.postValue(Resource.success(it.body()?.toFolder()))
-                _thumbnailUri.postValue("http://117.17.198.45:8080/images/" + it.body()!!.thumbnailImage)
-            } else {
-                _detailFolderList.postValue(Resource.error(it.errorBody().toString(), null))
+        requestDetailListFolderUseCase(folderId = folderId)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> {
+                    _detailFolderList.postValue(Resource.success(ApiResponse.body?.toFolder()))
+                    _thumbnailUri.postValue("http://117.17.198.45:8080/images/" + ApiResponse.body?.thumbnailImage)
+                }
+                is NetworkResponse.NetworkError -> { _detailFolderList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _detailFolderList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _detailFolderList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
             }
         }
     }
 
     fun requestAllMyFolderList() = viewModelScope.launch {
         _folderList.postValue(Resource.loading(null))
-        val response = requestAllMyFolderListUseCase()
-        if (response.isSuccessful) {
-            _folderList.postValue(Resource.success(response.body()?.data?.map { it.toFolder() }))
-        } else {
-            _folderList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestAllMyFolderListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _folderList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toFolder() })) }
+                is NetworkResponse.NetworkError -> { _folderList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _folderList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _folderList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestOrderFolder(folderOrder: List<FolderOrder>) = viewModelScope.launch {
-        requestOrderFolderUseCase(folderOrder = folderOrder.map { it.toEditOrderDto() }).let {
-            if (it.isSuccessful) {
-                _orderFolderSuccess.postValue(Event(true))
-            }
-            else {
-                _orderFolderSuccess.postValue(Event(false))
+        requestOrderFolderUseCase(folderOrder = folderOrder.map { it.toEditOrderDto() })?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _orderFolderSuccess.postValue(Event(true)) }
+                else -> { _orderFolderSuccess.postValue(Event(false)) }
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.daily.dayo.common.Resource
 import com.daily.dayo.data.datasource.remote.heart.CreateHeartRequest
 import com.daily.dayo.data.mapper.toPost
 import com.daily.dayo.domain.model.Category
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.domain.usecase.like.RequestLikePostUseCase
 import com.daily.dayo.domain.usecase.like.RequestUnlikePostUseCase
@@ -57,39 +58,47 @@ class HomeViewModel @Inject constructor(
     }
 
     fun requestHomeNewPostList() = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestNewPostListUseCase()
-        if(response.isSuccessful){
-            _newPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
-        } else {
-            _newPostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestNewPostListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _newPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
+                is NetworkResponse.NetworkError -> { _newPostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _newPostList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _newPostList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestHomeNewPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestNewPostListCategoryUseCase(category = category)
-        if(response.isSuccessful) {
-            _newPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
-        } else {
-            _newPostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestNewPostListCategoryUseCase(category = category)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _newPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
+                is NetworkResponse.NetworkError -> { _newPostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _newPostList.postValue(Resource.error(ApiResponse.error.toString(), null))  }
+                is NetworkResponse.UnknownError -> { _newPostList.postValue(Resource.error(ApiResponse.throwable.toString(), null))  }
+            }
         }
     }
 
     fun requestHomeDayoPickPostList() = viewModelScope.launch(Dispatchers.IO) {
         _dayoPickPostList.postValue(Resource.loading(null))
-        val response = requestHomeDayoPickPostListUseCase()
-        if(response.isSuccessful){
-            _dayoPickPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
-        } else {
-            _dayoPickPostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestHomeDayoPickPostListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _dayoPickPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
+                is NetworkResponse.NetworkError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestHomeDayoPickPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
-        val response = requestDayoPickPostListCategoryUseCase(category = category)
-        if(response.isSuccessful) {
-            _dayoPickPostList.postValue(Resource.success(response.body()?.data?.map { it.toPost() }))
-        } else {
-            _dayoPickPostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestDayoPickPostListCategoryUseCase(category = category)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _dayoPickPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
+                is NetworkResponse.NetworkError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _dayoPickPostList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileSettingViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileSettingViewModel.kt
@@ -5,9 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.common.Event
-import com.daily.dayo.common.Resource
-import com.daily.dayo.common.Status
 import com.daily.dayo.data.mapper.toProfile
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.model.Profile
 import com.daily.dayo.domain.usecase.member.RequestOtherProfileUseCase
 import com.daily.dayo.domain.usecase.member.RequestUpdateMyProfileUseCase
@@ -22,23 +21,23 @@ class ProfileSettingViewModel @Inject constructor(
     private val requestUpdateMyProfileUseCase: RequestUpdateMyProfileUseCase
 ) : ViewModel() {
 
-    private val _profileInfo = MutableLiveData<Resource<Profile>>()
-    val profileInfo: LiveData<Resource<Profile>> get() = _profileInfo
+    private val _profileInfo = MutableLiveData<Profile>()
+    val profileInfo: LiveData<Profile> get() = _profileInfo
 
     private val _updateSuccess = MutableLiveData<Event<Boolean>>()
     val updateSuccess: LiveData<Event<Boolean>> get() = _updateSuccess
 
     fun requestProfile(memberId: String) = viewModelScope.launch {
         requestOtherProfileUseCase(memberId = memberId).let { ApiResponse ->
-            when (ApiResponse.status) {
-                Status.SUCCESS -> {
-                    _profileInfo.postValue(Resource.success(ApiResponse.data?.toProfile()))
+            when (ApiResponse) {
+                is NetworkResponse.Success -> {
+                    _profileInfo.postValue(ApiResponse.body?.toProfile())
                 }
-                Status.ERROR -> {
-                    _profileInfo.postValue(Resource.error(ApiResponse.exception))
+                is NetworkResponse.NetworkError -> {
+
                 }
-                Status.API_ERROR -> {
-                    _profileInfo.postValue(Resource(Status.API_ERROR, ApiResponse.data?.toProfile(), ApiResponse.message, null))
+                is NetworkResponse.ApiError -> {
+
                 }
             }
         }
@@ -51,14 +50,14 @@ class ProfileSettingViewModel @Inject constructor(
                 profileImg = profileImg,
                 onBasicProfileImg = isReset
             ).let { ApiResponse ->
-                when (ApiResponse.status) {
-                    Status.SUCCESS -> {
+                when (ApiResponse) {
+                    is NetworkResponse.Success -> {
                         _updateSuccess.postValue(Event(true))
                     }
-                    Status.ERROR -> {
+                    is NetworkResponse.NetworkError -> {
                         _updateSuccess.postValue(Event(false))
                     }
-                    Status.API_ERROR -> {
+                    is NetworkResponse.ApiError  -> {
                         _updateSuccess.postValue(Event(false))
                     }
                 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileSettingViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileSettingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.common.Event
 import com.daily.dayo.common.Resource
+import com.daily.dayo.common.Status
 import com.daily.dayo.data.mapper.toProfile
 import com.daily.dayo.domain.model.Profile
 import com.daily.dayo.domain.usecase.member.RequestOtherProfileUseCase
@@ -16,7 +17,7 @@ import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
-class ProfileSettingViewModel@Inject constructor(
+class ProfileSettingViewModel @Inject constructor(
     private val requestOtherProfileUseCase: RequestOtherProfileUseCase,
     private val requestUpdateMyProfileUseCase: RequestUpdateMyProfileUseCase
 ) : ViewModel() {
@@ -28,22 +29,39 @@ class ProfileSettingViewModel@Inject constructor(
     val updateSuccess: LiveData<Event<Boolean>> get() = _updateSuccess
 
     fun requestProfile(memberId: String) = viewModelScope.launch {
-        val response = requestOtherProfileUseCase(memberId = memberId)
-        if(response.isSuccessful){
-            _profileInfo.postValue(Resource.success(response.body()?.toProfile()))
-        }else{
-            _profileInfo.postValue(Resource.error(response.errorBody().toString(),null))
+        requestOtherProfileUseCase(memberId = memberId).let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _profileInfo.postValue(Resource.success(ApiResponse.data?.toProfile()))
+                }
+                Status.ERROR -> {
+                    _profileInfo.postValue(Resource.error(ApiResponse.exception))
+                }
+                Status.API_ERROR -> {
+                    _profileInfo.postValue(Resource(Status.API_ERROR, ApiResponse.data?.toProfile(), ApiResponse.message, null))
+                }
+            }
         }
     }
 
-    fun requestUpdateMyProfile(nickname: String?, profileImg: File?, isReset: Boolean) = viewModelScope.launch {
-        requestUpdateMyProfileUseCase(nickname = nickname, profileImg = profileImg, onBasicProfileImg = isReset).let {
-            if(it.isSuccessful){
-                _updateSuccess.postValue(Event(true))
-            }
-            else{
-                _updateSuccess.postValue(Event(false))
+    fun requestUpdateMyProfile(nickname: String?, profileImg: File?, isReset: Boolean) =
+        viewModelScope.launch {
+            requestUpdateMyProfileUseCase(
+                nickname = nickname,
+                profileImg = profileImg,
+                onBasicProfileImg = isReset
+            ).let { ApiResponse ->
+                when (ApiResponse.status) {
+                    Status.SUCCESS -> {
+                        _updateSuccess.postValue(Event(true))
+                    }
+                    Status.ERROR -> {
+                        _updateSuccess.postValue(Event(false))
+                    }
+                    Status.API_ERROR -> {
+                        _updateSuccess.postValue(Event(false))
+                    }
+                }
             }
         }
-    }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.common.Event
 import com.daily.dayo.common.Resource
-import com.daily.dayo.common.Status
 import com.daily.dayo.data.datasource.remote.follow.CreateFollowRequest
 import com.daily.dayo.data.mapper.toBookmarkPost
 import com.daily.dayo.data.mapper.toFolder
@@ -39,8 +38,8 @@ class ProfileViewModel @Inject constructor(
 
     lateinit var profileMemberId: String
 
-    private val _profileInfo = MutableLiveData<Resource<Profile>>()
-    val profileInfo: LiveData<Resource<Profile>> get() = _profileInfo
+    private val _profileInfo = MutableLiveData<Profile>()
+    val profileInfo: LiveData<Profile> get() = _profileInfo
 
     private val _followSuccess = MutableLiveData<Event<Boolean>>()
     val followSuccess: LiveData<Event<Boolean>> get() = _followSuccess
@@ -62,15 +61,14 @@ class ProfileViewModel @Inject constructor(
 
     fun requestProfile(memberId: String) = viewModelScope.launch {
         requestOtherProfileUseCase(memberId = memberId).let { ApiResponse ->
-            when (ApiResponse.status) {
-                Status.SUCCESS -> {
-                    _profileInfo.postValue(Resource.success(ApiResponse.data?.toProfile()))
+            when (ApiResponse) {
+                is NetworkResponse.Success -> {
+                    _profileInfo.postValue(ApiResponse.body?.toProfile())
                 }
-                Status.ERROR -> {
-                    _profileInfo.postValue(Resource.error(ApiResponse.exception))
+                is NetworkResponse.NetworkError  -> {
                 }
-                Status.API_ERROR -> {
-                    _profileInfo.postValue(Resource(Status.API_ERROR, ApiResponse.data?.toProfile(), ApiResponse.message, null))
+                is NetworkResponse.ApiError  -> {
+
                 }
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
@@ -75,21 +75,19 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun requestCreateFollow(followerId: String) = viewModelScope.launch {
-        requestCreateFollowUseCase(CreateFollowRequest(followerId = followerId)).let {
-            if (it.isSuccessful) {
-                _followSuccess.postValue(Event(true))
-            } else {
-                _followSuccess.postValue(Event(false))
+        requestCreateFollowUseCase(CreateFollowRequest(followerId = followerId))?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _followSuccess.postValue(Event(true)) }
+                else -> { _followSuccess.postValue(Event(false)) }
             }
         }
     }
 
     fun requestDeleteFollow(followerId: String) = viewModelScope.launch {
-        requestDeleteFollowUseCase(followerId = followerId).let {
-            if (it.isSuccessful) {
-                _unfollowSuccess.postValue(Event(true))
-            } else {
-                _unfollowSuccess.postValue(Event(false))
+        requestDeleteFollowUseCase(followerId = followerId)?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _unfollowSuccess.postValue(Event(true)) }
+                else -> { _unfollowSuccess.postValue(Event(false)) }
             }
         }
     }
@@ -97,45 +95,56 @@ class ProfileViewModel @Inject constructor(
     fun requestFolderList(memberId: String, isMine: Boolean) = viewModelScope.launch {
         _folderList.postValue(Resource.loading(null))
         if (isMine) {
-            val response = requestAllMyFolderListUseCase()
-            if (response.isSuccessful) {
-                _folderList.postValue(Resource.success(response.body()?.data?.map { it.toFolder() }))
-            } else {
-                _folderList.postValue(Resource.error(response.errorBody().toString(), null))
+            requestAllMyFolderListUseCase()?.let { ApiResponse ->
+                when (ApiResponse) {
+                    is NetworkResponse.Success -> { _folderList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toFolder() })) }
+                    is NetworkResponse.NetworkError -> { _folderList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                    is NetworkResponse.ApiError -> { _folderList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                    is NetworkResponse.UnknownError -> { _folderList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+                }
             }
         } else {
-            val response = requestAllFolderListUseCase(memberId = memberId)
-            if (response.isSuccessful) {
-                _folderList.postValue(Resource.success(response.body()?.data?.map { it.toFolder() }))
-            } else {
-                _folderList.postValue(Resource.error(response.errorBody().toString(), null))
+            requestAllFolderListUseCase(memberId = memberId)?.let { ApiResponse ->
+                when (ApiResponse) {
+                    is NetworkResponse.Success -> { _folderList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toFolder() })) }
+                    is NetworkResponse.NetworkError -> { _folderList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                    is NetworkResponse.ApiError -> { _folderList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                    is NetworkResponse.UnknownError -> { _folderList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+                }
             }
         }
     }
 
     fun requestAllMyLikePostList() = viewModelScope.launch {
-        val response = requestAllMyLikePostListUseCase()
-        if (response.isSuccessful) {
-            _likePostList.postValue(Resource.success(response.body()?.data?.map { it.toLikePost() }))
-        } else {
-            _likePostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestAllMyLikePostListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _likePostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toLikePost() })) }
+                is NetworkResponse.NetworkError -> { _likePostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _likePostList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _likePostList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestAllMyBookmarkPostList() = viewModelScope.launch {
-        val response = requestAllMyBookmarkPostListUseCase()
-        if (response.isSuccessful) {
-            _bookmarkPostList.postValue(Resource.success(response.body()?.data?.map { it.toBookmarkPost() }))
-        } else {
-            _bookmarkPostList.postValue(Resource.error(response.errorBody().toString(), null))
+        requestAllMyBookmarkPostListUseCase()?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _bookmarkPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toBookmarkPost() })) }
+                is NetworkResponse.NetworkError -> { _bookmarkPostList.postValue(Resource.error(ApiResponse.exception.toString(), null)) }
+                is NetworkResponse.ApiError -> { _bookmarkPostList.postValue(Resource.error(ApiResponse.error.toString(), null)) }
+                is NetworkResponse.UnknownError -> { _bookmarkPostList.postValue(Resource.error(ApiResponse.throwable.toString(), null)) }
+            }
         }
     }
 
     fun requestBlockMember(memberId: String) = viewModelScope.launch {
-        if (requestBlockMemberUseCase(memberId).isSuccessful) {
-            _blockSuccess.postValue(Event(true))
-        } else {
-            _blockSuccess.postValue(Event(false))
+        requestBlockMemberUseCase(memberId)?.let {  ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _blockSuccess.postValue(Event(true)) }
+                is NetworkResponse.NetworkError -> { _blockSuccess.postValue(Event(false)) }
+                is NetworkResponse.ApiError -> { _blockSuccess.postValue(Event(false)) }
+                is NetworkResponse.UnknownError -> { _blockSuccess.postValue(Event(false)) }
+            }
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ReportViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.data.datasource.remote.report.CreateReportMemberRequest
 import com.daily.dayo.data.datasource.remote.report.CreateReportPostRequest
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.usecase.report.RequestSaveMemberReportUseCase
 import com.daily.dayo.domain.usecase.report.RequestSavePostReportUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,11 +31,10 @@ class ReportViewModel @Inject constructor(
                 comment = comment,
                 memberId = memberId
             )
-        ).let {
-            if (it.isSuccessful) {
-                _reportMemberSuccess.postValue(true)
-            } else {
-                _reportMemberSuccess.postValue(false)
+        )?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _reportMemberSuccess.postValue(true) }
+                else -> { _reportMemberSuccess.postValue(false) }
             }
         }
     }
@@ -45,11 +45,10 @@ class ReportViewModel @Inject constructor(
                 comment = comment,
                 postId = postId
             )
-        ).let {
-            if (it.isSuccessful) {
-                _reportPostSuccess.postValue(true)
-            } else {
-                _reportPostSuccess.postValue(false)
+        )?.let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> { _reportPostSuccess.postValue(true) }
+                else -> { _reportPostSuccess.postValue(false) }
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/SettingNotificationViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/SettingNotificationViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.common.Event
 import com.daily.dayo.common.Resource
+import com.daily.dayo.common.Status
 import com.daily.dayo.data.datasource.remote.member.ChangeReceiveAlarmRequest
 import com.daily.dayo.data.datasource.remote.member.DeviceTokenRequest
 import com.daily.dayo.domain.usecase.member.*
@@ -32,9 +33,11 @@ class SettingNotificationViewModel @Inject constructor(
     }
 
     fun requestReceiveAlarm() = viewModelScope.launch {
-        val response = requestReceiveAlarmUseCase().let {
-            if (it.isSuccessful) {
-                _notiReactionPermit.postValue(it.body()?.onReceiveAlarm)
+        requestReceiveAlarmUseCase().let { ApiResponse ->
+            when (ApiResponse.status) {
+                Status.SUCCESS -> {
+                    _notiReactionPermit.postValue(ApiResponse.data?.onReceiveAlarm)
+                }
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/SettingNotificationViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/SettingNotificationViewModel.kt
@@ -5,10 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daily.dayo.common.Event
-import com.daily.dayo.common.Resource
-import com.daily.dayo.common.Status
 import com.daily.dayo.data.datasource.remote.member.ChangeReceiveAlarmRequest
 import com.daily.dayo.data.datasource.remote.member.DeviceTokenRequest
+import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.usecase.member.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -34,9 +33,9 @@ class SettingNotificationViewModel @Inject constructor(
 
     fun requestReceiveAlarm() = viewModelScope.launch {
         requestReceiveAlarmUseCase().let { ApiResponse ->
-            when (ApiResponse.status) {
-                Status.SUCCESS -> {
-                    _notiReactionPermit.postValue(ApiResponse.data?.onReceiveAlarm)
+            when (ApiResponse) {
+                is NetworkResponse.Success  -> {
+                    _notiReactionPermit.postValue(ApiResponse.body?.onReceiveAlarm)
                 }
             }
         }


### PR DESCRIPTION
## 내용 및 작업 사항
- `Status` Class에서 API 호출시 발생하는 ERROR와 이외 ERROR들을 구분하기 위해 API_ERROR 추가
   - API 통신간 ERROR와 이외 ERROR를 분기하여 처리할수 있도록 구현
   - API 호출간에 문제가 발생하는 경우 Sentry에 기록될 수 있도록 추가
- `Resource` Class에서 Exception이 발생하는 경우와 API 에러 발생에 따른 응답코드를 넣는 경우에 대해 추가
- Data Layer에서 API 통신을 통해 `Response` 객체로 wrapping되어서 반환된 데이터를 `toResource` 메소드를 통해 `Resource`로 wrapping 시켜주고 Exception이 발생하면 `setExceptionHandling`으로 감싸서 `Resource`로 return 할 수 있도록 처리

## 참고
- setExceptionHandling으로 감싸서 처리하는 부분이 뭔가 보일러플레이트 코드 같은 느낌이 자꾸 들긴하는데 어떻게 더 깔끔하게 처리해야 할 지 감이 안오네요ㅎㅎ;
- `API_ERROR`인 경우에 의도된 상태코드인 경우에는, `Sentry captureMessage`가 작동하지 않도록 하고, `_isApiErrorExceptionOccurred`가 `true`로 설정되지 않도록 해서 서버 연결상태 불안정 토스트가 나오지 않도록 수정해야 합니다

- resolved: #349