### PR TITLE
#412 Add Clean up Post Detail logic when postFragment is destroyed

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/post/PostFragment.kt
@@ -4,14 +4,12 @@ import android.app.AlertDialog
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowInsets
 import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -110,6 +108,7 @@ class PostFragment : Fragment() {
         super.onDestroyView()
         LoadingAlertDialog.hideLoadingDialog(loadingAlertDialog)
         keyboardVisibilityUtils.detachKeyboardListeners()
+        postViewModel.cleanUpPostDetail()
     }
 
     private fun setBackButtonClickListener() {
@@ -153,8 +152,7 @@ class PostFragment : Fragment() {
 
     private fun setPostDetailCollect() {
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                postViewModel.requestPostDetail(args.postId)
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
                 postViewModel.postDetail.observe(viewLifecycleOwner) {
                     when (it.status) {
                         Status.SUCCESS -> {
@@ -199,6 +197,7 @@ class PostFragment : Fragment() {
                         Status.ERROR -> {}
                     }
                 }
+                postViewModel.requestPostDetail(args.postId)
             }
         }
     }
@@ -323,6 +322,9 @@ class PostFragment : Fragment() {
         postImageSliderAdapter = PostImageSliderAdapter(requestManager = glideRequestManager)
         with(binding.vpPostImage) {
             adapter = postImageSliderAdapter
+            setPageTransformer { page, position ->
+                // To Disable image changing animation
+            }
             offscreenPageLimit = 1
             registerOnPageChangeCallback(object : OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/PostViewModel.kt
@@ -65,6 +65,11 @@ class PostViewModel @Inject constructor(
     private val _blockSuccess = MutableLiveData<Event<Boolean>>()
     val blockSuccess: LiveData<Event<Boolean>> get() = _blockSuccess
 
+    fun cleanUpPostDetail() {
+        _postDetail.postValue(Resource.loading(null))
+        _postComment.postValue(Resource.loading(null))
+    }
+
     fun requestPostDetail(postId: Int) = viewModelScope.launch {
         _postDetail.postValue(Resource.loading(null))
         requestPostDetailUseCase(postId)?.let { ApiResponse ->


### PR DESCRIPTION
## 내용
- PostFragment에서 이전에 사용했던 PostFragment 내용이 보이는 문제에 대한 해결

## 작업 내용
- PostFragment가 Destroy되는 경우 해당 PostFragment에서 보여줬던 내용을 초기화한 이후에 Destroy되도록 구현
- 새로운 이미지를 보여주는 경우에 불필요한 Fade animation이 보여지지 않도록 `setPageTransformer`에 대해 빈 코드로 오버라이드

## 참고
- resolved: #412