### PR TITLE
#396 [feature] Change Image options

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
@@ -18,6 +19,8 @@ import com.daily.dayo.R
 
 object GlideLoadUtil {
     private const val BASE_URL_IMG = "http://117.17.198.45:8080/images/"
+    const val HOME_POST_THUMBNAIL_SIZE = 158
+    const val HOME_USER_THUMBNAIL_SIZE = 17
 
     fun loadImageView(
         requestManager: RequestManager,
@@ -71,13 +74,18 @@ object GlideLoadUtil {
         placeholderImg: Int? = null,
         errorImg: Int? = null
     ) {
-        val requestOption = RequestOptions()
-        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
-        if (errorImg != null) requestOption.error(errorImg)
-        if (placeholderImg != null && errorImg != null) {
-            requestOption.placeholder(placeholderImg)
-                .error(errorImg)
-        }
+        val requestOption =
+            if (placeholderImg != null && errorImg != null) {
+                RequestOptions()
+                    .placeholder(placeholderImg)
+                    .error(errorImg)
+            } else if (placeholderImg != null) {
+                RequestOptions().placeholder(placeholderImg)
+            } else if (errorImg != null) {
+                RequestOptions().error(errorImg)
+            } else {
+                RequestOptions()
+            }
 
         requestManager.load(img)
             .override(width, height)
@@ -94,13 +102,18 @@ object GlideLoadUtil {
         placeholderImg: Int? = null,
         errorImg: Int? = null
     ): Bitmap {
-        val requestOption = RequestOptions()
-        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
-        if (errorImg != null) requestOption.error(errorImg)
-        if (placeholderImg != null && errorImg != null) {
-            requestOption.placeholder(placeholderImg)
-                .error(errorImg)
-        }
+        val requestOption =
+            if (placeholderImg != null && errorImg != null) {
+                RequestOptions()
+                    .placeholder(placeholderImg)
+                    .error(errorImg)
+            } else if (placeholderImg != null) {
+                RequestOptions().placeholder(placeholderImg)
+            } else if (errorImg != null) {
+                RequestOptions().error(errorImg)
+            } else {
+                RequestOptions()
+            }
 
         return Glide.with(context)
             .asBitmap()
@@ -138,13 +151,18 @@ object GlideLoadUtil {
         placeholderImg: Int? = null,
         errorImg: Int? = null
     ): Bitmap {
-        val requestOption = RequestOptions()
-        if (placeholderImg != null) requestOption.placeholder(placeholderImg)
-        if (errorImg != null) requestOption.error(errorImg)
-        if (placeholderImg != null && errorImg != null) {
-            requestOption.placeholder(placeholderImg)
-                .error(errorImg)
-        }
+        val requestOption =
+            if (placeholderImg != null && errorImg != null) {
+                RequestOptions()
+                    .placeholder(placeholderImg)
+                    .error(errorImg)
+            } else if (placeholderImg != null) {
+                RequestOptions().placeholder(placeholderImg)
+            } else if (errorImg != null) {
+                RequestOptions().error(errorImg)
+            } else {
+                RequestOptions()
+            }
 
         return requestManager.asBitmap()
             .override(width, height)
@@ -155,6 +173,9 @@ object GlideLoadUtil {
     }
 
     fun loadImagePreload(requestManager: RequestManager, width: Int, height: Int, imgName: String) {
-        requestManager.load("$BASE_URL_IMG${imgName}").preload(width, height)
+        requestManager.asBitmap()
+            .load("$BASE_URL_IMG${imgName}")
+            .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+            .preload(width, height)
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.lottie.LottieAnimationView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
+import com.daily.dayo.common.GlideLoadUtil.HOME_POST_THUMBNAIL_SIZE
+import com.daily.dayo.common.GlideLoadUtil.HOME_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImagePreload
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
@@ -92,23 +94,7 @@ class HomeDayoPickAdapter(
     override fun onBindViewHolder(holder: HomeDayoPickViewHolder, position: Int) {
         val item = getItem(position)
         holder.bind(item, position)
-
-        //Preload
-        if (position <= itemCount) {
-            val endPosition = if (position + 6 > itemCount) {
-                itemCount
-            } else {
-                position + 6
-            }
-            for (i in position until endPosition) {
-                loadImagePreload(
-                    requestManager = requestManager,
-                    width = 158,
-                    height = 158,
-                    imgName = getItem(i).thumbnailImage ?: ""
-                )
-            }
-        }
+        preloadFutureLoadingImages(position)
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -118,6 +104,24 @@ class HomeDayoPickAdapter(
 
     override fun submitList(list: MutableList<Post>?) {
         super.submitList(list?.let { ArrayList(it) })
+    }
+
+    private fun preloadFutureLoadingImages(position: Int) {
+        if (position <= itemCount) {
+            val endPosition = if (position + 6 > itemCount) {
+                itemCount
+            } else {
+                position + 6
+            }
+            for (i in position until endPosition) {
+                loadImagePreload(
+                    requestManager = requestManager,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
+                    imgName = getItem(i).thumbnailImage ?: ""
+                )
+            }
+        }
     }
 
     inner class HomeDayoPickViewHolder(
@@ -255,16 +259,16 @@ class HomeDayoPickAdapter(
                     postImgBitmap = withContext(Dispatchers.IO) {
                         loadImageBackground(
                             requestManager = requestManager,
-                            width = 158,
-                            height = 158,
+                            width = HOME_POST_THUMBNAIL_SIZE,
+                            height = HOME_POST_THUMBNAIL_SIZE,
                             imgName = postContent.thumbnailImage ?: ""
                         )
                     }
                     userThumbnailImgBitmap = withContext(Dispatchers.IO) {
                         loadImageBackground(
                             requestManager = requestManager,
-                            width = 17,
-                            height = 17,
+                            width = HOME_USER_THUMBNAIL_SIZE,
+                            height = HOME_USER_THUMBNAIL_SIZE,
                             imgName = postContent.userProfileImage ?: ""
                         )
                     }
@@ -274,17 +278,18 @@ class HomeDayoPickAdapter(
                     postContent.preLoadThumbnail = null
                     postContent.preLoadUserImg = null
                 }
+
                 loadImageView(
                     requestManager = requestManager,
-                    width = 158,
-                    height = 158,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
                     img = postImgBitmap!!,
                     imgView = postImg
                 )
                 loadImageViewProfile(
                     requestManager = requestManager,
-                    width = 17,
-                    height = 17,
+                    width = HOME_USER_THUMBNAIL_SIZE,
+                    height = HOME_USER_THUMBNAIL_SIZE,
                     img = userThumbnailImgBitmap!!,
                     imgView = userThumbnailImg
                 )

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.lottie.LottieAnimationView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
+import com.daily.dayo.common.GlideLoadUtil.HOME_POST_THUMBNAIL_SIZE
+import com.daily.dayo.common.GlideLoadUtil.HOME_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackgroundProfile
 import com.daily.dayo.common.GlideLoadUtil.loadImagePreload
@@ -93,8 +95,14 @@ class HomeNewAdapter(
     override fun onBindViewHolder(holder: HomeNewViewHolder, position: Int) {
         val item = getItem(position)
         holder.bind(item, position)
+        preloadFutureLoadingImages(position)
+    }
 
-        //Preload
+    override fun submitList(list: MutableList<Post>?) {
+        super.submitList(list?.let { ArrayList(it) })
+    }
+
+    private fun preloadFutureLoadingImages(position: Int) {
         if (position <= itemCount) {
             val endPosition = if (position + 6 > itemCount) {
                 itemCount
@@ -104,16 +112,12 @@ class HomeNewAdapter(
             for (i in position until endPosition) {
                 loadImagePreload(
                     requestManager = requestManager,
-                    width = 158,
-                    height = 158,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
                     imgName = getItem(i).thumbnailImage ?: ""
                 )
             }
         }
-    }
-
-    override fun submitList(list: MutableList<Post>?) {
-        super.submitList(list?.let { ArrayList(it) })
     }
 
     inner class HomeNewViewHolder(
@@ -252,16 +256,16 @@ class HomeNewAdapter(
                     postImgBitmap = withContext(Dispatchers.IO) {
                         loadImageBackground(
                             requestManager = requestManager,
-                            width = 158,
-                            height = 158,
+                            width = HOME_POST_THUMBNAIL_SIZE,
+                            height = HOME_POST_THUMBNAIL_SIZE,
                             imgName = postContent.thumbnailImage ?: ""
                         )
                     }
                     userThumbnailImgBitmap = withContext(Dispatchers.IO) {
                         loadImageBackgroundProfile(
                             requestManager = requestManager,
-                            width = 17,
-                            height = 17,
+                            width = HOME_USER_THUMBNAIL_SIZE,
+                            height = HOME_USER_THUMBNAIL_SIZE,
                             imgName = postContent.userProfileImage ?: ""
                         )
                     }
@@ -273,15 +277,15 @@ class HomeNewAdapter(
                 }
                 loadImageView(
                     requestManager = requestManager,
-                    width = 158,
-                    height = 158,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
                     img = postImgBitmap!!,
                     imgView = postImg
                 )
                 loadImageViewProfile(
                     requestManager = requestManager,
-                    width = 17,
-                    height = 17,
+                    width = HOME_USER_THUMBNAIL_SIZE,
+                    height = HOME_USER_THUMBNAIL_SIZE,
                     img = userThumbnailImgBitmap!!,
                     imgView = userThumbnailImg
                 )

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -94,7 +94,7 @@ class HomeDayoPickPostListFragment : Fragment() {
                     Status.SUCCESS -> {
                         it.data?.let { postList ->
                             binding.swipeRefreshLayoutDayoPickPost.isRefreshing = false
-                            loadPostThumbnail(postList)
+                            loadInitialPostThumbnail(postList)
                         }
                     }
                     Status.LOADING -> {
@@ -157,7 +157,7 @@ class HomeDayoPickPostListFragment : Fragment() {
         })
     }
 
-    private fun loadPostThumbnail(postList: List<Post>) {
+    private fun loadInitialPostThumbnail(postList: List<Post>) {
         val thumbnailImgList = emptyList<Bitmap>().toMutableList()
         val userImgList = emptyList<Bitmap>().toMutableList()
 
@@ -184,10 +184,11 @@ class HomeDayoPickPostListFragment : Fragment() {
             when (throwable) {
                 is CancellationException -> Log.e("Image Loading", "CANCELLED")
                 null -> {
-                    var loadedPostList = postList.toMutableList()
                     for (i in 0 until (if (postList.size >= 6) 6 else postList.size)) {
-                        loadedPostList[i].preLoadThumbnail = thumbnailImgList[i]
-                        loadedPostList[i].preLoadUserImg = userImgList[i]
+                        with(postList[i]) {
+                            preLoadThumbnail = thumbnailImgList[i]
+                            preLoadUserImg = userImgList[i]
+                        }
                     }
                     homeDayoPickAdapter.submitList(postList.toMutableList())
                     stopLoadingView()


### PR DESCRIPTION
## 내용 및 작업사항
- Glide를 사용해 이미지 캐싱시, 이미지 크기가 모든 이미지 리스트 페이지마다 일정하고, 큰 이미지의 경우엔 게시글만 존재함에 따라 디코딩된 이미지만 캐싱하도록 정책 설정
- 기존에 RequestOption이 정상적으로 작동되지 않던 코드 수정
- 리사이징 크기를 상수로 설정해 일괄적으로 설정할 수 있도록 구현

## 참고
- resolved: #396