### PR TITLE
[bug] Change Trim bugs

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/ReplaceUnicode.kt
+++ b/app/src/main/java/com/daily/dayo/common/ReplaceUnicode.kt
@@ -1,22 +1,41 @@
 package com.daily.dayo.common
 
+import android.text.Editable
+
 object ReplaceUnicode {
     fun replaceBlankText(originalText: String): String {
         var editedText = originalText
-        editedText = editedText.replace( " ", "")
-        editedText = editedText.replace( "\u00A0", "")
-        editedText = editedText.replace( "\u2000", "")
-        editedText = editedText.replace( "\u2001", "")
-        editedText = editedText.replace( "\u2002", "")
-        editedText = editedText.replace( "\u2003", "")
-        editedText = editedText.replace( "\u2004", "")
-        editedText = editedText.replace( "\u2005", "")
-        editedText = editedText.replace( "\u2006", "")
-        editedText = editedText.replace( "\u200b", "")
+        editedText = editedText.replace(" ", "")
+        editedText = editedText.replace("\u00A0", "")
+        editedText = editedText.replace("\u2000", "")
+        editedText = editedText.replace("\u2001", "")
+        editedText = editedText.replace("\u2002", "")
+        editedText = editedText.replace("\u2003", "")
+        editedText = editedText.replace("\u2004", "")
+        editedText = editedText.replace("\u2005", "")
+        editedText = editedText.replace("\u2006", "")
+        editedText = editedText.replace("\u200b", "")
         return editedText
     }
+
     fun trimBlankText(originalText: String): String {
         var editedText = originalText
+        editedText = editedText.trim()
+        editedText = editedText.trim(' ')
+        editedText = editedText.trim('\u00A0')
+        editedText = editedText.trim('\u2000')
+        editedText = editedText.trim('\u2001')
+        editedText = editedText.trim('\u2002')
+        editedText = editedText.trim('\u2003')
+        editedText = editedText.trim('\u2004')
+        editedText = editedText.trim('\u2005')
+        editedText = editedText.trim('\u2006')
+        editedText = editedText.trim('\u200b')
+        return editedText
+    }
+
+    fun trimBlankText(originalText: Editable?): String {
+        var editedText = (originalText ?: "").toString()
         editedText = editedText.trim()
         editedText = editedText.trim(' ')
         editedText = editedText.trim('\u00A0')

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.convertCountPlace
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.ItemFeedPostBinding
@@ -192,7 +193,7 @@ class FeedListAdapter(private val requestManager: RequestManager) :
                             )
                         )
                         setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12F)
-                        text = "# ${tagList[index].trim()}"
+                        text = "# ${trimBlankText(tagList[index])}"
 
                         setOnDebounceClickListener {
                             listener?.tagPostClick(chip = this)

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailCertificateFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailCertificateFragment.kt
@@ -20,6 +20,7 @@ import com.daily.dayo.databinding.FragmentFindAccountPasswordCheckEmailCertifica
 import com.daily.dayo.presentation.viewmodel.AccountViewModel
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -279,7 +280,7 @@ class FindAccountPasswordCheckEmailCertificateFragment : Fragment() {
         binding.btnLoginEmailFindPasswordCertificateNext.setOnDebounceClickListener {
             Navigation.findNavController(it).navigate(
                 FindAccountPasswordCheckEmailCertificateFragmentDirections.actionFindAccountPasswordCheckEmailCertificateFragmentToFindAccountPasswordNewPasswordFragment(
-                    binding.etLoginEmailFindPasswordCertificateUserInput.text.toString().trim()
+                    trimBlankText(binding.etLoginEmailFindPasswordCertificateUserInput.text)
                 )
             )
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCheckEmailFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
 import android.text.TextWatcher
+import android.util.Patterns
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -17,6 +18,7 @@ import com.daily.dayo.databinding.FragmentFindAccountPasswordCheckEmailBinding
 import com.daily.dayo.presentation.viewmodel.AccountViewModel
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -44,45 +46,53 @@ class FindAccountPasswordCheckEmailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.setOnTouchListener { _, _ ->
-            HideKeyBoardUtil.hide(requireContext(), binding.etFindAccountPasswordCheckEmailUserInput)
-            changeEditTextTitle()
-            SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutFindAccountPasswordCheckEmailUserInput, binding.etFindAccountPasswordCheckEmailUserInput, binding.etFindAccountPasswordCheckEmailUserInput.text.isNullOrEmpty())
+            with(binding.etFindAccountPasswordCheckEmailUserInput) {
+                HideKeyBoardUtil.hide(requireContext(), this)
+                changeEditTextTitle()
+                SetTextInputLayout.setEditTextTheme(
+                    requireContext(),
+                    binding.layoutFindAccountPasswordCheckEmailUserInput,
+                    this,
+                    this.text.isNullOrEmpty()
+                )
+            }
+
             verifyEmailAddress()
             true
         }
     }
 
     private fun setTextEditorActionListener() {
-        binding.etFindAccountPasswordCheckEmailUserInput.setOnEditorActionListener { _, actionId, _ ->
-            when (actionId) {
-                EditorInfo.IME_ACTION_DONE -> {
-                    HideKeyBoardUtil.hide(
-                        requireContext(),
-                        binding.etFindAccountPasswordCheckEmailUserInput
-                    )
-                    changeEditTextTitle()
-                    SetTextInputLayout.setEditTextTheme(
-                        requireContext(),
-                        binding.layoutFindAccountPasswordCheckEmailUserInput,
-                        binding.etFindAccountPasswordCheckEmailUserInput,
-                        binding.etFindAccountPasswordCheckEmailUserInput.text.isNullOrEmpty()
-                    )
-                    verifyEmailAddress()
-                    true
+        with(binding.etFindAccountPasswordCheckEmailUserInput) {
+            this.setOnEditorActionListener { _, actionId, _ ->
+                when (actionId) {
+                    EditorInfo.IME_ACTION_DONE -> {
+                        HideKeyBoardUtil.hide(requireContext(), this)
+                        changeEditTextTitle()
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutFindAccountPasswordCheckEmailUserInput,
+                            this,
+                            this.text.isNullOrEmpty()
+                        )
+                        verifyEmailAddress()
+                        true
+                    }
+                    else -> false
                 }
-                else -> false
             }
         }
     }
 
     private fun initEditText() {
-        SetTextInputLayout.setEditTextTheme(
-            requireContext(),
-            binding.layoutFindAccountPasswordCheckEmailUserInput,
-            binding.etFindAccountPasswordCheckEmailUserInput,
-            binding.etFindAccountPasswordCheckEmailUserInput.text.isNullOrEmpty()
-        )
         with(binding.etFindAccountPasswordCheckEmailUserInput) {
+            SetTextInputLayout.setEditTextTheme(
+                requireContext(),
+                binding.layoutFindAccountPasswordCheckEmailUserInput,
+                this,
+                this.text.isNullOrEmpty()
+            )
+
             setOnFocusChangeListener { _, hasFocus -> // Title
                 with(binding.layoutFindAccountPasswordCheckEmailUserInput) {
                     if (hasFocus) {
@@ -140,12 +150,12 @@ class FindAccountPasswordCheckEmailFragment : Fragment() {
     }
 
     private fun verifyEmailAddress() {
-        if (android.util.Patterns.EMAIL_ADDRESS.matcher(
-                binding.etFindAccountPasswordCheckEmailUserInput.text.toString().trim()
+        if (Patterns.EMAIL_ADDRESS.matcher(
+                trimBlankText(binding.etFindAccountPasswordCheckEmailUserInput.text)
             ).matches()
         ) { // 이메일 주소 양식 검사
             loginViewModel.requestCheckEmail(
-                inputEmail = binding.etFindAccountPasswordCheckEmailUserInput.text.toString().trim()
+                inputEmail = trimBlankText(binding.etFindAccountPasswordCheckEmailUserInput.text)
             )
             loginViewModel.checkEmailSuccess.observe(viewLifecycleOwner) { isSuccess ->
                 if (isSuccess) { // 이메일 가입과 달리 중복검사해서 false 경우에는 있는 이메일 이므로 성공 처리
@@ -210,7 +220,7 @@ class FindAccountPasswordCheckEmailFragment : Fragment() {
         binding.btnFindAccountPasswordCheckEmailNext.setOnDebounceClickListener {
             Navigation.findNavController(it).navigate(
                 FindAccountPasswordCheckEmailFragmentDirections.actionFindAccountPasswordCheckEmailFragmentToFindAccountPasswordCheckEmailCertificateFragment(
-                    binding.etFindAccountPasswordCheckEmailUserInput.text.toString().trim()
+                    trimBlankText(binding.etFindAccountPasswordCheckEmailUserInput.text)
                 )
             )
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordConfirmationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordConfirmationFragment.kt
@@ -17,6 +17,7 @@ import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentFindAccountPasswordNewPasswordConfirmationBinding
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -146,8 +147,7 @@ class FindAccountPasswordNewPasswordConfirmationFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                if (args.password != binding.etFindAccountPasswordNewPasswordConfirmationUserInput.text.toString()
-                        .trim()
+                if (args.password != trimBlankText(binding.etFindAccountPasswordNewPasswordConfirmationUserInput.text)
                 ) { // 동일 비밀번호 검사
                     ButtonActivation.setSignupButtonInactive(
                         requireContext(),
@@ -209,7 +209,7 @@ class FindAccountPasswordNewPasswordConfirmationFragment : Fragment() {
 
     private fun observeChangePasswordSuccess() {
         loginViewModel.changePasswordSuccess.observe(viewLifecycleOwner) { isChangeSuccess ->
-            if(isChangeSuccess) {
+            if (isChangeSuccess) {
                 findNavController().navigate(R.id.action_findAccountPasswordNewPasswordConfirmationFragment_to_findAccountPasswordCompleteFragment)
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordFragment.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentFindAccountPasswordNewPasswordBinding
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -130,7 +131,7 @@ class FindAccountPasswordNewPasswordFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                if (s.toString().trim().length < 8) { // 비밀번호 길이 검사 1에
+                if (trimBlankText(s).length < 8) { // 비밀번호 길이 검사 1에
                     SetTextInputLayout.setEditTextTheme(
                         requireContext(),
                         binding.layoutFindAccountPasswordNewPasswordUserPassword,
@@ -142,7 +143,7 @@ class FindAccountPasswordNewPasswordFragment : Fragment() {
                         requireContext(),
                         binding.btnFindAccountPasswordNewPasswordNext
                     )
-                } else if (s.toString().trim().length > 16) { // 비밀번호 길이 검사 2
+                } else if (trimBlankText(s).length > 16) { // 비밀번호 길이 검사 2
                     SetTextInputLayout.setEditTextErrorTheme(
                         requireContext(),
                         binding.layoutFindAccountPasswordNewPasswordUserPassword,
@@ -154,7 +155,7 @@ class FindAccountPasswordNewPasswordFragment : Fragment() {
                         requireContext(),
                         binding.btnFindAccountPasswordNewPasswordNext
                     )
-                } else if (!Pattern.matches("^[a-z|0-9|]+\$", s.toString().trim())) { // 비밀번호 양식 검사
+                } else if (!Pattern.matches("^[a-z|0-9|]+\$", trimBlankText(s))) { // 비밀번호 양식 검사
                     SetTextInputLayout.setEditTextErrorTheme(
                         requireContext(),
                         binding.layoutFindAccountPasswordNewPasswordUserPassword,
@@ -206,7 +207,7 @@ class FindAccountPasswordNewPasswordFragment : Fragment() {
             Navigation.findNavController(it).navigate(
                 FindAccountPasswordNewPasswordFragmentDirections.actionFindAccountPasswordNewPasswordFragmentToFindAccountPasswordNewPasswordConfirmationFragment(
                     args.email,
-                    binding.etFindAccountPasswordNewPasswordUserPassword.text.toString().trim()
+                    trimBlankText(binding.etFindAccountPasswordNewPasswordUserPassword.text)
                 )
             )
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signin/LoginEmailFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signin/LoginEmailFragment.kt
@@ -19,6 +19,7 @@ import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.databinding.FragmentLoginEmailBinding
@@ -88,8 +89,8 @@ class LoginEmailFragment : Fragment() {
             LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
             isLoginButtonClick = true
             loginViewModel.requestLoginEmail(
-                email = binding.etLoginEmailAddress.text.toString().trim(),
-                password = binding.etLoginEmailPassword.text.toString().trim(),
+                email = trimBlankText(binding.etLoginEmailAddress.text),
+                password = trimBlankText(binding.etLoginEmailPassword.text),
             )
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetEmailAddressFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetEmailAddressFragment.kt
@@ -18,6 +18,7 @@ import com.daily.dayo.databinding.FragmentSignupEmailSetEmailAddressBinding
 import com.daily.dayo.presentation.viewmodel.AccountViewModel
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -47,47 +48,88 @@ class SignupEmailSetEmailAddressFragment : Fragment() {
         view.setOnTouchListener { _, _ ->
             HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetEmailAddressUserInput)
             changeEditTextTitle()
-            SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty())
+            SetTextInputLayout.setEditTextTheme(
+                requireContext(),
+                binding.layoutSignupEmailSetEmailAddressUserInput,
+                binding.etSignupEmailSetEmailAddressUserInput,
+                binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty()
+            )
             verifyEmailAddress()
             true
         }
     }
 
     private fun setTextEditorActionListener() {
-        binding.etSignupEmailSetEmailAddressUserInput.setOnEditorActionListener{ _, actionId, _ ->
-            when(actionId) {
+        binding.etSignupEmailSetEmailAddressUserInput.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
-                    HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetEmailAddressUserInput)
+                    HideKeyBoardUtil.hide(
+                        requireContext(),
+                        binding.etSignupEmailSetEmailAddressUserInput
+                    )
                     changeEditTextTitle()
-                    SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty())
+                    SetTextInputLayout.setEditTextTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetEmailAddressUserInput,
+                        binding.etSignupEmailSetEmailAddressUserInput,
+                        binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty()
+                    )
                     verifyEmailAddress()
                     true
-                } else -> false
+                }
+                else -> false
             }
         }
     }
 
     private fun initEditText() {
-        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty())
+        SetTextInputLayout.setEditTextTheme(
+            requireContext(),
+            binding.layoutSignupEmailSetEmailAddressUserInput,
+            binding.etSignupEmailSetEmailAddressUserInput,
+            binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty()
+        )
         with(binding.etSignupEmailSetEmailAddressUserInput) {
             setOnFocusChangeListener { _, hasFocus -> // Title
                 with(binding.layoutSignupEmailSetEmailAddressUserInput) {
-                    if(hasFocus){
+                    if (hasFocus) {
                         hint = getString(R.string.email)
-                        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, false)
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutSignupEmailSetEmailAddressUserInput,
+                            binding.etSignupEmailSetEmailAddressUserInput,
+                            false
+                        )
                     } else {
                         hint = getString(R.string.email_address_example)
-                        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, true)
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutSignupEmailSetEmailAddressUserInput,
+                            binding.etSignupEmailSetEmailAddressUserInput,
+                            true
+                        )
                     }
                 }
             }
             addTextChangedListener(object : TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {  }
+                override fun beforeTextChanged(
+                    s: CharSequence?,
+                    start: Int,
+                    count: Int,
+                    after: Int
+                ) {
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
                 override fun afterTextChanged(s: Editable?) {
                     with(binding.layoutSignupEmailSetEmailAddressUserInput) {
                         isErrorEnabled = false
-                        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, false)
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutSignupEmailSetEmailAddressUserInput,
+                            binding.etSignupEmailSetEmailAddressUserInput,
+                            false
+                        )
                     }
                 }
             })
@@ -96,7 +138,7 @@ class SignupEmailSetEmailAddressFragment : Fragment() {
 
     private fun changeEditTextTitle() {
         with(binding.layoutSignupEmailSetEmailAddressUserInput) {
-            if(binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty()) {
+            if (binding.etSignupEmailSetEmailAddressUserInput.text.isNullOrEmpty()) {
                 hint = getString(R.string.email_address_example)
             } else {
                 hint = getString(R.string.email)
@@ -105,20 +147,50 @@ class SignupEmailSetEmailAddressFragment : Fragment() {
     }
 
     private fun verifyEmailAddress() {
-        if(android.util.Patterns.EMAIL_ADDRESS.matcher(binding.etSignupEmailSetEmailAddressUserInput.text.toString().trim()).matches()){ // 이메일 주소 양식 검사
-            loginViewModel.requestCheckEmailDuplicate(binding.etSignupEmailSetEmailAddressUserInput.text.toString().trim())
+        if (android.util.Patterns.EMAIL_ADDRESS.matcher(
+                trimBlankText(binding.etSignupEmailSetEmailAddressUserInput.text)
+            ).matches()
+        ) { // 이메일 주소 양식 검사
+            loginViewModel.requestCheckEmailDuplicate(trimBlankText(binding.etSignupEmailSetEmailAddressUserInput.text))
             loginViewModel.isEmailDuplicate.observe(viewLifecycleOwner, Observer { isDuplicate ->
-                if(isDuplicate) {
-                    SetTextInputLayout.setEditTextErrorThemeWithIcon(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, null, true)
-                    ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetEmailAddressNext)
+                if (isDuplicate) {
+                    SetTextInputLayout.setEditTextErrorThemeWithIcon(
+                        requireContext(),
+                        binding.layoutSignupEmailSetEmailAddressUserInput,
+                        binding.etSignupEmailSetEmailAddressUserInput,
+                        null,
+                        true
+                    )
+                    ButtonActivation.setSignupButtonActive(
+                        requireContext(),
+                        binding.btnSignupEmailSetEmailAddressNext
+                    )
                 } else {
-                    SetTextInputLayout.setEditTextErrorThemeWithIcon(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, getString(R.string.signup_email_set_email_address_message_duplicate_fail), false)
-                    ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetEmailAddressNext)
+                    SetTextInputLayout.setEditTextErrorThemeWithIcon(
+                        requireContext(),
+                        binding.layoutSignupEmailSetEmailAddressUserInput,
+                        binding.etSignupEmailSetEmailAddressUserInput,
+                        getString(R.string.signup_email_set_email_address_message_duplicate_fail),
+                        false
+                    )
+                    ButtonActivation.setSignupButtonInactive(
+                        requireContext(),
+                        binding.btnSignupEmailSetEmailAddressNext
+                    )
                 }
             })
         } else {
-            SetTextInputLayout.setEditTextErrorThemeWithIcon(requireContext(), binding.layoutSignupEmailSetEmailAddressUserInput, binding.etSignupEmailSetEmailAddressUserInput, getString(R.string.signup_email_set_email_address_message_format_fail), false)
-            ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetEmailAddressNext)
+            SetTextInputLayout.setEditTextErrorThemeWithIcon(
+                requireContext(),
+                binding.layoutSignupEmailSetEmailAddressUserInput,
+                binding.etSignupEmailSetEmailAddressUserInput,
+                getString(R.string.signup_email_set_email_address_message_format_fail),
+                false
+            )
+            ButtonActivation.setSignupButtonInactive(
+                requireContext(),
+                binding.btnSignupEmailSetEmailAddressNext
+            )
         }
     }
 
@@ -134,7 +206,7 @@ class SignupEmailSetEmailAddressFragment : Fragment() {
         binding.etSignupEmailSetEmailAddressUserInput.filters = arrayOf(filterInputCheck)
     }
 
-    private fun setBackClickListener(){
+    private fun setBackClickListener() {
         binding.btnSignupEmailSetEmailAddressBack.setOnDebounceClickListener {
             findNavController().navigateUp()
         }
@@ -142,7 +214,11 @@ class SignupEmailSetEmailAddressFragment : Fragment() {
 
     private fun setNextClickListener() {
         binding.btnSignupEmailSetEmailAddressNext.setOnDebounceClickListener {
-            Navigation.findNavController(it).navigate(SignupEmailSetEmailAddressFragmentDirections.actionSignupEmailSetEmailAddressFragmentToSignupEmailSetEmailAddressCertificateFragment(binding.etSignupEmailSetEmailAddressUserInput.text.toString().trim()))
+            Navigation.findNavController(it).navigate(
+                SignupEmailSetEmailAddressFragmentDirections.actionSignupEmailSetEmailAddressFragmentToSignupEmailSetEmailAddressCertificateFragment(
+                    trimBlankText(binding.etSignupEmailSetEmailAddressUserInput.text)
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetPasswordConfirmationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetPasswordConfirmationFragment.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentSignupEmailSetPasswordConfirmationBinding
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -94,7 +95,7 @@ class SignupEmailSetPasswordConfirmationFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
             override fun afterTextChanged(s: Editable?) {
-                if(args.password != binding.etSignupEmailSetPasswordConfirmationUserInput.text.toString().trim() ){ // 동일 비밀번호 검사
+                if(args.password != trimBlankText(binding.etSignupEmailSetPasswordConfirmationUserInput.text)){ // 동일 비밀번호 검사
                     ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordConfirmationNext)
                     SetTextInputLayout.setEditTextErrorTheme(requireContext(), binding.layoutSignupEmailSetPasswordConfirmationUserInput, binding.etSignupEmailSetPasswordConfirmationUserInput, getString(R.string.signup_email_set_password_confirmation_message_fail), false)
                 } else {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetPasswordFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetPasswordFragment.kt
@@ -16,6 +16,7 @@ import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentSignupEmailSetPasswordBinding
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -46,34 +47,64 @@ class SignupEmailSetPasswordFragment : Fragment() {
         view.setOnTouchListener { _, _ ->
             HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetPasswordUserPassword)
             changeEditTextTitle()
-            SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty())
+            SetTextInputLayout.setEditTextTheme(
+                requireContext(),
+                binding.layoutSignupEmailSetPasswordUserPassword,
+                binding.etSignupEmailSetPasswordUserPassword,
+                binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty()
+            )
             true
         }
     }
+
     private fun setTextEditorActionListener() {
-        binding.etSignupEmailSetPasswordUserPassword.setOnEditorActionListener {  _, actionId, _ ->
-            when(actionId) {
+        binding.etSignupEmailSetPasswordUserPassword.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
-                    HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetPasswordUserPassword)
+                    HideKeyBoardUtil.hide(
+                        requireContext(),
+                        binding.etSignupEmailSetPasswordUserPassword
+                    )
                     changeEditTextTitle()
-                    SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty())
+                    SetTextInputLayout.setEditTextTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty()
+                    )
                     true
-                } else -> false
+                }
+                else -> false
             }
         }
     }
 
     private fun initEditText() {
-        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty())
+        SetTextInputLayout.setEditTextTheme(
+            requireContext(),
+            binding.layoutSignupEmailSetPasswordUserPassword,
+            binding.etSignupEmailSetPasswordUserPassword,
+            binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty()
+        )
         with(binding.etSignupEmailSetPasswordUserPassword) {
             setOnFocusChangeListener { _, hasFocus -> // EditText Title 설정
                 with(binding.layoutSignupEmailSetPasswordUserPassword) {
-                    if(hasFocus){
+                    if (hasFocus) {
                         hint = getString(R.string.password)
-                        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, false)
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutSignupEmailSetPasswordUserPassword,
+                            binding.etSignupEmailSetPasswordUserPassword,
+                            false
+                        )
                     } else {
                         hint = getString(R.string.signup_email_set_password_message_length_fail_min)
-                        SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, true)
+                        SetTextInputLayout.setEditTextTheme(
+                            requireContext(),
+                            binding.layoutSignupEmailSetPasswordUserPassword,
+                            binding.etSignupEmailSetPasswordUserPassword,
+                            true
+                        )
                     }
                 }
             }
@@ -82,7 +113,7 @@ class SignupEmailSetPasswordFragment : Fragment() {
 
     private fun changeEditTextTitle() {
         with(binding.layoutSignupEmailSetPasswordUserPassword) {
-            if(binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty()) {
+            if (binding.etSignupEmailSetPasswordUserPassword.text.isNullOrEmpty()) {
                 hint = getString(R.string.signup_email_set_password_message_length_fail_min)
             } else {
                 hint = getString(R.string.password)
@@ -92,22 +123,58 @@ class SignupEmailSetPasswordFragment : Fragment() {
 
     private fun verifyPassword() {
         binding.etSignupEmailSetPasswordUserPassword.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                if(s.toString().trim().length < 8){ // 비밀번호 길이 검사 1에
-                    SetTextInputLayout.setEditTextTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, false)
+                if (trimBlankText(s).length < 8) { // 비밀번호 길이 검사 1에
+                    SetTextInputLayout.setEditTextTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword,
+                        false
+                    )
                     // 8자 이하일 때에는 오류 검사 실패시, 에러메시지가 나오지 않도록 디자인 수정
-                    ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordNext)
-                } else if(s.toString().trim().length > 16) { // 비밀번호 길이 검사 2
-                    SetTextInputLayout.setEditTextErrorTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, getString(R.string.signup_email_set_password_message_length_fail_max), false)
-                    ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordNext)
-                } else if(!Pattern.matches("^[a-z|0-9|]+\$", s.toString().trim())) { // 비밀번호 양식 검사
-                    SetTextInputLayout.setEditTextErrorTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, getString(R.string.signup_email_set_password_message_format_fail), false)
-                    ButtonActivation.setSignupButtonInactive(requireContext(), binding.btnSignupEmailSetPasswordNext)
+                    ButtonActivation.setSignupButtonInactive(
+                        requireContext(),
+                        binding.btnSignupEmailSetPasswordNext
+                    )
+                } else if (trimBlankText(s).length > 16) { // 비밀번호 길이 검사 2
+                    SetTextInputLayout.setEditTextErrorTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword,
+                        getString(R.string.signup_email_set_password_message_length_fail_max),
+                        false
+                    )
+                    ButtonActivation.setSignupButtonInactive(
+                        requireContext(),
+                        binding.btnSignupEmailSetPasswordNext
+                    )
+                } else if (!Pattern.matches("^[a-z|0-9|]+\$", trimBlankText(s))
+                ) { // 비밀번호 양식 검사
+                    SetTextInputLayout.setEditTextErrorTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword,
+                        getString(R.string.signup_email_set_password_message_format_fail),
+                        false
+                    )
+                    ButtonActivation.setSignupButtonInactive(
+                        requireContext(),
+                        binding.btnSignupEmailSetPasswordNext
+                    )
                 } else {
-                    SetTextInputLayout.setEditTextErrorTheme(requireContext(), binding.layoutSignupEmailSetPasswordUserPassword, binding.etSignupEmailSetPasswordUserPassword, null, true)
-                    ButtonActivation.setSignupButtonActive(requireContext(), binding.btnSignupEmailSetPasswordNext)
+                    SetTextInputLayout.setEditTextErrorTheme(
+                        requireContext(),
+                        binding.layoutSignupEmailSetPasswordUserPassword,
+                        binding.etSignupEmailSetPasswordUserPassword,
+                        null,
+                        true
+                    )
+                    ButtonActivation.setSignupButtonActive(
+                        requireContext(),
+                        binding.btnSignupEmailSetPasswordNext
+                    )
                 }
             }
         })
@@ -125,7 +192,7 @@ class SignupEmailSetPasswordFragment : Fragment() {
         binding.etSignupEmailSetPasswordUserPassword.filters = arrayOf(filterInputCheck)
     }
 
-    private fun setBackClickListener(){
+    private fun setBackClickListener() {
         binding.btnSignupEmailSetPasswordBack.setOnDebounceClickListener {
             findNavController().navigateUp()
         }
@@ -133,7 +200,12 @@ class SignupEmailSetPasswordFragment : Fragment() {
 
     private fun setNextClickListener() {
         binding.btnSignupEmailSetPasswordNext.setOnDebounceClickListener {
-            Navigation.findNavController(it).navigate(SignupEmailSetPasswordFragmentDirections.actionSignupEmailSetPasswordFragmentToSignupEmailSetPasswordConfirmationFragment(args.email,binding.etSignupEmailSetPasswordUserPassword.text.toString().trim()))
+            Navigation.findNavController(it).navigate(
+                SignupEmailSetPasswordFragmentDirections.actionSignupEmailSetPasswordFragmentToSignupEmailSetPasswordConfirmationFragment(
+                    args.email,
+                    trimBlankText(binding.etSignupEmailSetPasswordUserPassword.text)
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -42,6 +42,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 
 @AndroidEntryPoint
 class SignupEmailSetProfileFragment : Fragment() {
@@ -115,7 +116,7 @@ class SignupEmailSetProfileFragment : Fragment() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 with(binding) {
-                    if (s.toString().trim().length < 2) { // 닉네임 길이 검사 1
+                    if (trimBlankText(s).length < 2) { // 닉네임 길이 검사 1
                         setEditTextTheme(
                             getString(R.string.my_profile_edit_nickname_message_length_fail_min),
                             false
@@ -124,7 +125,7 @@ class SignupEmailSetProfileFragment : Fragment() {
                             requireContext(),
                             binding.btnSignupEmailSetProfileNext
                         )
-                    } else if (s.toString().trim().length > 10) { // 닉네임 길이 검사 2
+                    } else if (trimBlankText(s).length > 10) { // 닉네임 길이 검사 2
                         setEditTextTheme(
                             getString(R.string.my_profile_edit_nickname_message_length_fail_max),
                             false
@@ -134,14 +135,11 @@ class SignupEmailSetProfileFragment : Fragment() {
                             binding.btnSignupEmailSetProfileNext
                         )
                     } else {
-                        if (Pattern.matches(
-                                "^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$",
-                                s.toString().trim()
-                            )
+                        if (Pattern.matches("^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$", trimBlankText(s))
                         ) {
-                            loginViewModel.requestCheckNicknameDuplicate(binding.etSignupEmailSetProfileNickname.text.toString().trim())
+                            loginViewModel.requestCheckNicknameDuplicate(trimBlankText(binding.etSignupEmailSetProfileNickname.text))
                             loginViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
-                                if(isDuplicate) {
+                                if (isDuplicate) {
                                     setEditTextTheme(
                                         getString(R.string.my_profile_edit_nickname_message_success),
                                         true
@@ -314,14 +312,17 @@ class SignupEmailSetProfileFragment : Fragment() {
             if (args.password != null) {
                 loginViewModel.requestSignupEmail(
                     args.email,
-                    binding.etSignupEmailSetProfileNickname.text.toString().trim(),
+                    trimBlankText(binding.etSignupEmailSetProfileNickname.text),
                     args.password!!,
                     profileImgFile
                 )
             } else {
                 // 카카오 계정 회원가입 시 비밀번호가 null
                 profileSettingViewModel.requestUpdateMyProfile(
-                    binding.etSignupEmailSetProfileNickname.text.toString().trim(), profileImgFile, profileImgFile == null)
+                    trimBlankText(binding.etSignupEmailSetProfileNickname.text),
+                    profileImgFile,
+                    profileImgFile == null
+                )
             }
             Toast.makeText(
                 requireContext(),
@@ -336,7 +337,7 @@ class SignupEmailSetProfileFragment : Fragment() {
             if (isSuccess.getContentIfNotHandled() == true) {
                 Navigation.findNavController(requireView()).navigate(
                     SignupEmailSetProfileFragmentDirections.actionSignupEmailSetProfileFragmentToSignupEmailCompleteFragment(
-                        binding.etSignupEmailSetProfileNickname.text.toString().trim()
+                        trimBlankText(binding.etSignupEmailSetProfileNickname.text)
                     )
                 )
             } else if (isSuccess.getContentIfNotHandled() == false) {
@@ -355,7 +356,7 @@ class SignupEmailSetProfileFragment : Fragment() {
             if (isSuccess.getContentIfNotHandled() == true) {
                 Navigation.findNavController(requireView()).navigate(
                     SignupEmailSetProfileFragmentDirections.actionSignupEmailSetProfileFragmentToSignupEmailCompleteFragment(
-                        binding.etSignupEmailSetProfileNickname.text.toString().trim()
+                        trimBlankText(binding.etSignupEmailSetProfileNickname.text)
                     )
                 )
             } else if (isSuccess.getContentIfNotHandled() == false) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -14,6 +14,7 @@ import androidx.paging.LoadState
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentFeedBinding
@@ -105,7 +106,7 @@ class FeedFragment : Fragment() {
             override fun tagPostClick(chip: Chip) {
                 findNavController().navigate(
                     FeedFragmentDirections.actionFeedFragmentToSearchResultFragment(
-                        chip.text.toString().substringAfter("#").trim()
+                        trimBlankText(chip.text.toString().substringAfter("#"))
                     )
                 )
             }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
@@ -26,6 +26,7 @@ import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -241,13 +242,13 @@ class FolderEditFragment : Fragment() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 when {
-                    s.toString().trim().isEmpty() -> {
+                    trimBlankText(s).isEmpty() -> {
                         ButtonActivation.setTextViewConfirmButtonInactive(
                             requireContext(),
                             binding.tvFolderSettingAddConfirm
                         )
                     }
-                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", s.toString().trim()) -> {
+                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", trimBlankText(s)) -> {
                         ButtonActivation.setTextViewConfirmButtonActive(
                             requireContext(),
                             binding.tvFolderSettingAddConfirm

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
@@ -22,6 +22,7 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -168,13 +169,13 @@ class FolderSettingAddFragment : Fragment() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 when {
-                    s.toString().trim().isEmpty() -> {
+                    trimBlankText(s).isEmpty() -> {
                         ButtonActivation.setTextViewConfirmButtonInactive(
                             requireContext(),
                             binding.tvFolderSettingAddConfirm
                         )
                     }
-                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", s.toString().trim()) -> {
+                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", trimBlankText(s)) -> {
                         ButtonActivation.setTextViewConfirmButtonActive(
                             requireContext(),
                             binding.tvFolderSettingAddConfirm

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -30,6 +30,7 @@ import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.HideKeyBoardUtil
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -165,11 +166,11 @@ class ProfileEditFragment : Fragment() {
                             "0${getString(R.string.my_profile_edit_nickname_edittext_count)}"
                     } else {
                         tvProfileEditNicknameCount.text = "${
-                            s.toString().trim().length
+                            trimBlankText(s).length
                         }${getString(R.string.my_profile_edit_nickname_edittext_count)}"
                     }
 
-                    if (s.toString().trim().length < 2) { // 닉네임 길이 검사 1
+                    if (trimBlankText(s).length < 2) { // 닉네임 길이 검사 1
                         setEditTextTheme(
                             getString(R.string.my_profile_edit_nickname_message_length_fail_min),
                             false
@@ -178,7 +179,7 @@ class ProfileEditFragment : Fragment() {
                             requireContext(),
                             btnProfileEditComplete
                         )
-                    } else if (s.toString().trim().length > 10) { // 닉네임 길이 검사 2
+                    } else if (trimBlankText(s).length > 10) { // 닉네임 길이 검사 2
                         setEditTextTheme(
                             getString(R.string.my_profile_edit_nickname_message_length_fail_max),
                             false
@@ -190,7 +191,7 @@ class ProfileEditFragment : Fragment() {
                     } else {
                         if (Pattern.matches(
                                 "^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$",
-                                s.toString().trim()
+                                trimBlankText(s)
                             )
                         ) { // 닉네임 양식 검사
                             if (true) { // TODO : 닉네임 중복검사 통과 코드 작성
@@ -277,7 +278,7 @@ class ProfileEditFragment : Fragment() {
     private fun setProfileUpdateClickListener() {
         binding.btnProfileEditComplete.setOnDebounceClickListener {
             LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-            val nickname: String? = binding.etProfileEditNickname.text.toString().trim()
+            val nickname: String? = trimBlankText(binding.etProfileEditNickname.text)
             var profileImgFile: File?
 
             runBlocking {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
@@ -33,6 +33,7 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.common.*
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.dialog.DefaultDialogConfigure
 import com.daily.dayo.common.dialog.DefaultDialogConfirm
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -457,10 +458,11 @@ class PostFragment : Fragment() {
         }
 
         binding.tvPostCommentUpload.setOnDebounceClickListener {
-            if (binding.etPostCommentDescription.text.toString().trim().isNotEmpty()) {
+            val currentCommentEditText = trimBlankText(binding.etPostCommentDescription.text)
+            if (currentCommentEditText.isNotEmpty()) {
                 LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
                 postViewModel.requestCreatePostComment(
-                    contents = binding.etPostCommentDescription.text.toString(),
+                    contents = currentCommentEditText,
                     postId = args.postId
                 )
                 with(binding.etPostCommentDescription) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
@@ -306,11 +306,11 @@ class PostFragment : Fragment() {
                         )
                     )
                     ensureAccessibleTouchTarget(42.toPx())
-                    text = "# ${tagList[index].trim()}"
+                    text = "# ${trimBlankText(tagList[index])}"
                     setOnDebounceClickListener {
                         keyboardVisibilityUtils.detachKeyboardListeners() // TODO : 임시 처리, 화면을 벗어나므로 detach 처리 필요
                         Navigation.findNavController(it).navigate(
-                            PostFragmentDirections.actionPostFragmentToSearchResultFragment(tagList[index].trim())
+                            PostFragmentDirections.actionPostFragmentToSearchResultFragment(trimBlankText(tagList[index]))
                         )
                     }
                 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/changePassword/SettingChangePasswordCurrentFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/changePassword/SettingChangePasswordCurrentFragment.kt
@@ -14,6 +14,7 @@ import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -141,7 +142,7 @@ class SettingChangePasswordCurrentFragment : Fragment() {
 
     private fun checkPassword() {
         accountViewModel.requestCheckCurrentPassword(
-            inputPassword = binding.etSettingChangePasswordCurrentUserInput.text.toString().trim()
+            inputPassword = trimBlankText(binding.etSettingChangePasswordCurrentUserInput.text)
         )
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/changePassword/SettingChangePasswordNewFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/changePassword/SettingChangePasswordNewFragment.kt
@@ -18,6 +18,7 @@ import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
 import com.daily.dayo.common.HideKeyBoardUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.SetTextInputLayout
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -111,8 +112,7 @@ class SettingChangePasswordNewFragment : Fragment() {
                     setOnDebounceClickListener {
                         LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
                         accountViewModel.requestChangePassword(
-                            newPassword = binding.etSettingChangePasswordNewUserInput.text.toString()
-                                .trim()
+                            newPassword = trimBlankText(binding.etSettingChangePasswordNewUserInput.text)
                         )
                         accountViewModel.changePasswordSuccess.observe(viewLifecycleOwner) {
                             Toast.makeText(
@@ -193,9 +193,8 @@ class SettingChangePasswordNewFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                if (binding.etSettingChangePasswordNewUserInput.text.toString()
-                        .trim() != binding.etSettingChangePasswordNewConfirmation.text.toString()
-                        .trim()
+                if (trimBlankText(binding.etSettingChangePasswordNewUserInput.text)
+                    != trimBlankText(binding.etSettingChangePasswordNewConfirmation.text)
                 ) { // 동일 비밀번호 검사
                     ButtonActivation.setSignupButtonInactive(
                         requireContext(),
@@ -230,7 +229,7 @@ class SettingChangePasswordNewFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                if (s.toString().trim().length < 8) { // 비밀번호 길이 검사 1에
+                if (trimBlankText(s).length < 8) { // 비밀번호 길이 검사 1에
                     SetTextInputLayout.setEditTextTheme(
                         requireContext(),
                         binding.layoutSettingChangePasswordNewUserInput,
@@ -242,7 +241,7 @@ class SettingChangePasswordNewFragment : Fragment() {
                         requireContext(),
                         binding.btnSettingChangePasswordNewNext
                     )
-                } else if (s.toString().trim().length > 16) { // 비밀번호 길이 검사 2
+                } else if (trimBlankText(s).length > 16) { // 비밀번호 길이 검사 2
                     SetTextInputLayout.setEditTextErrorTheme(
                         requireContext(),
                         binding.layoutSettingChangePasswordNewUserInput,
@@ -254,7 +253,7 @@ class SettingChangePasswordNewFragment : Fragment() {
                         requireContext(),
                         binding.btnSettingChangePasswordNewNext
                     )
-                } else if (!Pattern.matches("^[a-z|0-9|]+\$", s.toString().trim())) { // 비밀번호 양식 검사
+                } else if (!Pattern.matches("^[a-z|0-9|]+\$", trimBlankText(s))) { // 비밀번호 양식 검사
                     SetTextInputLayout.setEditTextErrorTheme(
                         requireContext(),
                         binding.layoutSettingChangePasswordNewUserInput,

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderAddFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderAddFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -85,13 +86,13 @@ class WriteFolderAddFragment : Fragment() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 when {
-                    s.toString().trim().isEmpty() -> {
+                    trimBlankText(s).isEmpty() -> {
                         ButtonActivation.setTextViewConfirmButtonInactive(
                             requireContext(),
                             binding.tvPostFolderAddConfirm
                         )
                     }
-                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", s.toString().trim()) -> {
+                    Pattern.matches("[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|\\s]*", trimBlankText(s)) -> {
                         ButtonActivation.setTextViewConfirmButtonActive(
                             requireContext(),
                             binding.tvPostFolderAddConfirm

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -145,7 +146,7 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
                         isCloseIconVisible = false
                         isCheckable = false
                         ensureAccessibleTouchTarget(42.toPx())
-                        text = "# ${it[index].trim()}"
+                        text = "# ${trimBlankText(it[index])}"
                     }
                     binding.chipgroupWriteOptionTagListSaved.addView(chip, layoutParams)
                 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
@@ -16,7 +16,8 @@ import com.daily.dayo.R
 import com.daily.dayo.common.Event
 import com.daily.dayo.common.HideKeyBoardUtil
 import com.daily.dayo.common.ListLiveData
-import com.daily.dayo.common.ReplaceUnicode
+import com.daily.dayo.common.ReplaceUnicode.replaceBlankText
+import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -92,8 +93,8 @@ class WriteTagFragment : Fragment() {
         binding.etWriteTagAdd.setOnEditorActionListener { _, actionId, _ ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
-                    val originalTag = binding.etWriteTagAdd.text.toString().trim()
-                    val removeBlankTag = ReplaceUnicode.replaceBlankText(originalTag)
+                    val originalTag = trimBlankText(binding.etWriteTagAdd.text)
+                    val removeBlankTag = replaceBlankText(originalTag)
 
                     if (removeBlankTag.isEmpty()
                         || binding.chipgroupWriteTagListSaved.getAllChipsTagText()
@@ -147,7 +148,7 @@ class WriteTagFragment : Fragment() {
                         setTagCountLimit()
                         setTagSubmitClickListener(binding.chipgroupWriteTagListSaved.getAllChipsTagText())
                     }
-                    text = "# ${it[index].trim()}"
+                    text = "# ${trimBlankText(it[index])}"
                 }
                 binding.chipgroupWriteTagListSaved.addView(chip, layoutParams)
                 originalTagList.add(it[index])


### PR DESCRIPTION
## 내용 및 작업사항
- 공백제거를 위해 일반적인 띄어쓰기이외의 띄어쓰기와 동일한 형태를 보여주는 다른 유니코드들을 모두 한번에 제거할 수 있도록 별도의 함수 구현
- 글 상세보기에서 댓글을 다는 경우, 공백 제거 검사 이후 실제로 서버에 전송하는 경우 공백 제거 검사및 처리된 텍스트가 아닌 사용자가 입력한 텍스트가 서버에 전송되는 현상 수정
- 기존 기본적으로 제공되는 `trim()`을 사용한 경우 특수 공백문자까지 제거하는 `trimBlankText()`로 변경

## 참고
- #190 