### PR TITLE
#416 Change displaying limit toast message logic

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
@@ -268,11 +268,6 @@ class WriteFragment : Fragment() {
                         postImageBitmapToStringList.add(imageBitmap.toBase64String())
                     }
                     if (postImageBitmapToStringList.size >= 5) {
-                        Toast.makeText(
-                            requireContext(),
-                            getString(R.string.write_post_upload_alert_message_image_fail_max),
-                            Toast.LENGTH_SHORT
-                        ).show()
                         binding.btnUploadImage.visibility = View.GONE
                         break
                     }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
@@ -117,7 +117,7 @@ class WriteImageOptionFragment : DialogFragment() {
                 val remainingNum = 5 - writeViewModel.postImageUriList.size()
                 if (data?.clipData != null) { //사진 여러 개 선택 시
                     val count = data.clipData!!.itemCount
-                    if (count > remainingNum) {
+                    if (count >= remainingNum) {
                         Toast.makeText(
                             requireContext(),
                             getString(R.string.write_post_upload_alert_message_image_fail_max),
@@ -133,13 +133,15 @@ class WriteImageOptionFragment : DialogFragment() {
                     findNavController().popBackStack()
                 } else { // 단일 선택
                     data?.data?.let { uri ->
-                        if (remainingNum <= 0) {
+                        if (remainingNum <= 1) {
                             Toast.makeText(
                                 requireContext(),
                                 getString(R.string.write_post_upload_alert_message_image_fail_max),
                                 Toast.LENGTH_SHORT
                             ).show()
-                        } else {
+                        }
+
+                        if (remainingNum >= 1) {
                             val imageUri: Uri? = data.data
                             if (imageUri != null) {
                                 writeViewModel.postImageUriList.add(imageUri.toString())

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
@@ -81,7 +81,6 @@ class WriteTagFragment : Fragment() {
 
     private fun setSubmitButtonClickListener() {
         binding.btnWritePostTagSubmit.setOnDebounceClickListener {
-            writeViewModel.postTagList.replaceAll(binding.chipgroupWriteTagListSaved.getAllChipsTagText())
             displayLoadingDialog()
             findNavController().navigateUp()
         }


### PR DESCRIPTION
## 내용 및 작업사항
- 글자 및 개수 제한 토스트 메시지가 지속적으로 불필요하게 표시되는 현상 개선
   - WriteFragment에서 개수 제한을 체크하지 않고, ImageOption에서만 사진 개수를 제한 체크하도록 로직 변경
   - 태그 리스트가 replace되는 로직을 제거해 불필요한 list 값 변경으로 토스트 메시지가 나타나는 현상 개선

## 참고
- resolved: #416