### PR TITLE
[bug] Fix fade animation is appeared when refreshing posts

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -34,7 +34,13 @@ class HomeDayoPickAdapter(val rankingShowing: Boolean, private val requestManage
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: Post, newItem: Post): Boolean =
-                oldItem == newItem
+                oldItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                } == newItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -35,7 +35,13 @@ class HomeNewAdapter(val rankingShowing: Boolean, private val requestManager: Re
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: Post, newItem: Post): Boolean =
-                oldItem == newItem
+                oldItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                } == newItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                }
         }
     }
 


### PR DESCRIPTION
## 내용
- 홈 화면에서 새로고침을 할때마다 외부적으로 아이템 변경이 일어나지 않았음에도 불구하고 Fade 애니메이션이 보여는 현상 해결

## 작업사항
- 기존 `areContentsTheSame`를 통해 아이템을 비교해 Reclerview에서 보여지는 리스트의 아이템을 업데이트 하였으나, 아이템이 preload된 이미지가 새로고침할때마다 변경되어 아이템이 변경된것으로 인식된 것으로 확인
   - 이에따라 contents 비교시 preload 이미지는 제외하고 아이템 변경을 인식하도록 구현

## 참고
- resolved: #386
- [ListAdapter blink on refresh - StackOverFlow](https://stackoverflow.com/questions/71178205/listadapter-blink-on-refresh)