### PR TITLE
#435 [refactoring] Change thread networking when uploading post

### DIFF
--- a/app/src/main/java/com/daily/dayo/DayoApplication.kt
+++ b/app/src/main/java/com/daily/dayo/DayoApplication.kt
@@ -19,6 +19,7 @@ class DayoApplication : Application(){
         fun applicationContext(): Context {
             return instance.applicationContext
         }
+        val cacheDirPath get () = applicationContext().cacheDir.toString()
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/daily/dayo/common/ConvertBitmap.kt
+++ b/app/src/main/java/com/daily/dayo/common/ConvertBitmap.kt
@@ -1,0 +1,38 @@
+package com.daily.dayo.common
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStream
+
+fun Uri.toBitmap(contentResolver: ContentResolver): Bitmap? {
+    return try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            ImageDecoder.decodeBitmap(ImageDecoder.createSource(contentResolver, this))
+        } else {
+            MediaStore.Images.Media.getBitmap(contentResolver, this)
+        }
+    } catch (e: IOException) {
+        e.printStackTrace()
+        null
+    }
+}
+
+fun Bitmap?.toFile(path: String): File {
+    val file = File(path)
+    var out: OutputStream? = null
+    try {
+        file.createNewFile()
+        out = FileOutputStream(file)
+        this?.compress(Bitmap.CompressFormat.JPEG, 100, out)
+    } finally {
+        out?.close()
+    }
+    return file
+}

--- a/app/src/main/java/com/daily/dayo/common/ConvertPx.kt
+++ b/app/src/main/java/com/daily/dayo/common/ConvertPx.kt
@@ -1,0 +1,10 @@
+package com.daily.dayo.common
+
+import android.content.res.Resources
+
+
+val Int.Px: Int
+    get() {
+        val density = Resources.getSystem().displayMetrics.density
+        return (this * density).toInt()
+    }

--- a/app/src/main/java/com/daily/dayo/common/ListLiveData.kt
+++ b/app/src/main/java/com/daily/dayo/common/ListLiveData.kt
@@ -7,16 +7,20 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
         value = ArrayList()
     }
 
-    fun add(item: T) {
+    fun add(item: T, notify: Boolean) {
         val items: ArrayList<T>? = value
         items!!.add(item)
-        value = items
+        if (notify) {
+            value = items
+        }
     }
 
-    fun addAll(list: List<T>) {
+    fun addAll(list: List<T>, notify: Boolean) {
         val items: ArrayList<T>? = value
         items!!.addAll(list)
-        value = items
+        if (notify) {
+            value = items
+        }
     }
 
     fun clear(notify: Boolean) {
@@ -31,22 +35,28 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
         return value?.size ?: 0
     }
 
-    fun replaceAll(list: List<T>) {
+    fun replaceAll(list: List<T>, notify: Boolean) {
         val items: ArrayList<T> = arrayListOf()
         items.addAll(list)
-        value = items
+        if (notify) {
+            value = items
+        }
     }
 
-    fun removeAt(pos: Int) {
+    fun removeAt(pos: Int, notify: Boolean) {
         val items: ArrayList<T>? = value
         items!!.removeAt(pos)
-        value = items
+        if (notify) {
+            value = items
+        }
     }
 
-    fun remove(item: T) {
+    fun remove(item: T, notify: Boolean) {
         val items: ArrayList<T>? = value
         items!!.remove(item)
-        value = items
+        if (notify) {
+            value = items
+        }
     }
 
     fun notifyChange() {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFolderFragment.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.fragment.write
 
-import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -30,31 +29,24 @@ class WriteFolderFragment : Fragment() {
             writeViewModel.postFolderId.value!!
         )
     }
-    private lateinit var loadingAlertDialog: AlertDialog
+    private val loadingAlertDialog by lazy { LoadingAlertDialog.createLoadingDialog(requireContext()) }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentWriteFolderBinding.inflate(inflater, container, false)
-        loadingAlertDialog = LoadingAlertDialog.createLoadingDialog(requireContext())
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setBackButtonClickListener()
         setFolderAddButtonClickListener()
         setRvWriteFolderListAdapter()
         setWriteFolderList()
-        return binding.root
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val onBackPressedCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                displayLoadingDialog()
-                findNavController().navigateUp()
-            }
-        }
-        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
-    }
 
     override fun onStop() {
         super.onStop()
@@ -66,6 +58,17 @@ class WriteFolderFragment : Fragment() {
     }
 
     private fun setBackButtonClickListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                displayLoadingDialog()
+                findNavController().navigateUp()
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            onBackPressedCallback
+        )
+
         binding.btnWriteFolderBack.setOnDebounceClickListener {
             displayLoadingDialog()
             findNavController().navigateUp()
@@ -111,7 +114,7 @@ class WriteFolderFragment : Fragment() {
                                 }
                             }
                         }
-                        else -> { }
+                        else -> {}
                     }
                 }
             }
@@ -119,8 +122,8 @@ class WriteFolderFragment : Fragment() {
     }
 
     private fun displayLoadingDialog() {
-        writeViewModel.showWriteOptionDialog.value = Event(true)
         LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
         LoadingAlertDialog.resizeDialogFragment(requireContext(), loadingAlertDialog, 0.8f)
+        writeViewModel.showWriteOptionDialog.value = Event(true)
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteFragment.kt
@@ -14,7 +14,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
@@ -68,7 +67,6 @@ class WriteFragment : Fragment() {
         setImageModifyListener()
         setCategoryClickListener()
         setUploadButtonClickListener()
-        observeUploadStateCallBack()
         showOptionDialog()
     }
 
@@ -236,7 +234,7 @@ class WriteFragment : Fragment() {
                 uploadImageListAdapter?.setOnItemClickListener(object :
                     WriteUploadImageListAdapter.OnItemClickListener {
                     override fun deleteUploadImageClick(pos: Int) {
-                        writeViewModel.deleteUploadImage(if (it.size >= 5) pos else pos - 1)
+                        writeViewModel.deleteUploadImage(if (it.size >= 5) pos else pos - 1, true)
                     }
 
                     override fun addUploadImageClick(pos: Int) {
@@ -289,42 +287,5 @@ class WriteFragment : Fragment() {
                 }
             }
         }
-    }
-
-    private fun observeUploadStateCallBack() {
-        writeViewModel.writeSuccess.observe(viewLifecycleOwner, Observer { isSuccess ->
-            if (isSuccess.getContentIfNotHandled() == true) {
-                writeViewModel.writePostId.value?.getContentIfNotHandled()?.let { writePostId ->
-                    findNavController().navigateSafe(
-                        currentDestinationId = R.id.WriteFragment,
-                        action = R.id.action_writeFragment_to_postFragment,
-                        args = WriteFragmentDirections.actionWriteFragmentToPostFragment(writePostId).arguments
-                    )
-                }
-            } else if (isSuccess.getContentIfNotHandled() == false) {
-                Toast.makeText(
-                    requireContext(),
-                    R.string.write_post_upload_alert_message_fail,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        })
-        writeViewModel.writeEditSuccess.observe(viewLifecycleOwner, Observer { isSuccess ->
-            if (isSuccess.getContentIfNotHandled() == true) {
-                writeViewModel.writePostId.value?.getContentIfNotHandled()?.let { writePostId ->
-                    findNavController().navigateSafe(
-                        currentDestinationId = R.id.WriteFragment,
-                        action = R.id.action_writeFragment_to_postFragment,
-                        args = WriteFragmentDirections.actionWriteFragmentToPostFragment(writePostId).arguments
-                    )
-                }
-            } else if (isSuccess.getContentIfNotHandled() == false) {
-                Toast.makeText(
-                    requireContext(),
-                    R.string.write_post_upload_alert_message_fail,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        })
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteOptionFragment.kt
@@ -1,21 +1,16 @@
 package com.daily.dayo.presentation.fragment.write
 
-import android.app.AlertDialog
-import android.graphics.Bitmap
-import android.graphics.ImageDecoder
-import android.os.Build
 import android.os.Bundle
-import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.annotation.RequiresApi
-import androidx.core.net.toUri
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.R
-import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.Event
+import com.daily.dayo.common.Px
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog
@@ -27,11 +22,6 @@ import com.daily.dayo.presentation.viewmodel.WriteViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.chip.Chip
 import dagger.hilt.android.AndroidEntryPoint
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
-import java.text.SimpleDateFormat
-import java.util.*
 
 @AndroidEntryPoint
 class WriteOptionFragment : BottomSheetDialogFragment() {
@@ -39,77 +29,84 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
         LoadingAlertDialog.hideLoadingDialog(loadingAlertDialog)
     }
     private val writeViewModel by activityViewModels<WriteViewModel>()
-    private val postImageFileList = ArrayList<File>()
-    private val imageFileTimeFormat = SimpleDateFormat("yyyy-MM-d-HH-mm-ss-SSS", Locale.KOREA)
-    private lateinit var loadingAlertDialog: AlertDialog
+    private val loadingAlertDialog by lazy { LoadingAlertDialog.createLoadingDialog(requireContext()) }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentWriteOptionBinding.inflate(inflater, container, false)
-        loadingAlertDialog = LoadingAlertDialog.createLoadingDialog(requireContext())
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeUploadStateCallBack()
         setUploadButtonClickListener()
         setOptionTagListOriginalValue()
         setOptionTagClickListener()
         setOptionFolderClickListener()
         setFolderDescription()
-        return binding.root
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun setUploadImageFileList() {
-        writeViewModel.postImageUriList.observe(viewLifecycleOwner) {
-            postImageFileList.clear()
-            it.forEach { item ->
-                val postImageBitmap = item.toBitmap()
-                val resizedImageBitmap = ImageResizeUtil.resizeBitmap(
-                    originalBitmap = postImageBitmap,
-                    resizedWidth = 480,
-                    resizedHeight = 480
-                )
-                postImageFileList.add(bitmapToFile(resizedImageBitmap, setUploadImagePath()))
-            }
-        }
     }
 
     private fun setUploadButtonClickListener() {
         binding.btnWriteOptionConfirm.setOnDebounceClickListener {
             when {
-                writeViewModel.postFolderId.value == "" -> { // 폴더 미선택시 글 업로드 불가
-                    Toast.makeText(requireContext(), "폴더를 선택해 주세요", Toast.LENGTH_SHORT)
-                        .show()
+                writeViewModel.postFolderId.value.isNullOrEmpty() -> { // 폴더 미선택시 글 업로드 불가
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.write_post_upload_alert_message_empty_folder),
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
-                writeViewModel.postId.value != 0 -> { // 기존 게시글을 수정하는 경우
+                else -> {
                     LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-                    writeViewModel.requestEditPost()
+                    writeViewModel.requestUploadPost()
                     Toast.makeText(
                         requireContext(),
                         R.string.write_post_upload_alert_message_loading,
                         Toast.LENGTH_SHORT
                     ).show()
-                    findNavController().navigateUp()
-                }
-                else -> { // 새로 글을 작성하는 경우
-                    LoadingAlertDialog.showLoadingDialog(loadingAlertDialog)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        setUploadImageFileList()
-                    }
-                    writeViewModel.requestUploadPost(postImageFileList.toTypedArray())
-                    Toast.makeText(
-                        requireContext(),
-                        R.string.write_post_upload_alert_message_loading,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    findNavController().navigateUp()
                 }
             }
         }
     }
 
+    private fun observeUploadStateCallBack() {
+        with(writeViewModel) {
+            writeSuccess.observe(viewLifecycleOwner) { isSuccess ->
+                setUploadResultCallback(isSuccess)
+            }
+            writeEditSuccess.observe(viewLifecycleOwner) { isSuccess ->
+                setUploadResultCallback(isSuccess)
+            }
+        }
+    }
+
+    private fun setUploadResultCallback(isSuccess: Event<Boolean>) {
+        if (isSuccess.getContentIfNotHandled() == true) {
+            writeViewModel.writePostId.value?.getContentIfNotHandled()?.let { writePostId ->
+                findNavController().navigateSafe(
+                    currentDestinationId = R.id.WriteOptionFragment,
+                    action = R.id.action_writeOptionFragment_to_postFragment,
+                    args = WriteOptionFragmentDirections.actionWriteOptionFragmentToPostFragment(
+                        writePostId
+                    ).arguments
+                )
+            }
+        } else if (isSuccess.getContentIfNotHandled() == false) {
+            Toast.makeText(
+                requireContext(),
+                R.string.write_post_upload_alert_message_fail,
+                Toast.LENGTH_SHORT
+            ).show()
+        } else {
+        }
+    }
+
     private fun setFolderDescription() {
         writeViewModel.postFolderId.observe(viewLifecycleOwner) {
-            if (it != "") {
+            if (it.isNotEmpty()) {
                 binding.tvWriteOptionDescriptionFolder.text = writeViewModel.postFolderName.value
             }
         }
@@ -117,8 +114,8 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
 
     private fun setOptionTagListOriginalValue() {
         writeViewModel.postTagList.observe(viewLifecycleOwner) {
+            binding.tvWriteOptionDescriptionTag.isVisible = it.isNullOrEmpty()
             if (!it.isNullOrEmpty()) {
-                binding.tvWriteOptionDescriptionTag.visibility = View.GONE
                 (it.indices).mapNotNull { index ->
                     val chip = LayoutInflater.from(context)
                         .inflate(R.layout.item_write_post_tag_chip, null) as Chip
@@ -130,28 +127,21 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
                         setTextAppearance(R.style.WritePostTagTextStyle)
                         isCloseIconVisible = false
                         isCheckable = false
-                        ensureAccessibleTouchTarget(42.toPx())
+                        ensureAccessibleTouchTarget(42.Px)
                         text = "# ${trimBlankText(it[index])}"
                     }
                     binding.chipgroupWriteOptionTagListSaved.addView(chip, layoutParams)
                 }
-            } else {
-                binding.tvWriteOptionDescriptionTag.visibility = View.VISIBLE
             }
         }
     }
 
     private fun setOptionTagClickListener() {
         binding.layoutWriteOptionTag.setOnDebounceClickListener {
-            if (writeViewModel.postTagList.value.isNullOrEmpty()) {
-                val navigateWithDataPassAction =
-                    WriteOptionFragmentDirections.actionWriteOptionFragmentToWriteTagFragment()
-                findNavController().navigate(navigateWithDataPassAction)
-            } else {
-                val navigateWithDataPassAction =
-                    WriteOptionFragmentDirections.actionWriteOptionFragmentToWriteTagFragment()
-                findNavController().navigate(navigateWithDataPassAction)
-            }
+            findNavController().navigateSafe(
+                currentDestinationId = R.id.WriteOptionFragment,
+                action = R.id.action_writeOptionFragment_to_writeTagFragment
+            )
         }
     }
 
@@ -162,45 +152,5 @@ class WriteOptionFragment : BottomSheetDialogFragment() {
                 action = R.id.action_writeOptionFragment_to_writeFolderFragment
             )
         }
-    }
-
-    private fun String.toBitmap(): Bitmap {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            ImageDecoder.decodeBitmap(
-                ImageDecoder.createSource(
-                    requireContext().contentResolver,
-                    this.toUri()
-                )
-            )
-        } else {
-            MediaStore.Images.Media.getBitmap(requireContext().contentResolver, this.toUri())
-        }
-    }
-
-    private fun bitmapToFile(bitmap: Bitmap?, path: String): File {
-        val file = File(path)
-        var out: OutputStream? = null
-        try {
-            file.createNewFile()
-            out = FileOutputStream(file)
-            bitmap?.compress(Bitmap.CompressFormat.JPEG, 100, out)
-        } finally {
-            out?.close()
-        }
-        return file
-    }
-
-    private fun setUploadImagePath(): String {
-        // uri를 통하여 불러온 이미지를 임시로 파일로 저장할 경로로 앱 내부 캐시 디렉토리로 설정,
-        // 파일 이름은 불러온 시간 사용
-        val fileName =
-            imageFileTimeFormat.format(Date(System.currentTimeMillis())).toString() + ".jpg"
-        val cacheDir = requireContext().cacheDir.toString()
-        return "$cacheDir/$fileName"
-    }
-
-    fun Int.toPx(): Int {
-        val density = resources.displayMetrics.density
-        return (this * density).toInt()
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteTagFragment.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.fragment.write
 
-import android.app.AlertDialog
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
@@ -32,20 +31,9 @@ import com.google.android.material.chip.ChipGroup
 class WriteTagFragment : Fragment() {
     private var binding by autoCleared<FragmentWriteTagBinding>()
     private val writeViewModel by activityViewModels<WriteViewModel>()
-    private lateinit var loadingAlertDialog: AlertDialog
+    private val loadingAlertDialog by lazy { LoadingAlertDialog.createLoadingDialog(requireContext()) }
     private val originalTags by lazy {
         (writeViewModel.postTagList.value ?: arrayListOf()).toMutableList()
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val onBackPressedCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                displayLoadingDialog()
-                findNavController().navigateUp()
-            }
-        }
-        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
     override fun onCreateView(
@@ -53,7 +41,6 @@ class WriteTagFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentWriteTagBinding.inflate(inflater, container, false)
-        loadingAlertDialog = LoadingAlertDialog.createLoadingDialog(requireContext())
         return binding.root
     }
 
@@ -73,6 +60,17 @@ class WriteTagFragment : Fragment() {
     }
 
     private fun setBackButtonClickListener() {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                displayLoadingDialog()
+                findNavController().navigateUp()
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            onBackPressedCallback
+        )
+
         binding.btnWriteTagBack.setOnDebounceClickListener {
             displayLoadingDialog()
             findNavController().navigateUp()
@@ -97,7 +95,7 @@ class WriteTagFragment : Fragment() {
                             .contains(removeBlankTag)
                         && binding.chipgroupWriteTagListSaved.size < MAX_TAG_COUNT
                     ) {
-                        writeViewModel.addPostTag(removeBlankTag)
+                        writeViewModel.addPostTag(removeBlankTag, true)
                     }
                     binding.etWriteTagAdd.setText("")
                     true
@@ -155,7 +153,7 @@ class WriteTagFragment : Fragment() {
                                     "#",
                                     ""
                                 )
-                            )
+                            ), true
                         )
                     }
                     text = "# ${trimBlankText(it[index])}"

--- a/app/src/main/res/layout/fragment_write_option.xml
+++ b/app/src/main/res/layout/fragment_write_option.xml
@@ -22,7 +22,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="18dp"
-        android:layout_marginTop="31dp"
+        android:paddingTop="31dp"
+        android:paddingBottom="23dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/img_write_option_swipe_top_bar">
 
@@ -62,7 +63,6 @@
         android:id="@+id/view_folder_horizontal_line"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="23dp"
         android:background="@color/gray_5_E8EAEE"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -74,6 +74,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="18dp"
         android:paddingTop="18dp"
+        android:paddingBottom="23dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/view_folder_horizontal_line">
 
@@ -143,7 +144,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="18dp"
-        android:layout_marginTop="43dp"
+        android:layout_marginTop="20dp"
         android:layout_marginBottom="18dp"
         android:background="@drawable/button_default_green"
         android:stateListAnimator="@null"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -124,15 +124,6 @@
             android:id="@+id/action_writeFragment_to_writeOptionFragment"
             app:destination="@id/WriteOptionFragment" />
         <action
-            android:id="@+id/action_writeFragment_to_postFragment"
-            app:destination="@id/PostFragment"
-            app:enterAnim="@anim/translate_from_right_in"
-            app:exitAnim="@anim/translate_nothing"
-            app:popEnterAnim="@anim/translate_nothing"
-            app:popExitAnim="@anim/translate_to_right_out"
-            app:popUpTo="@id/WriteFragment"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_writeFragment_to_writeImageOptionFragment"
             app:destination="@id/WriteImageOptionFragment" />
     </fragment>
@@ -147,6 +138,17 @@
         android:name="com.daily.dayo.presentation.fragment.write.WriteOptionFragment"
         android:label="fragment_write_option"
         tools:layout="@layout/fragment_write_option">
+
+        <action
+            android:id="@+id/action_writeOptionFragment_to_postFragment"
+            app:destination="@id/PostFragment"
+            app:enterAnim="@anim/translate_from_right_in"
+            app:exitAnim="@anim/translate_nothing"
+            app:popEnterAnim="@anim/translate_nothing"
+            app:popExitAnim="@anim/translate_to_right_out"
+            app:popUpTo="@id/WriteFragment"
+            app:popUpToInclusive="true" />
+
         <action
             android:id="@+id/action_writeOptionFragment_to_writeTagFragment"
             app:destination="@id/WriteTagFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,8 +108,10 @@
     <string name="write_post_upload_alert_message_empty_content">내용을 입력해 주세요.</string>
     <string name="write_post_upload_alert_message_empty_image">사진을 추가해 주세요.</string>
     <string name="write_post_upload_alert_message_empty_category">카테고리를 선택해 주세요.</string>
+    <string name="write_post_upload_alert_message_empty_folder">폴더를 선택해 주세요</string>
     <string name="write_post_upload_alert_message_edittext_length_fail_max">내용은 200자까지 작성할 수 있어요.</string>
     <string name="write_post_upload_alert_message_image_fail_max">사진은 5장까지만 선택 가능합니다.</string>
+    <string name="write_post_upload_alert_message_image_fail_null">사진 가져오기에 실패했습니다. 다시 선택해주세요</string>
     <string name="write_post_upload_alert_message_loading">게시글을 올리고 있어요! 잠시만 기다려주세요.</string>
     <string name="write_post_upload_alert_message_fail">게시글을 업로드 할 수 없어요. 다시 시도해주세요.</string>
 


### PR DESCRIPTION
## 내용 및 작업사항
- 기존에 `Fragment`에서 업로드한 이미지 리사이징 등의 작업을 하던 것을 `WriteViewModel`에서 작업하도록 변경
- 글을 업로드 하는 네트워킹 과정간에 `Dispatcher` 미설정으로 인한 `메인 스레드`를 사용하고 있던 것을 `IO 스레드`로 변경
- 글 업로드 완료 후 업로드한 글 상세보기로 넘어갈 때 기존에 `WriteFragment`로 이동한뒤 `PostFragment`로 넘어갔던 것을 `WriteOptionFragment`에서 바로 이동하도록 변경
   - `WriteFragment`에서 글 업로드 완료를 Observe했던 것을 `WriteOptionFragment`에서 Observe하도록 변경
- `Bitmap`과 `File` 변환 로직, Px`로의` 변환 로직을 `Fragment`에서 작업했던 것을 `Util`로 별도 분리
- `ListLiveData`를 사용하는 경우 `Background`에서도 사용할 수 있도록 `setValue`를 사용할 것인지 여부에 대해 설정가능하도록 `ListLiveData.kt` 코드 수정 (`setValue`는 `Background 스레드`에서 사용 불가)
- `WriteOptionFragment`에서 폴더 및 태그 레이아웃이 차지하는 크기가 작아 잘 눌리지 않던 문제 `margin` 대신 `padding`을 사용하도록 설정해 좀 더 클릭하기 쉽도록 레이아웃 변경
- 기타 기능상 변경 없이 코드수를 줄일 수 있는 부분 수정

## 참고
- resolved: #435 