### PR TITLE
#417 change when dialog disappears when leaving the folder fragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderFragment.kt
@@ -49,25 +49,21 @@ class WriteFolderFragment : Fragment() {
         super.onCreate(savedInstanceState)
         val onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                writeViewModel.showWriteOptionDialog.value = Event(true)
-                LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-                LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog, 0.8f)
+                displayLoadingDialog()
                 findNavController().navigateUp()
             }
         }
         requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
+    override fun onStop() {
+        super.onStop()
         LoadingAlertDialog.hideLoadingDialog(loadingAlertDialog)
     }
 
     private fun setBackButtonClickListener() {
         binding.btnWriteFolderBack.setOnDebounceClickListener {
-            writeViewModel.showWriteOptionDialog.value = Event(true)
-            LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-            LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog, 0.8f)
+            displayLoadingDialog()
             findNavController().navigateUp()
         }
     }
@@ -85,9 +81,7 @@ class WriteFolderFragment : Fragment() {
     private fun onFolderClicked(folder: Folder) {
         writeViewModel.postFolderId.value = folder.folderId.toString()
         writeViewModel.postFolderName.value = folder.title
-        writeViewModel.showWriteOptionDialog.value = Event(true)
-        LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-        LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog, 0.8f)
+        displayLoadingDialog()
         findNavController().navigateUp()
     }
 
@@ -117,5 +111,11 @@ class WriteFolderFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun displayLoadingDialog() {
+        writeViewModel.showWriteOptionDialog.value = Event(true)
+        LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
+        LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog, 0.8f)
     }
 }


### PR DESCRIPTION
## 내용 및 작업사항
- `LoadingDialog`가 폴더 설정에서 나온 뒤 글 작성 페이지로 넘어간 뒤에 사라짐에 따라 어색한 부분에 대해 수정
   - `onDestroyView`가 호출되던 시점에 Dialog를 dismiss하던 것에서 `onStop`이 호출되는 시점에 Dialog를 dismiss하는 것으로 변경 

## 참고
- resolved: #417