### PR TITLE
[bug] Fix glide exception `Cannot obtain size for recycled Bitmap`

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
@@ -36,7 +36,7 @@ object GlideLoadUtil {
         imgView: ImageView,
         placeholderImg: Int? = null,
         errorImg: Int? = null,
-        placeholderLottie: LottieAnimationView?= null
+        placeholderLottie: LottieAnimationView? = null
     ) {
         requestManager
             .load("$BASE_URL_IMG${imgName}")
@@ -80,7 +80,7 @@ object GlideLoadUtil {
         imgView: ImageView,
         placeholderImg: Int? = null,
         errorImg: Int? = null,
-        placeholderLottie: LottieAnimationView?= null
+        placeholderLottie: LottieAnimationView? = null
     ) {
         requestManager.load(img)
             .override(width, height)
@@ -257,5 +257,9 @@ object GlideLoadUtil {
             .load("$BASE_URL_IMG${imgName}")
             .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
             .preload(width, height)
+    }
+
+    fun cancelImageLoad(requestManager: RequestManager, clearImageView: ImageView) {
+        requestManager.clear(clearImageView)
     }
 }

--- a/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/GlideLoadUtil.kt
@@ -22,6 +22,55 @@ object GlideLoadUtil {
     private const val BASE_URL_IMG = "${BuildConfig.BASE_URL}/images/"
     const val HOME_POST_THUMBNAIL_SIZE = 158
     const val HOME_USER_THUMBNAIL_SIZE = 17
+    const val COMMENT_USER_THUMBNAIL_SIZE = 40
+    const val PROFILE_USER_THUMBNAIL_SIZE = 70
+    const val PROFILE_EDIT_USER_THUMBNAIL_SIZE = 100
+    const val BLOCK_USER_THUMBNAIL_SIZE = 45
+    const val FOLLOW_USER_THUMBNAIL_SIZE = 40
+
+    fun loadImageView(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        imgName: String,
+        imgView: ImageView,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null,
+        placeholderLottie: LottieAnimationView?= null
+    ) {
+        requestManager
+            .load("$BASE_URL_IMG${imgName}")
+            .override(width, height)
+            .listener(object : RequestListener<Drawable> {
+                override fun onLoadFailed(
+                    e: GlideException?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    return false
+                }
+
+                override fun onResourceReady(
+                    resource: Drawable?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    dataSource: DataSource?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    placeholderLottie?.let { lottieView ->
+                        lottieView.visibility = View.GONE
+                    }
+                    return false
+                }
+            })
+            .thumbnail(0.1f)
+            .placeholder(placeholderImg ?: R.color.gray_3_9FA5AE)
+            .error(errorImg ?: R.drawable.ic_dayo_circle_grayscale)
+            .priority(Priority.HIGH)
+            .centerCrop()
+            .into(imgView)
+    }
 
     fun loadImageView(
         requestManager: RequestManager,
@@ -62,6 +111,36 @@ object GlideLoadUtil {
             .placeholder(placeholderImg ?: R.color.gray_3_9FA5AE)
             .error(errorImg ?: R.drawable.ic_dayo_circle_grayscale)
             .priority(Priority.HIGH)
+            .centerCrop()
+            .into(imgView)
+    }
+
+    fun loadImageViewProfile(
+        requestManager: RequestManager,
+        width: Int,
+        height: Int,
+        imgName: String,
+        imgView: ImageView,
+        placeholderImg: Int? = null,
+        errorImg: Int? = null
+    ) {
+        val requestOption =
+            if (placeholderImg != null && errorImg != null) {
+                RequestOptions()
+                    .placeholder(placeholderImg)
+                    .error(errorImg)
+            } else if (placeholderImg != null) {
+                RequestOptions().placeholder(placeholderImg)
+            } else if (errorImg != null) {
+                RequestOptions().error(errorImg)
+            } else {
+                RequestOptions()
+            }
+
+        requestManager
+            .load("$BASE_URL_IMG${imgName}")
+            .override(width, height)
+            .apply(requestOption)
             .centerCrop()
             .into(imgView)
     }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/BlockListAdapter.kt
@@ -7,22 +7,13 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil
+import com.daily.dayo.common.GlideLoadUtil.BLOCK_USER_THUMBNAIL_SIZE
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
-import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemBlockBinding
 import com.daily.dayo.domain.model.BlockUser
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class BlockListAdapter(
-    private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) :
+class BlockListAdapter(private val requestManager: RequestManager) :
     RecyclerView.Adapter<BlockListAdapter.BlockListViewHolder>() {
 
     companion object {
@@ -67,23 +58,13 @@ class BlockListAdapter(
 
         fun bind(blockUser: BlockUser) {
             binding.blockUser = blockUser.nickname
-            CoroutineScope(mainDispatcher).launch {
-                val profileImgBitmap = withContext(ioDispatcher) {
-                    GlideLoadUtil.loadImageBackground(
-                        requestManager = requestManager,
-                        width = 45,
-                        height = 45,
-                        imgName = blockUser.profileImg ?: ""
-                    )
-                }
-                GlideLoadUtil.loadImageView(
-                    requestManager = requestManager,
-                    width = 45,
-                    height = 45,
-                    img = profileImgBitmap,
-                    imgView = binding.imgBlockUserProfile
-                )
-            }
+            loadImageView(
+                requestManager = requestManager,
+                width = BLOCK_USER_THUMBNAIL_SIZE,
+                height = BLOCK_USER_THUMBNAIL_SIZE,
+                imgName = blockUser.profileImg ?: "",
+                imgView = binding.imgBlockUserProfile
+            )
             setUnblockButtonClickListener(blockUser)
         }
 

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FeedListAdapter.kt
@@ -1,7 +1,6 @@
 package com.daily.dayo.presentation.adapter
 
 import android.content.res.ColorStateList
-import android.graphics.Bitmap
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -14,28 +13,18 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.convertCountPlace
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
-import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFeedPostBinding
 import com.daily.dayo.domain.model.Post
 import com.daily.dayo.domain.model.categoryKR
 import com.daily.dayo.presentation.fragment.feed.FeedFragmentDirections
 import com.google.android.material.chip.Chip
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class FeedListAdapter(
-    private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : PagingDataAdapter<Post, FeedListAdapter.FeedListViewHolder>(diffCallback) {
+class FeedListAdapter(private val requestManager: RequestManager) :
+    PagingDataAdapter<Post, FeedListAdapter.FeedListViewHolder>(diffCallback) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Post>() {
             override fun areItemsTheSame(oldItem: Post, newItem: Post) =
@@ -52,7 +41,8 @@ class FeedListAdapter(
 
             override fun getChangePayload(oldItem: Post, newItem: Post): Any? {
                 return if (oldItem.heart != newItem.heart || oldItem.heartCount != newItem.heartCount ||
-                        oldItem.commentCount != newItem.commentCount) true else null
+                    oldItem.commentCount != newItem.commentCount
+                ) true else null
             }
         }
     }
@@ -93,40 +83,20 @@ class FeedListAdapter(
             binding.commentCountStr =
                 if (post?.commentCount != null) convertCountPlace(post.commentCount) else "0"
             binding.categoryKR = post?.category?.let { categoryKR(it) }
-            CoroutineScope(mainDispatcher).launch {
-                val postImgBitmap: Bitmap?
-                val userThumbnailImgBitmap: Bitmap?
-                postImgBitmap = withContext(ioDispatcher) {
-                    loadImageBackground(
-                        requestManager = requestManager,
-                        width = binding.imgFeedPost.width,
-                        height = binding.imgFeedPost.width,
-                        imgName = post?.thumbnailImage ?: ""
-                    )
-                }
-                userThumbnailImgBitmap = withContext(ioDispatcher) {
-                    loadImageBackground(
-                        requestManager = requestManager,
-                        width = binding.imgFeedPostUserProfile.width,
-                        height = binding.imgFeedPostUserProfile.height,
-                        imgName = post?.userProfileImage ?: ""
-                    )
-                }
-                loadImageView(
-                    requestManager = requestManager,
-                    width = binding.imgFeedPostUserProfile.width,
-                    height = binding.imgFeedPostUserProfile.height,
-                    img = userThumbnailImgBitmap,
-                    imgView = binding.imgFeedPostUserProfile
-                )
-                loadImageView(
-                    requestManager = requestManager,
-                    width = binding.imgFeedPost.width,
-                    height = binding.imgFeedPost.width,
-                    img = postImgBitmap,
-                    imgView = binding.imgFeedPost
-                )
-            }
+            loadImageView(
+                requestManager = requestManager,
+                width = binding.imgFeedPostUserProfile.width,
+                height = binding.imgFeedPostUserProfile.height,
+                imgName = post?.userProfileImage ?: "",
+                imgView = binding.imgFeedPostUserProfile
+            )
+            loadImageView(
+                requestManager = requestManager,
+                width = binding.imgFeedPost.width,
+                height = binding.imgFeedPost.width,
+                imgName = post?.thumbnailImage ?: "",
+                imgView = binding.imgFeedPost
+            )
 
             val isMine = (post?.memberId == DayoApplication.preferences.getCurrentUser().memberId)
             setPostOptionClickListener(

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FolderPostListAdapter.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.adapter
 
-import android.graphics.Bitmap
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -10,10 +9,8 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFolderPostBinding
 import com.daily.dayo.domain.model.FolderPost
@@ -22,8 +19,7 @@ import kotlinx.coroutines.*
 
 class FolderPostListAdapter(
     private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) : PagingDataAdapter<FolderPost, FolderPostListAdapter.FolderPostListViewHolder>(diffCallback) {
 
     companion object {
@@ -32,7 +28,9 @@ class FolderPostListAdapter(
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: FolderPost, newItem: FolderPost): Boolean =
-                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply {
+                    preLoadThumbnail = null
+                }
         }
     }
 
@@ -60,25 +58,11 @@ class FolderPostListAdapter(
             binding.imgFolderPost.visibility = View.INVISIBLE
 
             CoroutineScope(mainDispatcher).launch {
-                val folderPostImage: Bitmap?
-                if (folderPost?.preLoadThumbnail == null) {
-                    folderPostImage = withContext(ioDispatcher) {
-                        loadImageBackground(
-                            requestManager = requestManager,
-                            width = layoutParams.width,
-                            height = layoutParams.width,
-                            imgName = folderPost?.thumbnailImage ?: ""
-                        )
-                    }
-                } else {
-                    folderPostImage = folderPost.preLoadThumbnail!!
-                    folderPost.preLoadThumbnail = null
-                }
                 loadImageView(
                     requestManager = requestManager,
                     width = layoutParams.width,
                     height = layoutParams.width,
-                    img = folderPostImage,
+                    imgName = folderPost?.thumbnailImage ?: "",
                     imgView = binding.imgFolderPost
                 )
             }.invokeOnCompletion { throwable ->
@@ -93,7 +77,8 @@ class FolderPostListAdapter(
             }
 
             binding.root.setOnDebounceClickListener {
-                Navigation.findNavController(it).navigate(FolderFragmentDirections.actionFolderFragmentToPostFragment(folderPost!!.postId))
+                Navigation.findNavController(it)
+                    .navigate(FolderFragmentDirections.actionFolderFragmentToPostFragment(folderPost!!.postId))
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/FollowListAdapter.kt
@@ -9,24 +9,15 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.FOLLOW_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
-import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemFollowBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.fragment.mypage.follow.FollowFragmentDirections
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class FollowListAdapter(
-    private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
+class FollowListAdapter(private val requestManager: RequestManager) :
+    RecyclerView.Adapter<FollowListAdapter.FollowListViewHolder>() {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Follow>() {
@@ -72,23 +63,13 @@ class FollowListAdapter(
             binding.follow = follow
             binding.isMine =
                 follow.memberId == DayoApplication.preferences.getCurrentUser().memberId
-            CoroutineScope(mainDispatcher).launch {
-                val userThumbnailImgBitmap = withContext(ioDispatcher) {
-                    loadImageBackground(
-                        requestManager = requestManager,
-                        width = 40,
-                        height = 40,
-                        imgName = follow.profileImg ?: ""
-                    )
-                }
-                loadImageView(
-                    requestManager = requestManager,
-                    width = 40,
-                    height = 40,
-                    img = userThumbnailImgBitmap,
-                    imgView = binding.imgFollowUserProfile
-                )
-            }
+            loadImageView(
+                requestManager = requestManager,
+                width = FOLLOW_USER_THUMBNAIL_SIZE,
+                height = FOLLOW_USER_THUMBNAIL_SIZE,
+                imgName = follow.profileImg ?: "",
+                imgView = binding.imgFollowUserProfile
+            )
 
             setRootClickListener(follow.memberId)
             setFollowButtonClickListener(follow)

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -268,20 +268,56 @@ class HomeDayoPickAdapter(
                     postContent.preLoadUserImg = null
                 }
 
-                loadImageView(
-                    requestManager = requestManager,
-                    width = HOME_POST_THUMBNAIL_SIZE,
-                    height = HOME_POST_THUMBNAIL_SIZE,
-                    img = postImgBitmap!!,
-                    imgView = postImg
-                )
-                loadImageViewProfile(
-                    requestManager = requestManager,
-                    width = HOME_USER_THUMBNAIL_SIZE,
-                    height = HOME_USER_THUMBNAIL_SIZE,
-                    img = userThumbnailImgBitmap!!,
-                    imgView = userThumbnailImg
-                )
+                try {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        img = postImgBitmap!!,
+                        imgView = postImg
+                    )
+                } catch (loadException: IllegalStateException) {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        imgName = postContent.thumbnailImage ?: "",
+                        imgView = postImg
+                    )
+                } catch (imgNullException: NullPointerException) {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        imgName = postContent.thumbnailImage ?: "",
+                        imgView = postImg
+                    )
+                }
+                try {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        img = userThumbnailImgBitmap!!,
+                        imgView = userThumbnailImg
+                    )
+                } catch (loadException: IllegalStateException) {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        imgName = postContent.userProfileImage ?: "",
+                        imgView = userThumbnailImg
+                    )
+                } catch (imgNullException: NullPointerException) {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        imgName = postContent.userProfileImage ?: "",
+                        imgView = userThumbnailImg
+                    )
+                }
             }.invokeOnCompletion { throwable ->
                 when (throwable) {
                     is CancellationException -> Log.e("Image Loading", "CANCELLED")

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -6,14 +6,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
 import androidx.core.view.isVisible
 import androidx.databinding.library.baseAdapters.BR
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.airbnb.lottie.LottieAnimationView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.GlideLoadUtil.HOME_POST_THUMBNAIL_SIZE
@@ -266,20 +264,57 @@ class HomeNewAdapter(
                     postContent.preLoadThumbnail = null
                     postContent.preLoadUserImg = null
                 }
-                loadImageView(
-                    requestManager = requestManager,
-                    width = HOME_POST_THUMBNAIL_SIZE,
-                    height = HOME_POST_THUMBNAIL_SIZE,
-                    img = postImgBitmap!!,
-                    imgView = postImg
-                )
-                loadImageViewProfile(
-                    requestManager = requestManager,
-                    width = HOME_USER_THUMBNAIL_SIZE,
-                    height = HOME_USER_THUMBNAIL_SIZE,
-                    img = userThumbnailImgBitmap!!,
-                    imgView = userThumbnailImg
-                )
+
+                try {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        img = postImgBitmap!!,
+                        imgView = postImg
+                    )
+                } catch (loadException: IllegalStateException) {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        imgName = postContent.thumbnailImage ?: "",
+                        imgView = postImg
+                    )
+                } catch (imgNullException: NullPointerException) {
+                    loadImageView(
+                        requestManager = requestManager,
+                        width = HOME_POST_THUMBNAIL_SIZE,
+                        height = HOME_POST_THUMBNAIL_SIZE,
+                        imgName = postContent.thumbnailImage ?: "",
+                        imgView = postImg
+                    )
+                }
+                try {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        img = userThumbnailImgBitmap!!,
+                        imgView = userThumbnailImg
+                    )
+                } catch (loadException: IllegalStateException) {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        imgName = postContent.userProfileImage ?: "",
+                        imgView = userThumbnailImg
+                    )
+                } catch (imgNullException: NullPointerException) {
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = HOME_USER_THUMBNAIL_SIZE,
+                        height = HOME_USER_THUMBNAIL_SIZE,
+                        imgName = postContent.userProfileImage ?: "",
+                        imgView = userThumbnailImg
+                    )
+                }
             }.invokeOnCompletion { throwable ->
                 when (throwable) {
                     is CancellationException -> Log.e("Image Loading", "CANCELLED")

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/NotificationListAdapter.kt
@@ -16,26 +16,17 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
-import com.daily.dayo.common.GlideLoadUtil
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
-import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemNotificationBinding
 import com.daily.dayo.domain.model.Notification
 import com.daily.dayo.domain.model.Topic
 import com.daily.dayo.presentation.fragment.notification.NotificationFragmentDirections
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class NotificationListAdapter(
-    private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : PagingDataAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
-    diffCallback
-) {
+class NotificationListAdapter(private val requestManager: RequestManager) :
+    PagingDataAdapter<Notification, NotificationListAdapter.NotificationListViewHolder>(
+        diffCallback
+    ) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<Notification>() {
             override fun areItemsTheSame(oldItem: Notification, newItem: Notification) =
@@ -75,23 +66,13 @@ class NotificationListAdapter(
                     ViewGroup.MarginLayoutParams.MATCH_PARENT,
                     ViewGroup.MarginLayoutParams.MATCH_PARENT
                 )
-                CoroutineScope(mainDispatcher).launch {
-                    val thumbnailImage = withContext(ioDispatcher) {
-                        GlideLoadUtil.loadImageBackground(
-                            requestManager = requestManager,
-                            width = 56,
-                            height = 56,
-                            imgName = notification.image ?: ""
-                        )
-                    }
-                    GlideLoadUtil.loadImageView(
-                        requestManager = requestManager,
-                        width = layoutParams.width,
-                        height = layoutParams.width,
-                        img = thumbnailImage,
-                        imgView = binding.ivNotificationThumbnail
-                    )
-                }
+                loadImageView(
+                    requestManager = requestManager,
+                    width = layoutParams.width,
+                    height = layoutParams.width,
+                    imgName = notification.image,
+                    imgView = binding.ivNotificationThumbnail
+                )
             }
 
             val spanContent = SpannableStringBuilder()

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostCommentAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostCommentAdapter.kt
@@ -10,25 +10,16 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.BR
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideLoadUtil
+import com.daily.dayo.common.GlideLoadUtil.COMMENT_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
-import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemPostCommentBinding
 import com.daily.dayo.domain.model.Comment
 import com.daily.dayo.presentation.fragment.post.PostFragmentDirections
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class PostCommentAdapter(
-    private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : ListAdapter<Comment, PostCommentAdapter.PostCommentViewHolder>(
+class PostCommentAdapter(private val requestManager: RequestManager) :
+    ListAdapter<Comment, PostCommentAdapter.PostCommentViewHolder>(
         diffCallback
     ) {
     companion object {
@@ -83,23 +74,13 @@ class PostCommentAdapter(
                 layoutPostCommentDelete.setOnDebounceClickListener {
                     Snackbar.make(it, "삭제버튼 클릭", Snackbar.LENGTH_SHORT).show()
                 }
-                CoroutineScope(mainDispatcher).launch {
-                    val userThumbnailImgBitmap = withContext(ioDispatcher) {
-                        GlideLoadUtil.loadImageBackground(
-                            requestManager = requestManager,
-                            width = 40,
-                            height = 40,
-                            imgName = comment.profileImg
-                        )
-                    }
-                    loadImageViewProfile(
-                        requestManager = requestManager,
-                        width = 40,
-                        height = 40,
-                        img = userThumbnailImgBitmap,
-                        imgView = imgPostCommentUserProfile
-                    )
-                }
+                loadImageViewProfile(
+                    requestManager = requestManager,
+                    width = COMMENT_USER_THUMBNAIL_SIZE,
+                    height = COMMENT_USER_THUMBNAIL_SIZE,
+                    imgName = comment.profileImg,
+                    imgView = imgPostCommentUserProfile
+                )
             }
 
             val pos = adapterPosition

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
@@ -14,21 +14,18 @@ import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.GlideLoadUtil
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
-import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemPostImageSliderBinding
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class PostImageSliderAdapter(
     private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) : ListAdapter<String, PostImageSliderAdapter.PostImageViewHolder>(
-        diffCallback
-    ) {
+    diffCallback
+) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<String>() {
             override fun areItemsTheSame(oldItem: String, newItem: String) =
@@ -87,19 +84,11 @@ class PostImageSliderAdapter(
                 ViewGroup.MarginLayoutParams.MATCH_PARENT
             )
             CoroutineScope(mainDispatcher).launch {
-                val postImage = withContext(ioDispatcher) {
-                    GlideLoadUtil.loadImageBackground(
-                        requestManager = requestManager,
-                        width = layoutParams.width,
-                        height = layoutParams.width,
-                        imgName = imageURL ?: ""
-                    )
-                }
                 loadImageView(
                     requestManager = requestManager,
                     width = layoutParams.width,
                     height = layoutParams.width,
-                    img = postImage,
+                    imgName = imageURL ?: "",
                     imgView = binding.imgSlider,
                     placeholderLottie = binding.lottiePostImage
                 )

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileBookmarkPostListAdapter.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.adapter
 
-import android.graphics.Bitmap
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -9,9 +8,8 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil
+import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfilePostBinding
 import com.daily.dayo.domain.model.BookmarkPost
@@ -19,9 +17,10 @@ import kotlinx.coroutines.*
 
 class ProfileBookmarkPostListAdapter(
     private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : PagingDataAdapter<BookmarkPost, ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>(diffCallback) {
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
+) : PagingDataAdapter<BookmarkPost, ProfileBookmarkPostListAdapter.ProfileBookmarkPostListViewHolder>(
+    diffCallback
+) {
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<BookmarkPost>() {
@@ -29,7 +28,9 @@ class ProfileBookmarkPostListAdapter(
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: BookmarkPost, newItem: BookmarkPost): Boolean =
-                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply {
+                    preLoadThumbnail = null
+                }
         }
     }
 
@@ -71,25 +72,11 @@ class ProfileBookmarkPostListAdapter(
             binding.imgProfilePost.visibility = View.INVISIBLE
 
             CoroutineScope(mainDispatcher).launch {
-                val userThumbnailImgBitmap: Bitmap?
-                if (bookmarkPost?.preLoadThumbnail == null) {
-                    userThumbnailImgBitmap = withContext(ioDispatcher) {
-                        GlideLoadUtil.loadImageBackground(
-                            requestManager = requestManager,
-                            width = layoutParams.width,
-                            height = layoutParams.width,
-                            imgName = bookmarkPost?.thumbnailImage ?: ""
-                        )
-                    }
-                } else {
-                    userThumbnailImgBitmap = bookmarkPost.preLoadThumbnail
-                    bookmarkPost.preLoadThumbnail = null
-                }
-                GlideLoadUtil.loadImageView(
+                loadImageView(
                     requestManager = requestManager,
                     width = layoutParams.width,
                     height = layoutParams.width,
-                    img = userThumbnailImgBitmap!!,
+                    imgName = bookmarkPost?.thumbnailImage ?: "",
                     imgView = binding.imgProfilePost
                 )
             }.invokeOnCompletion { throwable ->

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileFolderListAdapter.kt
@@ -7,22 +7,18 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfileFolderBinding
 import com.daily.dayo.domain.model.Folder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class ProfileFolderListAdapter(
     private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) : RecyclerView.Adapter<ProfileFolderListAdapter.ProfileFolderListViewHolder>() {
 
     companion object {
@@ -73,19 +69,11 @@ class ProfileFolderListAdapter(
 
             binding.folder = folder
             CoroutineScope(mainDispatcher).launch {
-                val profileFolderThumbnailImage = withContext(ioDispatcher) {
-                    loadImageBackground(
-                        requestManager = requestManager,
-                        width = layoutParams.width,
-                        height = 163,
-                        imgName = folder.thumbnailImage
-                    )
-                }
                 loadImageView(
                     requestManager = requestManager,
                     width = layoutParams.width,
                     163,
-                    img = profileFolderThumbnailImage,
+                    imgName = folder.thumbnailImage,
                     imgView = binding.btnProfileFolderItem
                 )
             }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/ProfileLikePostListAdapter.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.adapter
 
-import android.graphics.Bitmap
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -9,10 +8,8 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
-import com.daily.dayo.data.di.IoDispatcher
 import com.daily.dayo.data.di.MainDispatcher
 import com.daily.dayo.databinding.ItemProfilePostBinding
 import com.daily.dayo.domain.model.LikePost
@@ -20,8 +17,7 @@ import kotlinx.coroutines.*
 
 class ProfileLikePostListAdapter(
     private val requestManager: RequestManager,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) :
     PagingDataAdapter<LikePost, ProfileLikePostListAdapter.ProfileLikePostListViewHolder>(
         diffCallback
@@ -33,7 +29,9 @@ class ProfileLikePostListAdapter(
                 oldItem.postId == newItem.postId
 
             override fun areContentsTheSame(oldItem: LikePost, newItem: LikePost): Boolean =
-                oldItem.apply { preLoadThumbnail = null } == newItem.apply { preLoadThumbnail = null }
+                oldItem.apply { preLoadThumbnail = null } == newItem.apply {
+                    preLoadThumbnail = null
+                }
 
             override fun getChangePayload(oldItem: LikePost, newItem: LikePost): Any? {
                 return if (oldItem.postId != newItem.postId || oldItem.thumbnailImage != newItem.thumbnailImage) true else null
@@ -78,25 +76,11 @@ class ProfileLikePostListAdapter(
             binding.imgProfilePost.visibility = View.INVISIBLE
 
             CoroutineScope(mainDispatcher).launch {
-                val profileListPostImage: Bitmap?
-                if (likePost.preLoadThumbnail == null) {
-                    profileListPostImage = withContext(ioDispatcher) {
-                        loadImageBackground(
-                            requestManager = requestManager,
-                            width = layoutParams.width,
-                            height = layoutParams.width,
-                            imgName = likePost.thumbnailImage
-                        )
-                    }
-                } else {
-                    profileListPostImage = likePost.preLoadThumbnail
-                    likePost.preLoadThumbnail = null
-                }
                 loadImageView(
                     requestManager = requestManager,
                     width = layoutParams.width,
                     height = layoutParams.width,
-                    img = profileListPostImage!!,
+                    imgName = likePost.thumbnailImage,
                     imgView = binding.imgProfilePost
                 )
             }.invokeOnCompletion { throwable ->

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
@@ -1,6 +1,5 @@
 package com.daily.dayo.presentation.adapter
 
-import android.graphics.Bitmap
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -10,7 +9,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
+import com.daily.dayo.common.GlideLoadUtil.HOME_POST_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.ItemSearchResultPostBinding
@@ -61,25 +60,11 @@ class SearchTagResultPostAdapter(private val requestManager: RequestManager) :
             binding.imgSearchResultPost.visibility = View.INVISIBLE
 
             CoroutineScope(Dispatchers.Main).launch {
-                val postImage: Bitmap?
-                if (postContent?.preLoadThumbnail == null) {
-                    postImage = withContext(Dispatchers.IO) {
-                        loadImageBackground(
-                            requestManager = requestManager,
-                            width = 158,
-                            height = 158,
-                            imgName = postContent?.thumbnailImage ?: ""
-                        )
-                    }
-                } else {
-                    postImage = postContent.preLoadThumbnail
-                    postContent.preLoadThumbnail = null
-                }
                 loadImageView(
                     requestManager = requestManager,
-                    width = 158,
-                    height = 158,
-                    img = postImage!!,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
+                    imgName = postContent?.thumbnailImage ?: "",
                     imgView = binding.imgSearchResultPost
                 )
             }.invokeOnCompletion { throwable ->

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -78,11 +78,7 @@ class FeedFragment : Fragment() {
 
     private fun setRvFeedListAdapter() {
         feedListAdapter = glideRequestManager?.let { requestManager ->
-            FeedListAdapter(
-                requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
-            )
+            FeedListAdapter(requestManager = requestManager)
         }
         binding.rvFeedPost.adapter = feedListAdapter
     }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderEditFragment.kt
@@ -26,7 +26,6 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.Status
@@ -36,10 +35,7 @@ import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentFolderSettingAddBinding
 import com.daily.dayo.domain.model.Privacy
 import com.daily.dayo.presentation.viewmodel.FolderViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -54,7 +50,7 @@ class FolderEditFragment : Fragment() {
     }
     private val folderViewModel by activityViewModels<FolderViewModel>()
     private val args by navArgs<FolderEditFragmentArgs>()
-    private var glideRequestManager: RequestManager?= null
+    private var glideRequestManager: RequestManager? = null
     private lateinit var imageUri: String
     var thumbnailImgBitmap: Bitmap? = null
     private lateinit var loadingAlertDialog: AlertDialog
@@ -69,6 +65,7 @@ class FolderEditFragment : Fragment() {
         initializeLoadingDialog()
         return binding.root
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setFolderInfoDescription()
@@ -120,32 +117,20 @@ class FolderEditFragment : Fragment() {
                             }
                             viewLifecycleOwner.lifecycleScope.launch {
                                 viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                    val folderThumbnailImage = withContext(Dispatchers.IO) {
-                                        glideRequestManager?.let { requestManager ->
-                                            loadImageBackground(
-                                                requestManager = requestManager,
-                                                width = layoutParams.width,
-                                                height = 40,
-                                                imgName = folder.thumbnailImage
-                                            )
-                                        }
-                                    }
                                     glideRequestManager?.let { requestManager ->
-                                        if (folderThumbnailImage != null) {
-                                            loadImageView(
-                                                requestManager = requestManager,
-                                                width = layoutParams.width,
-                                                height = 148,
-                                                img = folderThumbnailImage,
-                                                imgView = binding.ivFolderSettingThumbnail
-                                            )
-                                        }
+                                        loadImageView(
+                                            requestManager = requestManager,
+                                            width = layoutParams.width,
+                                            height = 148,
+                                            imgName = folder.thumbnailImage,
+                                            imgView = binding.ivFolderSettingThumbnail
+                                        )
                                     }
                                 }
                             }
                         }
                     }
-                    else -> { }
+                    else -> {}
                 }
             }
         }
@@ -214,7 +199,8 @@ class FolderEditFragment : Fragment() {
                 imageUri = it
                 if (this::imageUri.isInitialized) {
                     if (imageUri == "") {
-                        glideRequestManager?.load(R.drawable.ic_folder_thumbnail_empty)?.centerCrop()
+                        glideRequestManager?.load(R.drawable.ic_folder_thumbnail_empty)
+                            ?.centerCrop()
                             ?.into(binding.ivFolderSettingThumbnail)
                         thumbnailImgBitmap = null
                     } else {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
@@ -15,7 +15,6 @@ import androidx.paging.LoadState
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackground
 import com.daily.dayo.common.GlideLoadUtil.loadImageView
 import com.daily.dayo.common.Status
 import com.daily.dayo.common.autoCleared
@@ -25,7 +24,6 @@ import com.daily.dayo.presentation.adapter.FolderPostListAdapter
 import com.daily.dayo.presentation.viewmodel.FolderViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class FolderFragment : Fragment() {
     private var binding by autoCleared<FragmentFolderBinding> { onDestroyBindingView() }
@@ -94,30 +92,14 @@ class FolderFragment : Fragment() {
                     it.data?.let { folder ->
                         binding.folder = folder
                         binding.isMine = folder.memberId == DayoApplication.preferences.getCurrentUser().memberId
-                        viewLifecycleOwner.lifecycleScope.launch {
-                            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                val folderThumbnailImage = withContext(Dispatchers.IO) {
-                                    glideRequestManager?.let { requestManager ->
-                                        loadImageBackground(
-                                            requestManager = requestManager,
-                                            width = layoutParams.width,
-                                            height = 200,
-                                            imgName = folder.thumbnailImage
-                                        )
-                                    }
-                                }
-                                glideRequestManager?.let { requestManager ->
-                                    if (folderThumbnailImage != null) {
-                                        loadImageView(
-                                            requestManager = requestManager,
-                                            width = layoutParams.width,
-                                            height = 200,
-                                            img = folderThumbnailImage,
-                                            imgView = binding.imgFolderThumbnail
-                                        )
-                                    }
-                                }
-                            }
+                        glideRequestManager?.let { requestManager ->
+                            loadImageView(
+                                requestManager = requestManager,
+                                width = layoutParams.width,
+                                height = 200,
+                                imgName = folder.thumbnailImage,
+                                imgView = binding.imgFolderThumbnail
+                            )
                         }
                     }
                 }
@@ -130,8 +112,7 @@ class FolderFragment : Fragment() {
         folderPostListAdapter = glideRequestManager?.let { requestManager ->
             FolderPostListAdapter(
                 requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
+                mainDispatcher = Dispatchers.Main
             )
         }
         binding.rvFolderPost.adapter = folderPostListAdapter

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowerListFragment.kt
@@ -18,7 +18,6 @@ import com.daily.dayo.databinding.FragmentFollowerListBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.adapter.FollowListAdapter
 import com.daily.dayo.presentation.viewmodel.FollowViewModel
-import kotlinx.coroutines.Dispatchers
 
 class FollowerListFragment : Fragment() {
     private var binding by autoCleared<FragmentFollowerListBinding> { onDestroyBindingView() }
@@ -51,11 +50,7 @@ class FollowerListFragment : Fragment() {
 
     private fun setRvFollowerListAdapter() {
         followerListAdapter = glideRequestManager?.let { requestManager ->
-            FollowListAdapter(
-                requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
-            )
+            FollowListAdapter(requestManager = requestManager)
         }
         binding.rvFollower.adapter = followerListAdapter
         followerListAdapter?.setOnItemClickListener(object : FollowListAdapter.OnItemClickListener {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/follow/FollowingListFragment.kt
@@ -18,7 +18,6 @@ import com.daily.dayo.databinding.FragmentFollowingListBinding
 import com.daily.dayo.domain.model.Follow
 import com.daily.dayo.presentation.adapter.FollowListAdapter
 import com.daily.dayo.presentation.viewmodel.FollowViewModel
-import kotlinx.coroutines.Dispatchers
 
 class FollowingListFragment : Fragment() {
     private var binding by autoCleared<FragmentFollowingListBinding> { onDestroyBindingView() }
@@ -51,11 +50,7 @@ class FollowingListFragment : Fragment() {
 
     private fun setRvFollowingListAdapter() {
         followingListAdapter = glideRequestManager?.let { requestManager ->
-            FollowListAdapter(
-                requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
-            )
+            FollowListAdapter(requestManager = requestManager)
         }
         binding.rvFollowing.adapter = followingListAdapter
         followingListAdapter?.setOnItemClickListener(object :

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
@@ -6,16 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
-import com.daily.dayo.common.GlideLoadUtil.loadImageBackgroundProfile
+import com.daily.dayo.common.GlideLoadUtil.PROFILE_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.GlideLoadUtil.loadImageViewProfile
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.setOnDebounceClickListener
@@ -23,9 +20,6 @@ import com.daily.dayo.databinding.FragmentMyPageBinding
 import com.daily.dayo.presentation.adapter.ProfileFragmentPagerStateAdapter
 import com.daily.dayo.presentation.viewmodel.ProfileViewModel
 import com.google.android.material.tabs.TabLayoutMediator
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class MyPageFragment : Fragment() {
     private var binding by autoCleared<FragmentMyPageBinding> { onDestroyBindingView() }
@@ -76,28 +70,14 @@ class MyPageFragment : Fragment() {
         profileViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
                 binding.profile = profile
-                viewLifecycleOwner.lifecycleScope.launch {
-                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                        val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                            glideRequestManager?.let { requestManager ->
-                                loadImageBackgroundProfile(
-                                    requestManager = requestManager,
-                                    width = 70, height = 70, imgName = profile.profileImg
-                                )
-                            }
-                        }
-                        glideRequestManager?.let { requestManager ->
-                            if (userProfileThumbnailImage != null) {
-                                loadImageViewProfile(
-                                    requestManager = requestManager,
-                                    width = 70,
-                                    height = 70,
-                                    img = userProfileThumbnailImage,
-                                    imgView = binding.imgMyPageUserProfile
-                                )
-                            }
-                        }
-                    }
+                glideRequestManager?.let { requestManager ->
+                    loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = PROFILE_USER_THUMBNAIL_SIZE,
+                        height = PROFILE_USER_THUMBNAIL_SIZE,
+                        imgName = profile.profileImg,
+                        imgView = binding.imgMyPageUserProfile
+                    )
                 }
 
                 profile.memberId?.let {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
@@ -54,8 +54,7 @@ class ProfileBookmarkPostListFragment : Fragment() {
         profileBookmarkPostListAdapter = glideRequestManager?.let { requestManager ->
             ProfileBookmarkPostListAdapter(
                 requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
+                mainDispatcher = Dispatchers.Main
             )
         }
         binding.rvProfileBookmarkPost.adapter = profileBookmarkPostListAdapter

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -21,15 +21,13 @@ import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.common.*
+import com.daily.dayo.common.GlideLoadUtil.PROFILE_EDIT_USER_THUMBNAIL_SIZE
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.databinding.FragmentProfileEditBinding
@@ -118,30 +116,14 @@ class ProfileEditFragment : Fragment() {
         profileSettingViewModel.requestProfile(memberId = DayoApplication.preferences.getCurrentUser().memberId!!)
         profileSettingViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
-                viewLifecycleOwner.lifecycleScope.launch {
-                    viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                        val userProfileThumbnailImage = withContext(Dispatchers.IO) {
-                            glideRequestManager?.let { requestManager ->
-                                GlideLoadUtil.loadImageBackgroundProfile(
-                                    requestManager = requestManager,
-                                    width = 100,
-                                    height = 100,
-                                    imgName = profile.profileImg
-                                )
-                            }
-                        }
-                        glideRequestManager?.let { requestManager ->
-                            if (userProfileThumbnailImage != null) {
-                                GlideLoadUtil.loadImageViewProfile(
-                                    requestManager = requestManager,
-                                    width = 100,
-                                    height = 100,
-                                    img = userProfileThumbnailImage,
-                                    imgView = binding.imgProfileEditUserImage
-                                )
-                            }
-                        }
-                    }
+                glideRequestManager?.let { requestManager ->
+                    GlideLoadUtil.loadImageViewProfile(
+                        requestManager = requestManager,
+                        width = PROFILE_EDIT_USER_THUMBNAIL_SIZE,
+                        height = PROFILE_EDIT_USER_THUMBNAIL_SIZE,
+                        imgName = profile.profileImg,
+                        imgView = binding.imgProfileEditUserImage
+                    )
                 }
                 binding.etProfileEditNickname.setText(profile.nickname)
             }
@@ -200,7 +182,11 @@ class ProfileEditFragment : Fragment() {
                                 trimBlankText(s)
                             )
                         ) {
-                            profileSettingViewModel.requestCheckNicknameDuplicate(trimBlankText(binding.etProfileEditNickname.text))
+                            profileSettingViewModel.requestCheckNicknameDuplicate(
+                                trimBlankText(
+                                    binding.etProfileEditNickname.text
+                                )
+                            )
                             profileSettingViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
                                 if (isDuplicate) {
                                     setEditTextTheme(

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -49,8 +49,7 @@ class ProfileFolderListFragment : Fragment() {
         profileFolderListAdapter = glideRequestManager?.let {
             ProfileFolderListAdapter(
                 requestManager = it,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
+                mainDispatcher = Dispatchers.Main
             )
         }
         binding.rvProfileFolder.adapter = profileFolderListAdapter

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
@@ -53,8 +53,7 @@ class ProfileLikePostListFragment : Fragment() {
         profileLikePostListAdapter = glideRequestManager?.let { requestManager ->
             ProfileLikePostListAdapter(
                 requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
+                mainDispatcher = Dispatchers.Main
             )
         }
         binding.rvProfileLikePost.adapter = profileLikePostListAdapter

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
@@ -53,11 +53,7 @@ class NotificationFragment : Fragment() {
 
     private fun setNotificationListAdapter() {
         notificationAdapter = glideRequestManager?.let {
-            NotificationListAdapter(
-                requestManager = it,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
-            )
+            NotificationListAdapter(requestManager = it)
         }
         binding.rvNotificationList.layoutManager = LinearLayoutManager(requireContext())
         binding.rvNotificationList.adapter = notificationAdapter

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/setting/block/SettingBlockFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/setting/block/SettingBlockFragment.kt
@@ -58,11 +58,7 @@ class SettingBlockFragment : Fragment() {
 
     private fun setBlockListAdapter() {
         blockListAdapter = glideRequestManager?.let { requestManager ->
-            BlockListAdapter(
-                requestManager = requestManager,
-                mainDispatcher = Dispatchers.Main,
-                ioDispatcher = Dispatchers.IO
-            )
+            BlockListAdapter(requestManager = requestManager)
         }
         binding.rvBlock.adapter = blockListAdapter
         blockListAdapter?.setOnItemClickListener(object :


### PR DESCRIPTION
## 내용
- Glide 사용간 'Cannot obtain size for recycled Bitmap' 예외가 발생하면서 앱이 종료되는 현상 해결
  - 해당 예외는 Glide를 사용할 때 `bitmap pool`에 해당 `bitmap`이 없음에도, `recycle()` 메소드를 이용해 bitmap을 얻으려고 할 때 발생한다.
  - 문제는, 해당 프로젝트에서 `bitmap.recycle()`을 호출한 적이 없음에도 해당 예외가 발생한다는 것이었다.

## 원인
- 그러나, 해당 프로젝트에서 이미지를 보여주는 경우에 Glide를 활용해 Background에서 이미지를 Get한 뒤에 그 이미지를 캐시에서 찾아오는 방식으로 동작하고 있었기 때문에, 결국엔 `bitmap`이 `bitmap pool`에 없는데도 recycle하려고 하는 것과 같은 결과를 내고 있는 것으로 판단됨

## 작업 사항
- 서버로부터 받아오는 이미지 로딩과 이미지를 보여주는 경우에 분리될 필요가 없는 경우, **불필요한 Background 호출 삭제 및 직접적으로 Glide에서 load한 뒤 받아 올 수 있도록 설정**
- Home 탭과 같이 미리 로드되는 이미지가 존재해, 서버와의 통신과 이미지를 보여주는 시기의 차이가 존재하는 경우, 기존의 Background에서 로드한 뒤 해당 bitmap을 이용하는 로직을 유지하되, bitmap pool에서 해당 bitmap이 로드한 뒤 이미지 뷰를 통해 이미지를 보여주기 전에 삭제돼 이미지 뷰에서 bitmap을 정상적으로 로딩하지 못하는 경우 bitmap을 다시 서버에서 받아올 수 있도록 `try ~ catch` 예외 처리 추가
- 추가적으로 메모리가 부족한 상황이 되는 경우, Glide에서 사용하고 있는 메모리를 Clear할 수 있도록 명시적으로 처리
- 이외에 Profile, Folder 페이지 등 기존에 미리 로드되는 이미지가 존재하지 않는데도 Preload 이미지를 체크하던 코드 삭제

## 참고
- #413 