### PR TITLE
#410 [refactoring] Change diffUtil Logic

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
@@ -37,7 +37,13 @@ class FeedListAdapter(private val requestManager: RequestManager) :
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: Post, newItem: Post): Boolean =
-                oldItem == newItem
+                oldItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                } == newItem.apply {
+                    preLoadThumbnail = null
+                    preLoadUserImg = null
+                }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
@@ -24,10 +24,10 @@ class FolderPostListAdapter(private val requestManager: RequestManager) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<FolderPost>() {
             override fun areItemsTheSame(oldItem: FolderPost, newItem: FolderPost) =
-                oldItem === newItem
+                oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: FolderPost, newItem: FolderPost): Boolean =
-                oldItem.hashCode() == newItem.hashCode()
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FolderSettingAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FolderSettingAdapter.kt
@@ -22,10 +22,10 @@ class FolderSettingAdapter(private val isChange: Boolean) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Folder>() {
             override fun areItemsTheSame(oldItem: Folder, newItem: Folder) =
-                oldItem === newItem
+                oldItem.folderId == newItem.folderId
 
             override fun areContentsTheSame(oldItem: Folder, newItem: Folder): Boolean =
-                oldItem.folderId == newItem.folderId
+                oldItem == newItem
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
@@ -24,7 +24,7 @@ class ProfileBookmarkPostListAdapter(private val requestManager: RequestManager)
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: BookmarkPost, newItem: BookmarkPost): Boolean =
-                oldItem == newItem
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
@@ -23,7 +23,7 @@ class ProfileFolderListAdapter(private val requestManager: RequestManager) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Folder>() {
             override fun areItemsTheSame(oldItem: Folder, newItem: Folder) =
-                oldItem === newItem
+                oldItem.folderId == newItem.folderId
 
             override fun areContentsTheSame(oldItem: Folder, newItem: Folder): Boolean =
                 oldItem == newItem

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
@@ -22,10 +22,14 @@ class ProfileLikePostListAdapter(private val requestManager: RequestManager) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<LikePost>() {
             override fun areItemsTheSame(oldItem: LikePost, newItem: LikePost) =
-                oldItem === newItem
+                oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: LikePost, newItem: LikePost): Boolean =
-                oldItem == newItem
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
+
+            override fun getChangePayload(oldItem: LikePost, newItem: LikePost): Any? {
+                return if (oldItem.postId != newItem.postId || oldItem.thumbnailImage != newItem.thumbnailImage) true else null
+            }
         }
     }
 


### PR DESCRIPTION
## 내용 및 작업사항
- Item을 비교하는 `DiffUtil` 작성 과정간 `areItemsTheSame` 및 `areContentsTheSame` 로직이 잘못 작성되어 있어 불필요한 새로고침과 애니메이션이 나타나는 현상 수정
   - 내용이 아닌 주소값을 비교하는 `===` 로 비교하는 부분에 대해 수정
   - `areItemsTheSame` 은 가능한 해당 아이템의 고유 ID로, `areContentsTheSame`는 해당 아이템의 미리보기 등 속도를 위한 요소를 제외한 요소들에 대한 비교로 처리할 수 있도록 수정

## 참고
- resolved: #410