### PR TITLE
#379 [layout] Create Information Layout

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/extension/NavControllerExtension.kt
+++ b/app/src/main/java/com/daily/dayo/common/extension/NavControllerExtension.kt
@@ -1,0 +1,20 @@
+package com.daily.dayo.common.extension
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+
+@SuppressLint("UnsafeNavigation")
+fun NavController.navigateSafe(@IdRes currentDestinationId: Int, @IdRes action: Int, args: Bundle? = null): Boolean {
+    return try {
+        if (currentDestination?.id == currentDestinationId) {
+            navigate(action, args)
+        }
+        true
+    } catch (t: Throwable) {
+        Log.e("NAVIGATION_SAFE_TAG", "navigation error for action $action")
+        false
+    }
+}

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/SettingFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/SettingFragment.kt
@@ -19,6 +19,7 @@ import com.daily.dayo.common.dialog.DefaultDialogConfirm
 import com.daily.dayo.common.dialog.DefaultDialogExplanationConfirm
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
+import com.daily.dayo.common.extension.navigateSafe
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentSettingBinding
 import com.daily.dayo.presentation.activity.LoginActivity
@@ -43,6 +44,7 @@ class SettingFragment : Fragment() {
         setWithdrawButtonClickListener()
         setNotificationButtonClickListener()
         setBlockButtonClickListener()
+        setInformationButtonClickListener()
         return binding.root
     }
 
@@ -72,6 +74,15 @@ class SettingFragment : Fragment() {
     private fun setBlockButtonClickListener() {
         binding.layoutSettingBlock.setOnDebounceClickListener {
             findNavController().navigate(SettingFragmentDirections.actionSettingFragmentToSettingBlockFragment())
+        }
+    }
+
+    private fun setInformationButtonClickListener() {
+        binding.layoutSettingInformation.setOnDebounceClickListener {
+            findNavController().navigateSafe(
+                currentDestinationId = R.id.SettingFragment,
+                action = R.id.action_settingFragment_to_informationFragment
+            )
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/information/InformationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/information/InformationFragment.kt
@@ -1,0 +1,71 @@
+package com.daily.dayo.presentation.fragment.setting.information
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
+import com.daily.dayo.R
+import com.daily.dayo.common.autoCleared
+import com.daily.dayo.common.extension.navigateSafe
+import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.databinding.FragmentInformationBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class InformationFragment : Fragment() {
+    private var binding by autoCleared<FragmentInformationBinding>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentInformationBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setBackButtonClickListener()
+        setTermsClickListener()
+        setPrivacyClickListener()
+        setAppVersionClickListener()
+    }
+
+    private fun setBackButtonClickListener() {
+        binding.btnInformationBack.setOnDebounceClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun setTermsClickListener() {
+        binding.layoutInformationContentsPolicyTerms.setOnDebounceClickListener {
+            findNavController().navigateSafe(
+                currentDestinationId = R.id.InformationFragment,
+                action = R.id.action_informationFragment_to_policyFragment,
+                args = InformationFragmentDirections.actionInformationFragmentToPolicyFragment(
+                    informationType = "terms"
+                ).arguments
+            )
+        }
+    }
+
+    private fun setPrivacyClickListener() {
+        binding.layoutInformationContentsPolicyPrivacy.setOnDebounceClickListener {
+            findNavController().navigateSafe(
+                currentDestinationId = R.id.InformationFragment,
+                action = R.id.action_informationFragment_to_policyFragment,
+                args = InformationFragmentDirections.actionInformationFragmentToPolicyFragment(
+                    informationType = "privacy"
+                ).arguments
+            )
+        }
+    }
+
+    private fun setAppVersionClickListener() {
+        binding.layoutInformationContentsAppVersion.setOnDebounceClickListener {
+
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_information.xml
+++ b/app/src/main/res/layout/fragment_information.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/white_FFFFFF"
+    tools:context=".presentation.fragment.setting.information.InformationFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_information_action_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0">
+
+            <ImageButton
+                android:id="@+id/btn_information_back"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
+                android:src="@drawable/ic_back_sign"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/tv_information_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/information_title"
+                android:textColor="@color/gray_1_313131"
+                android:textSize="16dp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/layout_scroll_information"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_information_action_bar">
+
+            <LinearLayout
+                android:id="@+id/layout_information_contents"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginHorizontal="18dp"
+                android:layout_marginTop="5dp"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/layout_information_contents_policy_terms"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tv_information_contents_policy_terms_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:lineHeight="22dp"
+                        android:paddingVertical="12dp"
+                        android:text="@string/policy_terms"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="15dp" />
+
+                    <ImageView
+                        android:id="@+id/img_information_contents_policy_terms"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="right"
+                        android:background="@android:color/transparent"
+                        android:paddingStart="17dp"
+                        android:src="@drawable/ic_right_sign_light_gray"
+                        app:tint="@color/gray_5_E8EAEE" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/view_information_contents_policy_terms_horizontal_line"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/gray_6_F0F1F3" />
+
+                <LinearLayout
+                    android:id="@+id/layout_information_contents_policy_privacy"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tv_information_contents_policy_privacy_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:lineHeight="22dp"
+                        android:paddingVertical="12dp"
+                        android:text="@string/policy_privacy"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="15dp" />
+
+                    <ImageView
+                        android:id="@+id/img_information_contents_policy_privacy"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="right"
+                        android:background="@android:color/transparent"
+                        android:paddingStart="17dp"
+                        android:src="@drawable/ic_right_sign_light_gray"
+                        app:tint="@color/gray_5_E8EAEE" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/view_information_contents_policy_privacy_horizontal_line"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/gray_6_F0F1F3" />
+
+                <LinearLayout
+                    android:id="@+id/layout_information_contents_app_version"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tv_information_contents_app_version_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:lineHeight="22dp"
+                        android:paddingVertical="12dp"
+                        android:text="@string/app_version"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="15dp" />
+
+                    <ImageView
+                        android:id="@+id/img_information_contents_app_version"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="right"
+                        android:background="@android:color/transparent"
+                        android:paddingStart="17dp"
+                        android:src="@drawable/ic_right_sign_light_gray"
+                        app:tint="@color/gray_5_E8EAEE" />
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/view_information_contents_app_version_horizontal_line"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/gray_6_F0F1F3" />
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -468,6 +468,14 @@
         <action
             android:id="@+id/action_settingFragment_to_settingBlockFragment"
             app:destination="@+id/SettingBlockFragment" />
+
+        <action
+            android:id="@+id/action_settingFragment_to_informationFragment"
+            app:destination="@id/InformationFragment"
+            app:enterAnim="@anim/translate_from_right_in"
+            app:exitAnim="@anim/translate_to_left_out"
+            app:popEnterAnim="@anim/translate_from_left_in"
+            app:popExitAnim="@anim/translate_to_right_out" />
     </fragment>
 
     <fragment
@@ -614,5 +622,30 @@
             app:exitAnim="@anim/translate_nothing"
             app:popEnterAnim="@anim/translate_nothing"
             app:popExitAnim="@anim/translate_to_right_out" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/InformationFragment"
+        android:name="com.daily.dayo.presentation.fragment.setting.information.InformationFragment"
+        android:label="fragment_information"
+        tools:layout="@layout/fragment_information">
+        <action
+            android:id="@+id/action_informationFragment_to_policyFragment"
+            app:destination="@+id/PolicyFragment"
+            app:enterAnim="@anim/translate_bottom_up"
+            app:exitAnim="@anim/translate_nothing"
+            app:popEnterAnim="@anim/translate_nothing"
+            app:popExitAnim="@anim/translate_top_down"/>
+    </fragment>
+
+    <fragment
+        android:id="@+id/PolicyFragment"
+        android:name="com.daily.dayo.presentation.fragment.policy.PolicyFragment"
+        android:label="fragment_policy"
+        tools:layout="@layout/fragment_policy">
+        <argument
+            android:name="informationType"
+            android:defaultValue="privacy"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="login">로그인</string>
     <string name="like">좋아요</string>
     <string name="comment">댓글</string>
+    <string name="app_version">버전 정보</string>
 
     <!-- Time -->
     <string name="time_format">%d%s</string>
@@ -302,6 +303,9 @@
     <string name="withdraw_reason_other">기타</string>
     <string name="withdraw_reason_other_hint">탈퇴 사유를 작성해주세요. (100자 이내)</string>
     <string name="withdraw_final_message">계정 삭제시 정보가 회원님의 모든 콘텐츠와 활동기록이 함께 삭제됩니다. 삭제된 정보는 복구할 수 없습니다.</string>
+
+    <!-- Information -->
+    <string name="information_title">정보</string>
 
     <!-- Dialog -->
     <string name="dialog_loading_wait">잠시만 기다려주세요</string>


### PR DESCRIPTION
## 내용 및 작업사항
- 정보 페이지 레이아웃 구현
- 기존 구현된 이용약관 및 개인정보 보호방침 페이지로 이동될 수 있도록 `navigation graph`에 해당 Fragment 추가 및 연결

## 참고
- 앱 버전 관련 페이지에 대한 디자인 미구현 상태로 인한 해당 버튼 관련 동작 미구현 처리
- resolved: #379