### PR TITLE
#359 [bug] Fix Crash issue at signupEmailSetProfileFragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
+++ b/app/src/main/java/com/daily/dayo/data/datasource/remote/member/MemberApiService.kt
@@ -12,7 +12,7 @@ interface MemberApiService {
         @Part("email") email: String,
         @Part("nickname") nickname: String,
         @Part("password") password: String,
-        @Part profileImg: MultipartBody.Part
+        @Part profileImg: MultipartBody.Part?
     ): NetworkResponse<MemberSignupResponse>
 
     @Multipart

--- a/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/daily/dayo/data/repository/MemberRepositoryImpl.kt
@@ -15,7 +15,7 @@ class MemberRepositoryImpl @Inject constructor(
         email: String,
         nickname: String,
         password: String,
-        profileImg: MultipartBody.Part
+        profileImg: MultipartBody.Part?
     ): NetworkResponse<MemberSignupResponse> =
         memberApiService.requestSignupEmail(
             email,

--- a/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/daily/dayo/domain/repository/MemberRepository.kt
@@ -10,7 +10,7 @@ interface MemberRepository {
         email: String,
         nickname: String,
         password: String,
-        profileImg: MultipartBody.Part
+        profileImg: MultipartBody.Part?
     ): NetworkResponse<MemberSignupResponse>
 
     suspend fun requestUpdateMyProfile(

--- a/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
+++ b/app/src/main/java/com/daily/dayo/domain/usecase/member/RequestSignUpEmailUseCase.kt
@@ -18,15 +18,18 @@ class RequestSignUpEmailUseCase @Inject constructor(
         password: String,
         profileImg: File?
     ): NetworkResponse<MemberSignupResponse> {
-        val uploadFile: MultipartBody.Part
+        val uploadFile: MultipartBody.Part?
         val fileNameDivideList: List<String> = profileImg.toString().split("/")
-        val requestBodyFile: RequestBody =
+        val requestBodyFile: RequestBody? = if (profileImg != null) {
             RequestBody.create("image/*".toMediaTypeOrNull(), profileImg!!)
-        uploadFile = MultipartBody.Part.createFormData(
-            "profileImg",
-            fileNameDivideList[fileNameDivideList.size - 1],
-            requestBodyFile
-        )
+        } else null
+        uploadFile = if (requestBodyFile!= null) {
+            MultipartBody.Part.createFormData(
+                "profileImg",
+                fileNameDivideList[fileNameDivideList.size - 1],
+                requestBodyFile
+            )
+        } else null
         return memberRepository.requestSignupEmail(
             email = email,
             nickname = nickname,

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -3,7 +3,9 @@ package com.daily.dayo.presentation.fragment.account.signup
 import android.app.AlertDialog
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.ImageDecoder
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
@@ -39,6 +41,7 @@ import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
+import com.daily.dayo.common.ImageResizeUtil
 
 @AndroidEntryPoint
 class SignupEmailSetProfileFragment : Fragment() {
@@ -63,6 +66,7 @@ class SignupEmailSetProfileFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentSignupEmailSetProfileBinding.inflate(inflater, container, false)
+        initAlertDialog()
         setBackClickListener()
         setNextClickListener()
         setLimitEditTextInputType()
@@ -86,6 +90,11 @@ class SignupEmailSetProfileFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         LoadingAlertDialog.hideLoadingDialog(loadingAlertDialog)
+    }
+
+    private fun initAlertDialog() {
+        loadingAlertDialog = LoadingAlertDialog.createLoadingDialog(requireContext())
+        loadingAlertDialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }
 
     private fun setTextEditorActionListener() {
@@ -130,24 +139,27 @@ class SignupEmailSetProfileFragment : Fragment() {
                                 s.toString().trim()
                             )
                         ) { // 닉네임 양식 검사
-                            if (true) { // TODO : 닉네임 중복검사 통과 코드 작성
-                                setEditTextTheme(
-                                    getString(R.string.my_profile_edit_nickname_message_success),
-                                    true
-                                )
-                                ButtonActivation.setSignupButtonActive(
-                                    requireContext(),
-                                    binding.btnSignupEmailSetProfileNext
-                                )
-                            } else {
-                                setEditTextTheme(
-                                    getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
-                                    false
-                                )
-                                ButtonActivation.setSignupButtonInactive(
-                                    requireContext(),
-                                    binding.btnSignupEmailSetProfileNext
-                                )
+                            loginViewModel.requestCheckNicknameDuplicate(binding.etSignupEmailSetProfileNickname.text.toString().trim())
+                            loginViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
+                                if(isDuplicate) {
+                                    setEditTextTheme(
+                                        getString(R.string.my_profile_edit_nickname_message_success),
+                                        true
+                                    )
+                                    ButtonActivation.setSignupButtonActive(
+                                        requireContext(),
+                                        binding.btnSignupEmailSetProfileNext
+                                    )
+                                } else {
+                                    setEditTextTheme(
+                                        getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
+                                        false
+                                    )
+                                    ButtonActivation.setSignupButtonInactive(
+                                        requireContext(),
+                                        binding.btnSignupEmailSetProfileNext
+                                    )
+                                }
                             }
                         } else {
                             setEditTextTheme(
@@ -286,7 +298,7 @@ class SignupEmailSetProfileFragment : Fragment() {
 
     private fun setNextClickListener() {
         binding.btnSignupEmailSetProfileNext.setOnDebounceClickListener {
-            LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
+            showLoadingDialog()
             var profileImgFile: File? = null
             profileImgFile = if (this::userProfileImageString.isInitialized) {
                 setUploadImagePath(userProfileImageExtension)
@@ -355,5 +367,10 @@ class SignupEmailSetProfileFragment : Fragment() {
                 ).show()
             }
         }
+    }
+
+    private fun showLoadingDialog() {
+        LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
+        LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog)
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -139,27 +139,24 @@ class SignupEmailSetProfileFragment : Fragment() {
                                 s.toString().trim()
                             )
                         ) { // 닉네임 양식 검사
-                            loginViewModel.requestCheckNicknameDuplicate(binding.etSignupEmailSetProfileNickname.text.toString().trim())
-                            loginViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
-                                if(isDuplicate) {
-                                    setEditTextTheme(
-                                        getString(R.string.my_profile_edit_nickname_message_success),
-                                        true
-                                    )
-                                    ButtonActivation.setSignupButtonActive(
-                                        requireContext(),
-                                        binding.btnSignupEmailSetProfileNext
-                                    )
-                                } else {
-                                    setEditTextTheme(
-                                        getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
-                                        false
-                                    )
-                                    ButtonActivation.setSignupButtonInactive(
-                                        requireContext(),
-                                        binding.btnSignupEmailSetProfileNext
-                                    )
-                                }
+                            if (true) { // TODO : 닉네임 중복검사 통과 코드 작성
+                                setEditTextTheme(
+                                    getString(R.string.my_profile_edit_nickname_message_success),
+                                    true
+                                )
+                                ButtonActivation.setSignupButtonActive(
+                                    requireContext(),
+                                    binding.btnSignupEmailSetProfileNext
+                                )
+                            } else {
+                                setEditTextTheme(
+                                    getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
+                                    false
+                                )
+                                ButtonActivation.setSignupButtonInactive(
+                                    requireContext(),
+                                    binding.btnSignupEmailSetProfileNext
+                                )
                             }
                         } else {
                             setEditTextTheme(


### PR DESCRIPTION
## 내용 및 작업사항
- 이메일 회원가입 과정 페이지에서, 프로필 설정간에 튕기는 원인
   - LoadingDialog가 선언되지 않은채로 View Destroy및 다음으로 버튼 클릭시 사용하는 상황에 발생
   - 프로필 이미지를 설정하지 않은 채로 넘어가는 경우에 발생
- LoadingDialog를 View를 Create하는 경우에 init하도록 설정 및 Dialog 사이즈 변경 코드 추가
- 프로필 이미지를 설정하지 않고 넘어가는 경우에 null로 서버에 보내도록 구현

## 참고
- resolved: #359