### PR TITLE
#406 [refactoring] Remove unnecessary dispatchers and Change coroutine scope

### DIFF
--- a/app/src/main/java/com/daily/dayo/data/di/CoroutinesDispatchersModule.kt
+++ b/app/src/main/java/com/daily/dayo/data/di/CoroutinesDispatchersModule.kt
@@ -1,0 +1,30 @@
+package com.daily.dayo.data.di
+
+import com.daily.dayo.common.DispatcherProvider
+import com.daily.dayo.data.datasource.remote.block.BlockApiService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InstallIn(SingletonComponent::class)
+@Module
+object CoroutinesDispatchersModule {
+    @DefaultDispatcher
+    @Provides
+    fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @IoDispatcher
+    @Provides
+    fun providesIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @MainDispatcher
+    @Provides
+    fun providesMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    @MainImmediateDispatcher
+    @Provides
+    fun providesMainImmediateDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+}

--- a/app/src/main/java/com/daily/dayo/data/di/CoroutinesQualifiers.kt
+++ b/app/src/main/java/com/daily/dayo/data/di/CoroutinesQualifiers.kt
@@ -1,0 +1,19 @@
+package com.daily.dayo.data.di
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class DefaultDispatcher
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class IoDispatcher
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class MainDispatcher
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class MainImmediateDispatcher

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
@@ -67,14 +67,14 @@ class BlockListAdapter(
 
         fun bind(blockUser: BlockUser) {
             binding.blockUser = blockUser.nickname
-            CoroutineScope(mainDispatcher).launch {
+            CoroutineScope(ioDispatcher).launch {
                 val profileImgBitmap = GlideLoadUtil.loadImageBackground(
                     requestManager = requestManager,
                     width = 45,
                     height = 45,
                     imgName = blockUser.profileImg ?: ""
                 )
-                withContext(ioDispatcher) {
+                withContext(mainDispatcher) {
                     GlideLoadUtil.loadImageView(
                         requestManager = requestManager,
                         width = 45,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
@@ -67,22 +67,22 @@ class BlockListAdapter(
 
         fun bind(blockUser: BlockUser) {
             binding.blockUser = blockUser.nickname
-            CoroutineScope(ioDispatcher).launch {
-                val profileImgBitmap = GlideLoadUtil.loadImageBackground(
-                    requestManager = requestManager,
-                    width = 45,
-                    height = 45,
-                    imgName = blockUser.profileImg ?: ""
-                )
-                withContext(mainDispatcher) {
-                    GlideLoadUtil.loadImageView(
+            CoroutineScope(mainDispatcher).launch {
+                val profileImgBitmap = withContext(ioDispatcher) {
+                    GlideLoadUtil.loadImageBackground(
                         requestManager = requestManager,
                         width = 45,
                         height = 45,
-                        img = profileImgBitmap,
-                        imgView = binding.imgBlockUserProfile
+                        imgName = blockUser.profileImg ?: ""
                     )
                 }
+                GlideLoadUtil.loadImageView(
+                    requestManager = requestManager,
+                    width = 45,
+                    height = 45,
+                    img = profileImgBitmap,
+                    imgView = binding.imgBlockUserProfile
+                )
             }
             setUnblockButtonClickListener(blockUser)
         }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
@@ -9,14 +9,20 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemBlockBinding
 import com.daily.dayo.domain.model.BlockUser
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class BlockListAdapter(private val requestManager: RequestManager) :
+class BlockListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) :
     RecyclerView.Adapter<BlockListAdapter.BlockListViewHolder>() {
 
     companion object {
@@ -61,22 +67,22 @@ class BlockListAdapter(private val requestManager: RequestManager) :
 
         fun bind(blockUser: BlockUser) {
             binding.blockUser = blockUser.nickname
-            CoroutineScope(Dispatchers.Main).launch {
-                val profileImgBitmap = withContext(Dispatchers.IO) {
-                    GlideLoadUtil.loadImageBackground(
-                        requestManager = requestManager,
-                        width = 45,
-                        height = 45,
-                        imgName = blockUser.profileImg ?: ""
-                    )
-                }
-                GlideLoadUtil.loadImageView(
+            CoroutineScope(mainDispatcher).launch {
+                val profileImgBitmap = GlideLoadUtil.loadImageBackground(
                     requestManager = requestManager,
                     width = 45,
                     height = 45,
-                    img = profileImgBitmap,
-                    imgView = binding.imgBlockUserProfile
+                    imgName = blockUser.profileImg ?: ""
                 )
+                withContext(ioDispatcher) {
+                    GlideLoadUtil.loadImageView(
+                        requestManager = requestManager,
+                        width = 45,
+                        height = 45,
+                        img = profileImgBitmap,
+                        imgView = binding.imgBlockUserProfile
+                    )
+                }
             }
             setUnblockButtonClickListener(blockUser)
         }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
@@ -18,18 +18,23 @@ import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.convertCountPlace
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFeedPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.domain.model.categoryKR
 import com.daily.dayo.presentation.fragment.feed.FeedFragmentDirections
 import com.google.android.material.chip.Chip
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class FeedListAdapter(private val requestManager: RequestManager) :
-    PagingDataAdapter<Post, FeedListAdapter.FeedListViewHolder>(diffCallback) {
+class FeedListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : PagingDataAdapter<Post, FeedListAdapter.FeedListViewHolder>(diffCallback) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Post>() {
             override fun areItemsTheSame(oldItem: Post, newItem: Post) =
@@ -76,10 +81,10 @@ class FeedListAdapter(private val requestManager: RequestManager) :
             binding.commentCountStr =
                 if (post?.commentCount != null) convertCountPlace(post.commentCount) else "0"
             binding.categoryKR = post?.category?.let { categoryKR(it) }
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val postImgBitmap: Bitmap?
                 val userThumbnailImgBitmap: Bitmap?
-                postImgBitmap = withContext(Dispatchers.IO) {
+                postImgBitmap = withContext(ioDispatcher) {
                     loadImageBackground(
                         requestManager = requestManager,
                         width = binding.imgFeedPost.width,
@@ -87,7 +92,7 @@ class FeedListAdapter(private val requestManager: RequestManager) :
                         imgName = post?.thumbnailImage ?: ""
                     )
                 }
-                userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                userThumbnailImgBitmap = withContext(ioDispatcher) {
                     loadImageBackground(
                         requestManager = requestManager,
                         width = binding.imgFeedPostUserProfile.width,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
@@ -13,13 +13,18 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFolderPostBinding
 import com.daily.dayo.domain.model.FolderPost
 import com.daily.dayo.presentation.fragment.mypage.folder.FolderFragmentDirections
 import kotlinx.coroutines.*
 
-class FolderPostListAdapter(private val requestManager: RequestManager) :
-    PagingDataAdapter<FolderPost, FolderPostListAdapter.FolderPostListViewHolder>(diffCallback) {
+class FolderPostListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : PagingDataAdapter<FolderPost, FolderPostListAdapter.FolderPostListViewHolder>(diffCallback) {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<FolderPost>() {
@@ -54,10 +59,10 @@ class FolderPostListAdapter(private val requestManager: RequestManager) :
             binding.layoutFolderPostContentsShimmer.visibility = View.VISIBLE
             binding.imgFolderPost.visibility = View.INVISIBLE
 
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val folderPostImage: Bitmap?
                 if (folderPost?.preLoadThumbnail == null) {
-                    folderPostImage = withContext(Dispatchers.IO) {
+                    folderPostImage = withContext(ioDispatcher) {
                         loadImageBackground(
                             requestManager = requestManager,
                             width = layoutParams.width,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
@@ -12,16 +12,21 @@ import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFollowBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.fragment.mypage.follow.FollowFragmentDirections
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class FollowListAdapter(private val requestManager: RequestManager) :
-    RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
+class FollowListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Follow>() {
@@ -67,8 +72,8 @@ class FollowListAdapter(private val requestManager: RequestManager) :
             binding.follow = follow
             binding.isMine =
                 follow.memberId == DayoApplication.preferences.getCurrentUser().memberId
-            CoroutineScope(Dispatchers.Main).launch {
-                val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+            CoroutineScope(mainDispatcher).launch {
+                val userThumbnailImgBitmap = withContext(ioDispatcher) {
                     loadImageBackground(
                         requestManager = requestManager,
                         width = 40,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -24,19 +24,23 @@ import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.common.extension.navigateSafe
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemMainPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class HomeDayoPickAdapter(
     val rankingShowing: Boolean,
     private val requestManager: RequestManager,
-    private val likeListener: (Int, Boolean) -> Unit
+    private val likeListener: (Int, Boolean) -> Unit,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ListAdapter<Post, HomeDayoPickAdapter.HomeDayoPickViewHolder>(diffCallback) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Post>() {
@@ -252,11 +256,11 @@ class HomeDayoPickAdapter(
             val postImg = binding.imgMainPost
             val userThumbnailImg = binding.imgMainPostUserProfile
 
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val postImgBitmap: Bitmap?
                 val userThumbnailImgBitmap: Bitmap?
                 if (postContent.preLoadThumbnail == null) {
-                    postImgBitmap = withContext(Dispatchers.IO) {
+                    postImgBitmap = withContext(ioDispatcher) {
                         loadImageBackground(
                             requestManager = requestManager,
                             width = HOME_POST_THUMBNAIL_SIZE,
@@ -264,7 +268,7 @@ class HomeDayoPickAdapter(
                             imgName = postContent.thumbnailImage ?: ""
                         )
                     }
-                    userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    userThumbnailImgBitmap = withContext(ioDispatcher) {
                         loadImageBackground(
                             requestManager = requestManager,
                             width = HOME_USER_THUMBNAIL_SIZE,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -25,19 +25,23 @@ import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.common.extension.navigateSafe
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemMainPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class HomeNewAdapter(
     val rankingShowing: Boolean,
     private val requestManager: RequestManager,
-    private val likeListener: (Int, Boolean) -> Unit
+    private val likeListener: (Int, Boolean) -> Unit,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ListAdapter<Post, HomeNewAdapter.HomeNewViewHolder>(diffCallback) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Post>() {
@@ -249,11 +253,11 @@ class HomeNewAdapter(
             val userThumbnailImg = binding.imgMainPostUserProfile
 
 
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val postImgBitmap: Bitmap?
                 val userThumbnailImgBitmap: Bitmap?
                 if (postContent.preLoadThumbnail == null) {
-                    postImgBitmap = withContext(Dispatchers.IO) {
+                    postImgBitmap = withContext(ioDispatcher) {
                         loadImageBackground(
                             requestManager = requestManager,
                             width = HOME_POST_THUMBNAIL_SIZE,
@@ -261,7 +265,7 @@ class HomeNewAdapter(
                             imgName = postContent.thumbnailImage ?: ""
                         )
                     }
-                    userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    userThumbnailImgBitmap = withContext(ioDispatcher) {
                         loadImageBackgroundProfile(
                             requestManager = requestManager,
                             width = HOME_USER_THUMBNAIL_SIZE,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
@@ -18,19 +18,24 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemNotificationBinding
 import com.daily.dayo.domain.model.Notification
 import com.daily.dayo.domain.model.Topic
 import com.daily.dayo.presentation.fragment.notification.NotificationFragmentDirections
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class NotificationListAdapter(private val requestManager: RequestManager) :
-    PagingDataAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
-        diffCallback
-    ) {
+class NotificationListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : PagingDataAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
+    diffCallback
+) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Notification>() {
             override fun areItemsTheSame(oldItem: Notification, newItem: Notification) =
@@ -70,8 +75,8 @@ class NotificationListAdapter(private val requestManager: RequestManager) :
                     ViewGroup.MarginLayoutParams.MATCH_PARENT,
                     ViewGroup.MarginLayoutParams.MATCH_PARENT
                 )
-                CoroutineScope(Dispatchers.Main).launch {
-                    val thumbnailImage = withContext(Dispatchers.IO) {
+                CoroutineScope(mainDispatcher).launch {
+                    val thumbnailImage = withContext(ioDispatcher) {
                         GlideLoadUtil.loadImageBackground(
                             requestManager = requestManager,
                             width = 56,
@@ -102,7 +107,10 @@ class NotificationListAdapter(private val requestManager: RequestManager) :
                     }
 
                     override fun updateDrawState(textPaint: TextPaint) {
-                        textPaint.color = ContextCompat.getColor(binding.tvNotificationTitle.context, R.color.gray_1_313131)
+                        textPaint.color = ContextCompat.getColor(
+                            binding.tvNotificationTitle.context,
+                            R.color.gray_1_313131
+                        )
                         textPaint.isUnderlineText = false
                         textPaint.typeface = Typeface.DEFAULT_BOLD
                     }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostCommentAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostCommentAdapter.kt
@@ -13,17 +13,22 @@ import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemPostCommentBinding
 import com.daily.dayo.domain.model.Comment
 import com.daily.dayo.presentation.fragment.post.PostFragmentDirections
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PostCommentAdapter(private val requestManager: RequestManager) :
-    ListAdapter<Comment, PostCommentAdapter.PostCommentViewHolder>(
+class PostCommentAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : ListAdapter<Comment, PostCommentAdapter.PostCommentViewHolder>(
         diffCallback
     ) {
     companion object {
@@ -78,8 +83,8 @@ class PostCommentAdapter(private val requestManager: RequestManager) :
                 layoutPostCommentDelete.setOnDebounceClickListener {
                     Snackbar.make(it, "삭제버튼 클릭", Snackbar.LENGTH_SHORT).show()
                 }
-                CoroutineScope(Dispatchers.Main).launch {
-                    val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                CoroutineScope(mainDispatcher).launch {
+                    val userThumbnailImgBitmap = withContext(ioDispatcher) {
                         GlideLoadUtil.loadImageBackground(
                             requestManager = requestManager,
                             width = 40,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
@@ -14,14 +14,19 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemPostImageSliderBinding
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PostImageSliderAdapter(private val requestManager: RequestManager) :
-    ListAdapter<String, PostImageSliderAdapter.PostImageViewHolder>(
+class PostImageSliderAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : ListAdapter<String, PostImageSliderAdapter.PostImageViewHolder>(
         diffCallback
     ) {
     companion object {
@@ -81,8 +86,8 @@ class PostImageSliderAdapter(private val requestManager: RequestManager) :
                 ViewGroup.MarginLayoutParams.MATCH_PARENT,
                 ViewGroup.MarginLayoutParams.MATCH_PARENT
             )
-            CoroutineScope(Dispatchers.Main).launch {
-                val postImage = withContext(Dispatchers.IO) {
+            CoroutineScope(mainDispatcher).launch {
+                val postImage = withContext(ioDispatcher) {
                     GlideLoadUtil.loadImageBackground(
                         requestManager = requestManager,
                         width = layoutParams.width,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
@@ -11,12 +11,17 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfilePostBinding
 import com.daily.dayo.domain.model.BookmarkPost
 import kotlinx.coroutines.*
 
-class ProfileBookmarkPostListAdapter(private val requestManager: RequestManager) :
-    PagingDataAdapter<BookmarkPost, ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>(diffCallback) {
+class ProfileBookmarkPostListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : PagingDataAdapter<BookmarkPost, ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>(diffCallback) {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<BookmarkPost>() {
@@ -65,10 +70,10 @@ class ProfileBookmarkPostListAdapter(private val requestManager: RequestManager)
             }
             binding.imgProfilePost.visibility = View.INVISIBLE
 
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val userThumbnailImgBitmap: Bitmap?
                 if (bookmarkPost?.preLoadThumbnail == null) {
-                    userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    userThumbnailImgBitmap = withContext(ioDispatcher) {
                         GlideLoadUtil.loadImageBackground(
                             requestManager = requestManager,
                             width = layoutParams.width,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
@@ -10,15 +10,20 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfileFolderBinding
 import com.daily.dayo.domain.model.Folder
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class ProfileFolderListAdapter(private val requestManager: RequestManager) :
-    RecyclerView.Adapter<ProfileFolderListAdapter.ProfileFolderListViewHolder>() {
+class ProfileFolderListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : RecyclerView.Adapter<ProfileFolderListAdapter.ProfileFolderListViewHolder>() {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Folder>() {
@@ -67,8 +72,8 @@ class ProfileFolderListAdapter(private val requestManager: RequestManager) :
             )
 
             binding.folder = folder
-            CoroutineScope(Dispatchers.Main).launch {
-                val profileFolderThumbnailImage = withContext(Dispatchers.IO) {
+            CoroutineScope(mainDispatcher).launch {
+                val profileFolderThumbnailImage = withContext(ioDispatcher) {
                     loadImageBackground(
                         requestManager = requestManager,
                         width = layoutParams.width,

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
@@ -12,12 +12,20 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
+import com.daily.dayo.data.di.IoDispatcher
+import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfilePostBinding
 import com.daily.dayo.domain.model.LikePost
 import kotlinx.coroutines.*
 
-class ProfileLikePostListAdapter(private val requestManager: RequestManager) :
-    PagingDataAdapter<LikePost, ProfileLikePostListAdapter.ProfileLikePostListViewHolder>(diffCallback) {
+class ProfileLikePostListAdapter(
+    private val requestManager: RequestManager,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) :
+    PagingDataAdapter<LikePost, ProfileLikePostListAdapter.ProfileLikePostListViewHolder>(
+        diffCallback
+    ) {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<LikePost>() {
@@ -65,10 +73,10 @@ class ProfileLikePostListAdapter(private val requestManager: RequestManager) :
             binding.layoutProfilePostShimmer.visibility = View.VISIBLE
             binding.imgProfilePost.visibility = View.INVISIBLE
 
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(mainDispatcher).launch {
                 val profileListPostImage: Bitmap?
                 if (likePost.preLoadThumbnail == null) {
-                    profileListPostImage = withContext(Dispatchers.IO) {
+                    profileListPostImage = withContext(ioDispatcher) {
                         loadImageBackground(
                             requestManager = requestManager,
                             width = layoutParams.width,

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -22,6 +22,7 @@ import com.daily.dayo.presentation.adapter.FeedListAdapter
 import com.daily.dayo.presentation.viewmodel.FeedViewModel
 import com.google.android.material.chip.Chip
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class FeedFragment : Fragment() {
@@ -62,7 +63,11 @@ class FeedFragment : Fragment() {
     }
 
     private fun setRvFeedListAdapter() {
-        feedListAdapter = FeedListAdapter(requestManager = glideRequestManager)
+        feedListAdapter = FeedListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvFeedPost.adapter = feedListAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -85,7 +85,13 @@ class HomeDayoPickPostListFragment : Fragment() {
     }
 
     private fun setRvDayoPickPostAdapter() {
-        homeDayoPickAdapter = HomeDayoPickAdapter(true, mGlideRequestManager, this::toggleLikeStatus)
+        homeDayoPickAdapter = HomeDayoPickAdapter(
+            rankingShowing = true,
+            requestManager = mGlideRequestManager,
+            likeListener = this::toggleLikeStatus,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvDayopickPost.adapter = homeDayoPickAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
@@ -17,7 +17,9 @@ import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
@@ -108,25 +110,28 @@ class FolderEditFragment : Fragment() {
                                 Privacy.ONLY_ME -> binding.radiobuttonFolderSettingAddSetPrivateOnlyMe.isChecked =
                                     true
                             }
-                            CoroutineScope(Dispatchers.Main).launch {
-                                val folderThumbnailImage = withContext(Dispatchers.IO) {
-                                    loadImageBackground(
+                            viewLifecycleOwner.lifecycleScope.launch {
+                                viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                    val folderThumbnailImage = withContext(Dispatchers.IO) {
+                                        loadImageBackground(
+                                            requestManager = glideRequestManager,
+                                            width = layoutParams.width,
+                                            height = 40,
+                                            imgName = folder.thumbnailImage
+                                        )
+                                    }
+                                    loadImageView(
                                         requestManager = glideRequestManager,
                                         width = layoutParams.width,
-                                        height = 40,
-                                        imgName = folder.thumbnailImage
+                                        height = 148,
+                                        img = folderThumbnailImage,
+                                        imgView = binding.ivFolderSettingThumbnail
                                     )
                                 }
-                                loadImageView(
-                                    requestManager = glideRequestManager,
-                                    width = layoutParams.width,
-                                    height = 148,
-                                    img = folderThumbnailImage,
-                                    imgView = binding.ivFolderSettingThumbnail
-                                )
                             }
                         }
                     }
+                    else -> { }
                 }
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
@@ -119,7 +119,11 @@ class FolderFragment : Fragment() {
     }
 
     private fun setRvFolderPostListAdapter() {
-        folderPostListAdapter = FolderPostListAdapter(requestManager = glideRequestManager)
+        folderPostListAdapter = FolderPostListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvFolderPost.adapter = folderPostListAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
@@ -7,6 +7,9 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.paging.LoadState
@@ -88,22 +91,24 @@ class FolderFragment : Fragment() {
                     it.data?.let { folder ->
                         binding.folder = folder
                         binding.isMine = folder.memberId == DayoApplication.preferences.getCurrentUser().memberId
-                        CoroutineScope(Dispatchers.Main).launch {
-                            val folderThumbnailImage = withContext(Dispatchers.IO) {
-                                loadImageBackground(
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                val folderThumbnailImage = withContext(Dispatchers.IO) {
+                                    loadImageBackground(
+                                        requestManager = glideRequestManager,
+                                        width = layoutParams.width,
+                                        height = 200,
+                                        imgName = folder.thumbnailImage
+                                    )
+                                }
+                                loadImageView(
                                     requestManager = glideRequestManager,
                                     width = layoutParams.width,
                                     height = 200,
-                                    imgName = folder.thumbnailImage
+                                    img = folderThumbnailImage,
+                                    imgView = binding.imgFolderThumbnail
                                 )
                             }
-                            loadImageView(
-                                requestManager = glideRequestManager,
-                                width = layoutParams.width,
-                                height = 200,
-                                img = folderThumbnailImage,
-                                imgView = binding.imgFolderThumbnail
-                            )
                         }
                         if (folder.memberId == DayoApplication.preferences.getCurrentUser().memberId) binding.btnFolderOption.isVisible =
                             true

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
@@ -18,6 +18,7 @@ import com.daily.dayo.databinding.FragmentFollowerListBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.adapter.FollowListAdapter
 import com.daily.dayo.presentation.viewmodel.FollowViewModel
+import kotlinx.coroutines.Dispatchers
 
 class FollowerListFragment : Fragment(){
     private var binding by autoCleared<FragmentFollowerListBinding>()
@@ -46,7 +47,11 @@ class FollowerListFragment : Fragment(){
     }
 
     private fun setRvFollowerListAdapter(){
-        followerListAdapter = FollowListAdapter(requestManager = glideRequestManager)
+        followerListAdapter = FollowListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvFollower.adapter = followerListAdapter
         followerListAdapter.setOnItemClickListener(object : FollowListAdapter.OnItemClickListener{
             override fun onItemClick(checkbox: CheckBox, follow: Follow, position: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
@@ -18,6 +18,7 @@ import com.daily.dayo.databinding.FragmentFollowingListBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.adapter.FollowListAdapter
 import com.daily.dayo.presentation.viewmodel.FollowViewModel
+import kotlinx.coroutines.Dispatchers
 
 class FollowingListFragment : Fragment() {
     private var binding by autoCleared<FragmentFollowingListBinding>()
@@ -46,7 +47,11 @@ class FollowingListFragment : Fragment() {
     }
 
     private fun setRvFollowingListAdapter(){
-        followingListAdapter = FollowListAdapter(requestManager = glideRequestManager)
+        followingListAdapter = FollowListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvFollowing.adapter = followingListAdapter
         followingListAdapter.setOnItemClickListener(object : FollowListAdapter.OnItemClickListener{
             override fun onItemClick(checkbox: CheckBox, follow: Follow, position: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
@@ -6,6 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
@@ -21,7 +24,6 @@ import com.daily.dayo.presentation.adapter.ProfileFragmentPagerStateAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -61,20 +63,22 @@ class MyPageFragment : Fragment() {
         profileViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
                 binding.profile = profile
-                CoroutineScope(Dispatchers.Main).launch {
-                    val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                        loadImageBackgroundProfile(
+                viewLifecycleOwner.lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        val userProfileThumbnailImage = withContext(Dispatchers.IO) {
+                            loadImageBackgroundProfile(
+                                requestManager = glideRequestManager,
+                                width = 70, height = 70, imgName = profile.profileImg
+                            )
+                        }
+                        loadImageViewProfile(
                             requestManager = glideRequestManager,
-                            width = 70, height = 70, imgName = profile.profileImg
+                            width = 70,
+                            height = 70,
+                            img = userProfileThumbnailImage,
+                            imgView = binding.imgMyPageUserProfile
                         )
                     }
-                    loadImageViewProfile(
-                        requestManager = glideRequestManager,
-                        width = 70,
-                        height = 70,
-                        img = userProfileThumbnailImage,
-                        imgView = binding.imgMyPageUserProfile
-                    )
                 }
 
                 setFollowerCountButtonClickListener(

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
@@ -15,6 +15,7 @@ import com.daily.dayo.databinding.FragmentProfileBookmarkPostListBinding
 import com.daily.dayo.domain.model.BookmarkPost
 import com.daily.dayo.presentation.adapter.ProfileBookmarkPostListAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
+import kotlinx.coroutines.Dispatchers
 
 class ProfileBookmarkPostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileBookmarkPostListBinding>()
@@ -44,7 +45,11 @@ class ProfileBookmarkPostListFragment : Fragment() {
     }
 
     private fun setRvProfileBookmarkPostListAdapter() {
-        profileBookmarkPostListAdapter = ProfileBookmarkPostListAdapter(requestManager = glideRequestManager)
+        profileBookmarkPostListAdapter = ProfileBookmarkPostListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvProfileBookmarkPost.adapter = profileBookmarkPostListAdapter
         profileBookmarkPostListAdapter.setOnItemClickListener(object : ProfileBookmarkPostListAdapter.OnItemClickListener {
             override fun onItemClick(v: View, bookmarkPost: BookmarkPost, pos: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -21,6 +21,9 @@ import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
@@ -37,7 +40,6 @@ import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentProfileEditBinding
 import com.daily.dayo.presentation.viewmodel.ProfileSettingViewModel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -119,22 +121,24 @@ class ProfileEditFragment : Fragment() {
         profileSettingViewModel.requestProfile(memberId = DayoApplication.preferences.getCurrentUser().memberId!!)
         profileSettingViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
-                CoroutineScope(Dispatchers.Main).launch {
-                    val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                        GlideLoadUtil.loadImageBackgroundProfile(
+                viewLifecycleOwner.lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        val userProfileThumbnailImage = withContext(Dispatchers.IO) {
+                            GlideLoadUtil.loadImageBackgroundProfile(
+                                requestManager = glideRequestManager,
+                                width = 100,
+                                height = 100,
+                                imgName = profile.profileImg
+                            )
+                        }
+                        GlideLoadUtil.loadImageViewProfile(
                             requestManager = glideRequestManager,
                             width = 100,
                             height = 100,
-                            imgName = profile.profileImg
+                            img = userProfileThumbnailImage,
+                            imgView = binding.imgProfileEditUserImage
                         )
                     }
-                    GlideLoadUtil.loadImageViewProfile(
-                        requestManager = glideRequestManager,
-                        width = 100,
-                        height = 100,
-                        img = userProfileThumbnailImage,
-                        imgView = binding.imgProfileEditUserImage
-                    )
                 }
                 binding.etProfileEditNickname.setText(profile.nickname)
             }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.databinding.FragmentProfileFolderListBinding
 import com.daily.dayo.domain.model.Folder
 import com.daily.dayo.presentation.adapter.ProfileFolderListAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
+import kotlinx.coroutines.Dispatchers
 
 class ProfileFolderListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileFolderListBinding>()
@@ -39,7 +40,11 @@ class ProfileFolderListFragment : Fragment() {
     }
 
     private fun setRvProfileFolderListAdapter() {
-        profileFolderListAdapter = ProfileFolderListAdapter(requestManager = glideRequestManager)
+        profileFolderListAdapter = ProfileFolderListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvProfileFolder.adapter = profileFolderListAdapter
         profileFolderListAdapter.setOnItemClickListener(object : ProfileFolderListAdapter.OnItemClickListener {
             override fun onItemClick(v: View, folder: Folder, pos: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
@@ -185,7 +185,11 @@ class ProfileFragment : Fragment() {
     }
 
     private fun setRvProfileFolderListAdapter() {
-        profileFolderListAdapter = ProfileFolderListAdapter(requestManager = glideRequestManager)
+        profileFolderListAdapter = ProfileFolderListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvProfileFolder.adapter = profileFolderListAdapter
         profileFolderListAdapter.setOnItemClickListener(object :
             ProfileFolderListAdapter.OnItemClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
@@ -28,7 +28,6 @@ import com.daily.dayo.presentation.adapter.ProfileFragmentPagerStateAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -96,7 +95,7 @@ class ProfileFragment : Fragment() {
         profileViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
                 binding.profile = profile
-                CoroutineScope(Dispatchers.Main).launch {
+                viewLifecycleOwner.lifecycleScope.launch {
                     val userProfileThumbnailImage = withContext(Dispatchers.IO) {
                         loadImageBackgroundProfile(
                             requestManager = glideRequestManager,

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
@@ -15,6 +15,7 @@ import com.daily.dayo.databinding.FragmentProfileLikePostListBinding
 import com.daily.dayo.domain.model.LikePost
 import com.daily.dayo.presentation.adapter.ProfileLikePostListAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
+import kotlinx.coroutines.Dispatchers
 
 class ProfileLikePostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileLikePostListBinding>()
@@ -44,7 +45,11 @@ class ProfileLikePostListFragment : Fragment() {
     }
 
     private fun setRvProfileLikePostListAdapter() {
-        profileLikePostListAdapter = ProfileLikePostListAdapter(requestManager = glideRequestManager)
+        profileLikePostListAdapter = ProfileLikePostListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvProfileLikePost.adapter = profileLikePostListAdapter
         profileLikePostListAdapter.setOnItemClickListener(object :
             ProfileLikePostListAdapter.OnItemClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
@@ -15,6 +15,7 @@ import com.daily.dayo.databinding.FragmentNotificationBinding
 import com.daily.dayo.presentation.adapter.NotificationListAdapter
 import com.daily.dayo.presentation.viewmodel.NotificationViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 
 @AndroidEntryPoint
 class NotificationFragment : Fragment() {
@@ -50,7 +51,11 @@ class NotificationFragment : Fragment() {
     }
 
     private fun setNotificationListAdapter() {
-        notificationAdapter = NotificationListAdapter(requestManager = glideRequestManager)
+        notificationAdapter = NotificationListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvNotificationList.layoutManager = LinearLayoutManager(requireContext())
         binding.rvNotificationList.adapter = notificationAdapter
         notificationAdapter.setOnItemClickListener(object :

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
@@ -36,6 +36,7 @@ import com.daily.dayo.common.*
 import com.daily.dayo.common.dialog.DefaultDialogConfigure
 import com.daily.dayo.common.dialog.DefaultDialogConfirm
 import com.daily.dayo.common.dialog.LoadingAlertDialog
+import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.databinding.FragmentPostBinding
 import com.daily.dayo.domain.model.Comment
 import com.daily.dayo.domain.model.categoryKR
@@ -46,7 +47,7 @@ import com.daily.dayo.presentation.viewmodel.PostViewModel
 import com.google.android.material.chip.Chip
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -90,9 +91,9 @@ class PostFragment : Fragment() {
         setBackButtonClickListener()
         setCommentListAdapter()
         setImageSlider()
-        setPostDetailCollect()
+        setPostDetailCollect(Dispatchers.IO)
         setPostCommentCollect()
-        setCreatePostComment()
+        setCreatePostComment(Dispatchers.IO)
         setPostCommentClickListener()
 
         return binding.root
@@ -129,7 +130,11 @@ class PostFragment : Fragment() {
     }
 
     private fun setCommentListAdapter() {
-        postCommentAdapter = PostCommentAdapter(requestManager = glideRequestManager)
+        postCommentAdapter = PostCommentAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvPostCommentList.layoutManager = LinearLayoutManager(requireContext())
         binding.rvPostCommentList.adapter = postCommentAdapter
     }
@@ -150,7 +155,7 @@ class PostFragment : Fragment() {
         }
     }
 
-    private fun setPostDetailCollect() {
+    private fun setPostDetailCollect(@IoDispatcher ioDispatcher: CoroutineDispatcher) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 postViewModel.requestPostDetail(args.postId)
@@ -164,7 +169,7 @@ class PostFragment : Fragment() {
                                 postImageSliderAdapter.submitList(post.postImages)
                                 viewLifecycleOwner.lifecycleScope.launch {
                                     viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                        val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                                        val userThumbnailImgBitmap = withContext(ioDispatcher) {
                                             GlideLoadUtil.loadImageBackground(
                                                 requestManager = glideRequestManager,
                                                 width = 40,
@@ -321,7 +326,11 @@ class PostFragment : Fragment() {
     }
 
     private fun setImageSlider() {
-        postImageSliderAdapter = PostImageSliderAdapter(requestManager = glideRequestManager)
+        postImageSliderAdapter = PostImageSliderAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         with(binding.vpPostImage) {
             adapter = postImageSliderAdapter
             offscreenPageLimit = 1
@@ -439,10 +448,10 @@ class PostFragment : Fragment() {
         }
     }
 
-    private fun setCreatePostComment() {
+    private fun setCreatePostComment(@IoDispatcher ioDispatcher: CoroutineDispatcher) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                val userThumbnailImgBitmap = withContext(ioDispatcher) {
                     GlideLoadUtil.loadImageBackground(
                         requestManager = glideRequestManager,
                         width = 40,

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
@@ -162,22 +162,24 @@ class PostFragment : Fragment() {
                                 binding.categoryKR = post.category?.let { it1 -> categoryKR(it1) }
                                 binding.executePendingBindings()
                                 postImageSliderAdapter.submitList(post.postImages)
-                                CoroutineScope(Dispatchers.Main).launch {
-                                    val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
-                                        GlideLoadUtil.loadImageBackground(
+                                viewLifecycleOwner.lifecycleScope.launch {
+                                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                        val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                                            GlideLoadUtil.loadImageBackground(
+                                                requestManager = glideRequestManager,
+                                                width = 40,
+                                                height = 40,
+                                                imgName = post.userProfileImage
+                                            )
+                                        }
+                                        GlideLoadUtil.loadImageViewProfile(
                                             requestManager = glideRequestManager,
                                             width = 40,
                                             height = 40,
-                                            imgName = post.userProfileImage
+                                            img = userThumbnailImgBitmap,
+                                            imgView = binding.imgPostUserProfile
                                         )
                                     }
-                                    GlideLoadUtil.loadImageViewProfile(
-                                        requestManager = glideRequestManager,
-                                        width = 40,
-                                        height = 40,
-                                        img = userThumbnailImgBitmap,
-                                        imgView = binding.imgPostUserProfile
-                                    )
                                 }
 
                                 val isMine =
@@ -438,22 +440,24 @@ class PostFragment : Fragment() {
     }
 
     private fun setCreatePostComment() {
-        CoroutineScope(Dispatchers.Main).launch {
-            val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
-                GlideLoadUtil.loadImageBackground(
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                val userThumbnailImgBitmap = withContext(Dispatchers.IO) {
+                    GlideLoadUtil.loadImageBackground(
+                        requestManager = glideRequestManager,
+                        width = 40,
+                        height = 40,
+                        imgName = DayoApplication.preferences.getCurrentUser().profileImg ?: ""
+                    )
+                }
+                GlideLoadUtil.loadImageViewProfile(
                     requestManager = glideRequestManager,
                     width = 40,
                     height = 40,
-                    imgName = DayoApplication.preferences.getCurrentUser().profileImg ?: ""
+                    img = userThumbnailImgBitmap,
+                    imgView = binding.imgPostCommentMyProfile
                 )
             }
-            GlideLoadUtil.loadImageViewProfile(
-                requestManager = glideRequestManager,
-                width = 40,
-                height = 40,
-                img = userThumbnailImgBitmap,
-                imgView = binding.imgPostCommentMyProfile
-            )
         }
 
         binding.tvPostCommentUpload.setOnDebounceClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/block/SettingBlockFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/block/SettingBlockFragment.kt
@@ -19,6 +19,7 @@ import com.daily.dayo.presentation.adapter.BlockListAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileSettingViewModel
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 
 @AndroidEntryPoint
 class SettingBlockFragment : Fragment() {
@@ -54,7 +55,11 @@ class SettingBlockFragment : Fragment() {
     }
 
     private fun setBlockListAdapter() {
-        blockListAdapter = BlockListAdapter(requestManager = glideRequestManager)
+        blockListAdapter = BlockListAdapter(
+            requestManager = glideRequestManager,
+            mainDispatcher = Dispatchers.Main,
+            ioDispatcher = Dispatchers.IO
+        )
         binding.rvBlock.adapter = blockListAdapter
         blockListAdapter.setOnItemClickListener(object :
             BlockListAdapter.OnItemClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
@@ -20,7 +20,10 @@ import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -36,7 +39,6 @@ import com.daily.dayo.presentation.adapter.WriteUploadImageListAdapter
 import com.daily.dayo.presentation.viewmodel.WriteViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
@@ -179,18 +181,20 @@ class WriteFragment : Fragment() {
                                                         .toString()
                                                 )
                                                 lateinit var imageBitmap: Bitmap
-                                                CoroutineScope(Dispatchers.IO).launch {
-                                                    val uploadImage = loadImageBackground(
-                                                        requestManager = glideRequestManager,
-                                                        width = 480,
-                                                        height = 480,
-                                                        imgName = element
-                                                    )
-                                                    imageBitmap = resizeBitmap(uploadImage)
-                                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                                        postImageBitmapToStringList.add(
-                                                            imageBitmap.toBase64String()
+                                                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                                                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                                        val uploadImage = loadImageBackground(
+                                                            requestManager = glideRequestManager,
+                                                            width = 480,
+                                                            height = 480,
+                                                            imgName = element
                                                         )
+                                                        imageBitmap = resizeBitmap(uploadImage)
+                                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                                            postImageBitmapToStringList.add(
+                                                                imageBitmap.toBase64String()
+                                                            )
+                                                        }
                                                     }
                                                 }
                                             }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -10,7 +10,6 @@ import com.daily.dayo.data.datasource.remote.member.*
 import com.daily.dayo.domain.model.NetworkResponse
 import com.daily.dayo.domain.usecase.member.*
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.io.File
@@ -161,7 +160,7 @@ class AccountViewModel @Inject constructor(
     }
 
     fun requestSignupEmail(email: String, nickname: String, password: String, profileImg: File?) =
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             requestSignUpEmailUseCase(email, nickname, password, profileImg).let {  ApiResponse ->
                 when (ApiResponse) {
                     is NetworkResponse.Success -> {
@@ -180,7 +179,7 @@ class AccountViewModel @Inject constructor(
             }
         }
 
-    fun requestCheckEmailDuplicate(email: String) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestCheckEmailDuplicate(email: String) = viewModelScope.launch {
         requestCheckEmailDuplicateUseCase(email).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
@@ -199,7 +198,7 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    fun requestCheckNicknameDuplicate(nickname: String) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestCheckNicknameDuplicate(nickname: String) = viewModelScope.launch {
         requestCheckNicknameDuplicateUseCase(nickname).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
@@ -218,7 +217,7 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    fun requestCertificateEmail(email: String) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestCertificateEmail(email: String) = viewModelScope.launch {
         requestCertificateEmailUseCase(email).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
@@ -246,7 +245,7 @@ class AccountViewModel @Inject constructor(
         registerFcmTokenUseCase()
     }
 
-    fun requestWithdraw(content: String) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestWithdraw(content: String) = viewModelScope.launch {
         requestResignUseCase(content).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/HomeViewModel.kt
@@ -17,7 +17,6 @@ import com.daily.dayo.domain.usecase.post.RequestDayoPickPostListUseCase
 import com.daily.dayo.domain.usecase.post.RequestNewPostListCategoryUseCase
 import com.daily.dayo.domain.usecase.post.RequestNewPostListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -39,14 +38,14 @@ class HomeViewModel @Inject constructor(
     private val _newPostList = MutableLiveData<Resource<List<Post>>>()
     val newPostList: LiveData<Resource<List<Post>>> get() = _newPostList
 
-    fun requestDayoPickPostList() = viewModelScope.launch(Dispatchers.IO) {
+    fun requestDayoPickPostList() = viewModelScope.launch {
         if (currentDayoPickCategory == Category.ALL) {
             requestHomeDayoPickPostList()
         } else {
             requestHomeDayoPickPostListCategory(currentDayoPickCategory)
         }
     }
-    fun requestNewPostList() = viewModelScope.launch(Dispatchers.IO) {
+    fun requestNewPostList() = viewModelScope.launch {
         if (currentNewCategory == Category.ALL) {
             requestHomeNewPostList()
         } else {
@@ -54,7 +53,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun requestHomeNewPostList() = viewModelScope.launch(Dispatchers.IO) {
+    private fun requestHomeNewPostList() = viewModelScope.launch {
         requestNewPostListUseCase()?.let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> { _newPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
@@ -65,7 +64,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun requestHomeNewPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
+    private fun requestHomeNewPostListCategory(category: Category) = viewModelScope.launch {
         requestNewPostListCategoryUseCase(category = category)?.let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> { _newPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
@@ -76,7 +75,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun requestHomeDayoPickPostList() = viewModelScope.launch(Dispatchers.IO) {
+    private fun requestHomeDayoPickPostList() = viewModelScope.launch {
         requestHomeDayoPickPostListUseCase()?.let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> { _dayoPickPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
@@ -87,7 +86,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun requestHomeDayoPickPostListCategory(category: Category) = viewModelScope.launch(Dispatchers.IO) {
+    private fun requestHomeDayoPickPostListCategory(category: Category) = viewModelScope.launch {
         requestDayoPickPostListCategoryUseCase(category = category)?.let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> { _dayoPickPostList.postValue(Resource.success(ApiResponse.body?.data?.map { it.toPost() })) }
@@ -98,11 +97,11 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun requestLikePost(postId: Int) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestLikePost(postId: Int) = viewModelScope.launch {
         val response = requestLikePostUseCase(CreateHeartRequest(postId = postId))
     }
 
-    fun requestUnlikePost(postId: Int) = viewModelScope.launch(Dispatchers.IO) {
+    fun requestUnlikePost(postId: Int) = viewModelScope.launch {
         val response = requestUnlikePostUseCase(postId = postId)
     }
 


### PR DESCRIPTION
## 내용 및 작업 사항
- 불필요한 Dispatcher들에 대해 삭제
   - Retrofit2 사용시, 내부적으로 IO를 알아서 처리하기 때문에 withContext(Dispatchers.IO)로 변경할 필요가 없으므로 해당 부분 삭제 
- 기존의 Coroutine Scope에서 Lifecycle 인식이 가능한 Coroutine Scope로 변경
   - 기존 Fragment및 ViewModel에서 생명주기 인식이 가능하도록 변경
- 기존 하드코딩된 Dispatcher들에 대해 수정
   - 안드로이드 개발자 문서에서 Dispatcher들에 대해 하드코딩하는 것을 지양함에 따라 하드코딩된 Dispatcher들에 대해 수정
- Hilt로 Dispatcher를 Inject하는 경우에 원활하게 사용할 수 있도록 DI Module 추가

## 참고
- #406
- [Retrofit2와 Coroutines 사용 시 스케줄러는 어떻게 처리할까? - 내부 코드로 알아보자](https://thdev.tech/kotlin/2021/01/12/Retrofit-Coroutines/)
- [Do I need to mention the coroutine dispatcher while working with Retrofit and Room?](https://stackoverflow.com/questions/72113443/do-i-need-to-mention-the-coroutine-dispatcher-while-working-with-retrofit-and-ro)
- [Don't hardcode Dispatchers when creating new coroutines or calling withContext](https://developer.android.com/kotlin/coroutines/coroutines-best-practices#inject-dispatchers)