### PR TITLE
#443 [layout] SearchResultFragment RecyclerView

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
@@ -10,6 +10,7 @@ import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.daily.dayo.R
 import com.daily.dayo.common.HideKeyBoardUtil
 import com.daily.dayo.common.ReplaceUnicode
 import com.daily.dayo.common.autoCleared
@@ -126,10 +127,7 @@ class SearchFragment : Fragment() {
     }
 
     private fun searchKeyword(keyword: String) {
-        findNavController().navigate(
-            SearchFragmentDirections.actionSearchFragmentToSearchResultFragment(
-                keyword
-            )
-        )
+        searchViewModel.searchKeyword = keyword
+        findNavController().navigate(R.id.action_searchFragment_to_searchResultFragment)
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
@@ -49,6 +49,7 @@ class SearchFragment : Fragment() {
 
     private fun onDestroyBindingView() {
         searchKeywordRecentAdapter = null
+        binding.rvSearchRecentKeyword.adapter = null
     }
 
     private fun setBackButtonClickListener() {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchFragment.kt
@@ -21,9 +21,9 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SearchFragment : Fragment() {
-    private var binding by autoCleared<FragmentSearchBinding>()
+    private var binding by autoCleared<FragmentSearchBinding> { onDestroyBindingView() }
     private val searchViewModel by activityViewModels<SearchViewModel>()
-    private lateinit var searchKeywordRecentAdapter: SearchKeywordRecentAdapter
+    private var searchKeywordRecentAdapter: SearchKeywordRecentAdapter? = null
     private lateinit var searchKeywordRecentList: ArrayList<String>
 
     override fun onCreateView(
@@ -31,6 +31,11 @@ class SearchFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View? {
         binding = FragmentSearchBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setBackButtonClickListener()
         setSearchKeywordRecentListAdapter()
         setSearchEditTextListener()
@@ -38,12 +43,11 @@ class SearchFragment : Fragment() {
         setSearchKeywordRecentClickListener()
         setSearchKeywordInputDone()
         setSearchKeywordInputRemoveClickListener()
-        return binding.root
+        HideKeyBoardUtil.hideTouchDisplay(requireActivity(), view)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        HideKeyBoardUtil.hideTouchDisplay(requireActivity(), view)
+    private fun onDestroyBindingView() {
+        searchKeywordRecentAdapter = null
     }
 
     private fun setBackButtonClickListener() {
@@ -97,11 +101,11 @@ class SearchFragment : Fragment() {
 
     private fun initSearchKeywordRecentList() {
         searchKeywordRecentList = searchViewModel.getSearchKeywordRecent()
-        searchKeywordRecentAdapter.submitList(searchKeywordRecentList)
+        searchKeywordRecentAdapter?.submitList(searchKeywordRecentList)
     }
 
     private fun setSearchKeywordRecentClickListener() {
-        searchKeywordRecentAdapter.setOnItemClickListener(object :
+        searchKeywordRecentAdapter?.setOnItemClickListener(object :
             SearchKeywordRecentAdapter.OnItemClickListener {
             override fun onItemClick(v: View, keyword: String, pos: Int) {
                 searchKeyword(keyword)
@@ -110,14 +114,14 @@ class SearchFragment : Fragment() {
             override fun deleteSearchKeywordRecentClick(keyword: String, pos: Int) {
                 searchViewModel.deleteSearchKeywordRecent(keyword)
                 searchKeywordRecentList = searchViewModel.getSearchKeywordRecent()
-                searchKeywordRecentAdapter.submitList(searchKeywordRecentList)
+                searchKeywordRecentAdapter?.submitList(searchKeywordRecentList)
             }
         })
 
         binding.tvSearchAllDelete.setOnDebounceClickListener {
             searchViewModel.clearSearchKeywordRecent()
             searchKeywordRecentList = searchViewModel.getSearchKeywordRecent()
-            searchKeywordRecentAdapter.submitList(searchKeywordRecentList)
+            searchKeywordRecentAdapter?.submitList(searchKeywordRecentList)
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
@@ -10,7 +10,6 @@ import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import androidx.paging.LoadState
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
@@ -26,9 +25,8 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SearchResultFragment : Fragment() {
-    private var binding by autoCleared<FragmentSearchResultBinding>{ onDestroyBindingView() }
+    private var binding by autoCleared<FragmentSearchResultBinding> { onDestroyBindingView() }
     private val searchViewModel by activityViewModels<SearchViewModel>()
-    private val args by navArgs<SearchResultFragmentArgs>()
     private var searchTagResultPostAdapter: SearchTagResultPostAdapter? = null
     private var glideRequestManager: RequestManager? = null
 
@@ -43,11 +41,13 @@ class SearchResultFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setSearchResult()
+        observeSearchTagList()
+        observeSearchTagCount()
         setBackButtonClickListener()
-        initUI()
         setSearchEditTextListener()
         setSearchTagResultPostAdapter()
-        setSearchTagCount()
         setAdapterLoadStateListener()
         setSearchTagResultPostClickListener()
         setSearchKeywordInputDone()
@@ -67,11 +67,10 @@ class SearchResultFragment : Fragment() {
         }
     }
 
-    private fun initUI() {
+    private fun setSearchResult() {
         loadingPost()
-        binding.tvSearchResultKeywordInput.setText(args.searchKeyword)
-        setSearchTagList()
-        getSearchTagList(args.searchKeyword)
+        binding.tvSearchResultKeywordInput.setText(searchViewModel.searchKeyword)
+        getSearchTagList(searchViewModel.searchKeyword)
     }
 
     private fun setSearchEditTextListener() {
@@ -116,7 +115,8 @@ class SearchResultFragment : Fragment() {
                     HideKeyBoardUtil.hide(requireContext(), binding.tvSearchResultKeywordInput)
                     binding.tvSearchResultKeywordInput.setText(ReplaceUnicode.replaceBlankText(binding.tvSearchResultKeywordInput.text.toString()))
                     if (ReplaceUnicode.replaceBlankText(binding.tvSearchResultKeywordInput.text.toString()).isNotBlank()) {
-                        getSearchTagList(ReplaceUnicode.replaceBlankText(binding.tvSearchResultKeywordInput.text.toString()))
+                        searchViewModel.searchKeyword = ReplaceUnicode.replaceBlankText(binding.tvSearchResultKeywordInput.text.toString())
+                        getSearchTagList(searchViewModel.searchKeyword)
                     }
                     true
                 }
@@ -135,13 +135,13 @@ class SearchResultFragment : Fragment() {
         searchViewModel.searchKeyword(keyword)
     }
 
-    private fun setSearchTagList() {
+    private fun observeSearchTagList() {
         searchViewModel.searchTagList.observe(viewLifecycleOwner) {
             searchTagResultPostAdapter?.submitData(viewLifecycleOwner.lifecycle, it)
         }
     }
 
-    private fun setSearchTagCount() {
+    private fun observeSearchTagCount() {
         searchViewModel.searchTotalCount.observe(viewLifecycleOwner) {
             binding.resultCount = it
         }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/SearchViewModel.kt
@@ -20,8 +20,10 @@ class SearchViewModel @Inject constructor(
     private val requestSearchKeywordRecentUseCase: RequestSearchKeywordRecentUseCase,
     private val requestSearchKeywordUseCase: RequestSearchKeywordUseCase,
     private val requestSearchTotalCountUseCase: RequestSearchTotalCountUseCase
-) :
-    ViewModel() {
+) : ViewModel() {
+
+    var searchKeyword = ""
+
     private val _searchTotalCount = MutableLiveData(0)
     val searchTotalCount: LiveData<Int> get() = _searchTotalCount
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -110,6 +110,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="21dp"
             android:orientation="horizontal"
+            android:overScrollMode="never"
             app:layoutManager="com.google.android.flexbox.FlexboxLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_search_result.xml
+++ b/app/src/main/res/layout/fragment_search_result.xml
@@ -131,7 +131,7 @@
             android:id="@+id/layout_search_result_contents"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginTop="15dp"
+            android:paddingTop="15dp"
             android:visibility="visible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -175,8 +175,9 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/view_search_result_contents_count_post_divider">
@@ -186,7 +187,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="8dp"
                     android:background="@color/gray_6_F0F1F3"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <androidx.constraintlayout.widget.Guideline
@@ -206,11 +206,13 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_search_result_contents_post_list"
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginTop="16dp"
+                    android:layout_height="0dp"
+                    android:paddingTop="16dp"
+                    android:clipToPadding="false"
                     android:overScrollMode="never"
                     android:visibility="gone"
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="@id/guideline_search_result_contents_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_search_result_contents_start"
                     app:layout_constraintTop_toBottomOf="@id/view_search_result_contents_count_post_margin"
@@ -224,6 +226,7 @@
                     android:layout_gravity="center"
                     android:orientation="vertical"
                     android:paddingTop="16dp"
+                    android:clipToPadding="false"
                     android:visibility="visible"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="@id/guideline_search_result_contents_end"

--- a/app/src/main/res/layout/item_search_result_post.xml
+++ b/app/src/main/res/layout/item_search_result_post.xml
@@ -6,32 +6,23 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="4dp">
+        android:layout_marginHorizontal="4dp"
+        android:layout_marginBottom="8dp">
 
         <ImageView
             android:id="@+id/img_search_result_post"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="8dp"
             android:adjustViewBounds="true"
             android:scaleType="centerCrop"
             android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_dayo_circle_grayscale" />
 
         <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/layout_search_result_post_contents_shimmer"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
             app:shimmer_base_color="@color/gray_3_9FA5AE"
             app:shimmer_colored="true"
             app:shimmer_highlight_color="@color/gray_6_F0F1F3">
@@ -47,11 +38,6 @@
                     android:adjustViewBounds="true"
                     android:background="@color/gray_3_9FA5AE"
                     android:src="@drawable/ic_dayo_circle_grayscale"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.0"
                     app:tint="@android:color/transparent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.facebook.shimmer.ShimmerFrameLayout>


### PR DESCRIPTION
## 작업 내용
+ RecyclerView의 마지막 아이템이 잘리는 문제 수정
+ `SearchFragment`에 빠져있던 `onDestroyBindingView` 추가
+ 기존에는 `SearchFragment`와 `SearchResultFragment`사이에 검색 키워드를 navigation args로 전달했음
  + 이때, 다른 키워드로 검색 후 뒤로가기를 통해 다시 `SearchResultFragment`로 접근하면 
  가장 처음에 전달된 키워드로 검색하는 문제 발생
  + 따라서 args를 제거하고 ViewModel을 통해 검색 키워드를 저장하도록 변경

resolved: #443 