### PR TITLE
#414 Change tag limit, counting logic

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -45,7 +45,8 @@ class WriteViewModel @Inject constructor(
     var postFolderId = MutableLiveData("")
     var postFolderName = MutableLiveData("")
     var postImageUriList = ListLiveData<String>() // 갤러리에서 불러온 이미지 리스트
-    var postTagList = ListLiveData<String>()
+    private val _postTagList = ListLiveData<String>()
+    val postTagList : ListLiveData<String> get () = _postTagList
 
     // WritePost
     private val _writePostId = MutableLiveData<Event<Int>>()
@@ -161,6 +162,14 @@ class WriteViewModel @Inject constructor(
         postFolderId = MutableLiveData<String>("")
         postFolderName = MutableLiveData<String>("")
         postImageUriList = ListLiveData()
-        postTagList = ListLiveData()
+        _postTagList.postValue(arrayListOf())
+    }
+
+    fun addPostTag(tagText: String) {
+        _postTagList.add(tagText)
+    }
+
+    fun removePostTag(tagText: String) {
+        _postTagList.remove(tagText)
     }
 }

--- a/app/src/main/res/layout/fragment_write_tag.xml
+++ b/app/src/main/res/layout/fragment_write_tag.xml
@@ -1,170 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
+        <import type="android.view.View" />
+        <variable
+            name="tagCountMax"
+            type="Integer" />
+
         <variable
             name="tagCount"
             type="Integer" />
+
+        <variable
+            name="isClickEnable"
+            type="Boolean" />
     </data>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white_FFFFFF"
-    tools:context=".presentation.fragment.write.WriteTagFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_write_tag_action_bar"
-        android:layout_width="0dp"
-        android:layout_height="?actionBarSize"
-        android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <ImageButton
-            android:id="@+id/btn_write_tag_back"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:paddingHorizontal="18dp"/>
-        <TextView
-            android:id="@+id/tv_write_post_tag_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/write_post_tag_add"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/black_000000"
-            app:layout_constraintTop_toTopOf="@id/btn_write_tag_back"
-            app:layout_constraintBottom_toBottomOf="@id/btn_write_tag_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
-        <TextView
-            android:id="@+id/btn_write_post_tag_submit"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:enabled="false"
-            android:text="@string/confirm"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/gray_4_C5CAD2"
-            android:background="@android:color/transparent"
-            android:gravity="center"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:paddingHorizontal="18dp" />
-
-        <View
-            android:id="@+id/view_write_tag_actionbar_horizontal_line"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/gray_5_E8EAEE"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <EditText
-        style="@style/WritePostTagEditTextStyle"
-        android:id="@+id/et_write_tag_add"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="@drawable/selector_edittext_write_tag"
-        android:singleLine="true"
-        android:hint="@string/hint_write_post_tag_add"
-        android:textSize="12dp"
-        android:textColorHint="@color/gray_4_C5CAD2"
-        app:layout_constraintTop_toBottomOf="@id/layout_write_tag_action_bar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="14dp"
-        android:layout_marginHorizontal="18dp"
-        android:paddingVertical="14dp"
-        android:paddingHorizontal="18dp"/>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_write_tag_list"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/et_write_tag_add"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="28dp">
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF"
+        tools:context=".presentation.fragment.write.WriteTagFragment">
+
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_write_tag_list_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
+            android:id="@+id/layout_write_tag_action_bar"
+            android:layout_width="0dp"
+            android:layout_height="?actionBarSize"
+            android:elevation="24dp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginStart="18dp">
-            <TextView
-                android:id="@+id/tv_write_tag_list_count_saved"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/btn_write_tag_back"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@{Integer.toString(tagCount) + ` `}"
-                android:textSize="13dp"
-                android:textColor="@color/gray_4_C5CAD2"
-                app:layout_constraintTop_toTopOf="parent"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
+                android:src="@drawable/ic_back_sign"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                tools:text="0"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
+
             <TextView
-                android:id="@+id/tv_write_tag_list_count_range"
+                android:id="@+id/tv_write_post_tag_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/write_post_tag_count_limit"
-                android:textSize="13dp"
-                android:textColor="@color/gray_2_767B83"
-                app:layout_constraintTop_toTopOf="@id/tv_write_tag_list_count_saved"
-                app:layout_constraintBottom_toBottomOf="@id/tv_write_tag_list_count_saved"
-                app:layout_constraintStart_toEndOf="@+id/tv_write_tag_list_count_saved"
-                tools:text=" / 8"/>
+                android:text="@string/write_post_tag_add"
+                android:textColor="@color/black_000000"
+                android:textSize="16dp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@id/btn_write_tag_back"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/btn_write_tag_back" />
+
+            <TextView
+                android:id="@+id/btn_write_post_tag_submit"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:enabled="@{isClickEnable}"
+                android:gravity="center"
+                android:paddingHorizontal="18dp"
+                android:text="@string/confirm"
+                android:textColor="@{isClickEnable == true ? @color/gray_1_313131 : @color/gray_4_C5CAD2}"
+                android:textSize="16dp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/view_write_tag_actionbar_horizontal_line"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/gray_5_E8EAEE"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <View
-            android:id="@+id/view_write_tag_list_count_horizontal_line"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/gray_6_F0F1F3"
-            app:layout_constraintTop_toBottomOf="@id/layout_write_tag_list_count"
-            app:layout_constraintStart_toStartOf="parent"
+        <EditText
+            android:id="@+id/et_write_tag_add"
+            style="@style/WritePostTagEditTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="18dp"
+            android:layout_marginTop="14dp"
+            android:background="@drawable/selector_edittext_write_tag"
+            android:hint="@string/hint_write_post_tag_add"
+            android:paddingHorizontal="18dp"
+            android:paddingVertical="14dp"
+            android:singleLine="true"
+            android:textColorHint="@color/gray_4_C5CAD2"
+            android:textSize="12dp"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="12dp"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_write_tag_action_bar" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_write_tag_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="28dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_write_tag_add">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_write_tag_list_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="18dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tv_write_tag_list_count_saved"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{Integer.toString(tagCount) + ` `}"
+                    android:textColor="@{tagCount == 0? @color/gray_4_C5CAD2: @color/primary_green_23C882}"
+                    android:textSize="13dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="0" />
+
+                <TextView
+                    android:id="@+id/tv_write_tag_list_count_range"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{@string/write_post_tag_count_limit(tagCountMax)}"
+                    android:textColor="@color/gray_2_767B83"
+                    android:textSize="13dp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_write_tag_list_count_saved"
+                    app:layout_constraintStart_toEndOf="@+id/tv_write_tag_list_count_saved"
+                    app:layout_constraintTop_toTopOf="@id/tv_write_tag_list_count_saved"
+                    tools:text=" / 8" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <View
+                android:id="@+id/view_write_tag_list_count_horizontal_line"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="12dp"
+                android:background="@color/gray_6_F0F1F3"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_write_tag_list_count" />
 
             <ImageView
                 android:id="@+id/img_write_tag_list_empty"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/ic_tag_list_empty"
-                app:layout_constraintTop_toTopOf="parent"
+                android:visibility="@{tagCount==0 ? View.VISIBLE : View.GONE}"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.497"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/layout_write_tag_list_saved"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:flexWrap="wrap"
-                app:alignItems="stretch"
-                app:alignContent="stretch"
-                app:layout_constraintTop_toBottomOf="@id/view_write_tag_list_count_horizontal_line"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginHorizontal="18dp"
                 android:layout_marginTop="16dp"
-                android:layout_marginHorizontal="18dp">
+                app:alignContent="stretch"
+                app:alignItems="stretch"
+                app:flexWrap="wrap"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/view_write_tag_list_count_horizontal_line">
+
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/chipgroup_write_tag_list_saved"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
             </com.google.android.flexbox.FlexboxLayout>
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,8 +100,9 @@
     <string name="write_option_title_private">공개 설정</string>
     <string name="write_option_title_tag">태그 추가</string>
     <string name="write_option_description_tag">기록에 관한 키워드를 추가해보세요.</string>
-    <string name="write_post_tag_count_limit"> / 8</string>
-    <string name="write_post_tag_alert_message_tag_size_fail_max">태그는 8개까지 등록 가능해요.</string>
+    <string name="write_post_tag_count_limit"> / %d</string>
+    <string name="write_post_tag_alert_message_tag_size_fail_max">태그는 %d개까지 등록 가능해요.</string>
+    <string name="write_post_tag_alert_message_tag_length_fail_max">태그는 %d자 까지만 입력할 수 있어요!</string>
     <string name="write_post_folder_title">폴더 설정</string>
     <string name="write_post_folder_new_title">폴더 추가</string>
     <string name="write_post_upload_alert_message_empty_content">내용을 입력해 주세요.</string>


### PR DESCRIPTION
## 내용 및 작업사항
- 업로드 게시글의 태그 리스트 값 조작위치를 `Fragment`에서 `ViewModel`로 이동
- 기존에 `LoadingDialog`를 hide하는 시기를 `onDestroyView`가 호출되던 시점에서 `onStop`이 호출되던 시점으로 변경
- `writeViewModel`의 `postTagList`를 Observe해 `Chip ItemView`가 추가및 삭제되도록 로직 변경
- `DataBinding`을 활용해 `XML` 상에서 확인 버튼 및 현재 입력된 태그 개수등을 조작할 수 있도록 설정
- 입력 가능한 태그 글자수 15자로 설정

## 참고
- #414
- #417 