### PR TITLE
#415 Fix different height of tag elements

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
@@ -19,6 +19,7 @@ import com.daily.dayo.common.ImageResizeUtil
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
+import com.daily.dayo.common.dp
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentWriteOptionBinding
 import com.daily.dayo.presentation.viewmodel.WriteViewModel
@@ -139,7 +140,7 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
                         .inflate(R.layout.item_write_post_tag_chip, null) as Chip
                     val layoutParams = ViewGroup.MarginLayoutParams(
                         ViewGroup.MarginLayoutParams.WRAP_CONTENT,
-                        ViewGroup.MarginLayoutParams.WRAP_CONTENT
+                        48.dp
                     )
                     with(chip) {
                         setTextAppearance(R.style.WritePostTagTextStyle)

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
@@ -20,6 +20,7 @@ import com.daily.dayo.common.ReplaceUnicode.replaceBlankText
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
+import com.daily.dayo.common.dp
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentWriteTagBinding
 import com.daily.dayo.presentation.viewmodel.WriteViewModel
@@ -139,7 +140,7 @@ class WriteTagFragment : Fragment() {
                     .inflate(R.layout.item_write_post_tag_chip, null) as Chip
                 val layoutParams = ViewGroup.MarginLayoutParams(
                     ViewGroup.MarginLayoutParams.WRAP_CONTENT,
-                    ViewGroup.MarginLayoutParams.WRAP_CONTENT
+                    48.dp
                 )
                 with(chip) {
                     setTextAppearance(R.style.WritePostTagTextStyle)


### PR DESCRIPTION
## 내용 및 작업사항
- Chip 내용에 따라 높이가 바뀌는 wrap_content로 height가 설정되어 요소들의 높이가 일정하지 않았던 문제를 48dp로 설정해 태그의 높이 설정

## 참고
- #415