### PR TITLE
#401 [bug] Fix Network error toast message is always displayed when not logged in app

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -136,7 +136,7 @@ class AccountViewModel @Inject constructor(
                     _loginSuccess.postValue(Event(false))
                 }
                 is NetworkResponse.ApiError -> {
-                    _isApiErrorExceptionOccurred.postValue(Event(true))
+                    if (ApiResponse.code != 401) _isApiErrorExceptionOccurred.postValue(Event(true))
                     _loginSuccess.postValue(Event(false))
                 }
             }


### PR DESCRIPTION
## 내용 및 작업사항
- API 요청에 대한 400번대의 응답코드 값을 모두 API ERROR로 처리함에 따라 발생한 문제
   - 자동 로그인 실행시 Token Refresh 과정에서 로그인이 되어있지 않은 경우 해당 값이 비어있으며 이에 따라 401 응답코드를 받음
   - 따라서 API ERROR로 처리됨에 따라 서버 연결 토스트 메시지가 나오게 되는 현상 발생
   - 이에 대해 401 응답코드로 오는 경우엔 API ERROR로 처리되지 않도록 분기처리

## 참고
- resolved: #401