### PR TITLE
[bug] Scroll position not saved when returned from Post Fragment

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.paging.LoadState
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
@@ -29,6 +30,12 @@ class FeedFragment : Fragment() {
     private val feedViewModel by activityViewModels<FeedViewModel>()
     private var feedListAdapter: FeedListAdapter? = null
     private var glideRequestManager: RequestManager? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getFeedPostList()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -52,7 +59,6 @@ class FeedFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         binding.swipeRefreshLayoutFeed.isEnabled = true
-        getFeedPostList()
     }
 
     override fun onPause() {
@@ -76,6 +82,7 @@ class FeedFragment : Fragment() {
         feedListAdapter = glideRequestManager?.let { requestManager ->
             FeedListAdapter(requestManager = requestManager)
         }
+        feedListAdapter?.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
         binding.rvFeedPost.adapter = feedListAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -11,6 +11,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
@@ -37,6 +38,12 @@ class HomeDayoPickPostListFragment : Fragment() {
     private var homeDayoPickAdapter: HomeDayoPickAdapter? = null
     private var glideRequestManager: RequestManager? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            loadPosts(homeViewModel.currentDayoPickCategory)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -58,7 +65,6 @@ class HomeDayoPickPostListFragment : Fragment() {
     }
 
     override fun onResume() {
-        loadPosts(homeViewModel.currentDayoPickCategory)
         binding.swipeRefreshLayoutDayoPickPost.isEnabled = true
         super.onResume()
     }
@@ -105,6 +111,7 @@ class HomeDayoPickPostListFragment : Fragment() {
                 ioDispatcher = Dispatchers.IO
             )
         }
+        homeDayoPickAdapter?.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
         binding.rvDayopickPost.adapter = homeDayoPickAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
@@ -6,12 +6,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
@@ -39,6 +39,12 @@ class HomeNewPostListFragment : Fragment() {
     private val homeViewModel by activityViewModels<HomeViewModel>()
     private var homeNewAdapter: HomeNewAdapter? = null
     private var glideRequestManager: RequestManager? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            loadPosts(homeViewModel.currentNewCategory)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -108,6 +114,7 @@ class HomeNewPostListFragment : Fragment() {
                 ioDispatcher = Dispatchers.IO
             )
         }
+        homeNewAdapter?.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
         binding.rvNewPost.adapter = homeNewAdapter
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderFragment.kt
@@ -6,9 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.paging.LoadState
@@ -23,7 +20,6 @@ import com.daily.dayo.databinding.FragmentFolderBinding
 import com.daily.dayo.presentation.adapter.FolderPostListAdapter
 import com.daily.dayo.presentation.viewmodel.FolderViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class FolderFragment : Fragment() {
     private var binding by autoCleared<FragmentFolderBinding> { onDestroyBindingView() }
@@ -31,6 +27,12 @@ class FolderFragment : Fragment() {
     private val args by navArgs<FolderFragmentArgs>()
     private var folderPostListAdapter: FolderPostListAdapter? = null
     private var glideRequestManager: RequestManager? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getFolderPostList()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -50,11 +52,6 @@ class FolderFragment : Fragment() {
         setFolderPostList()
         setAdapterLoadStateListener()
         setFolderDetail()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        getFolderPostList()
     }
 
     private fun onDestroyBindingView() {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
@@ -23,6 +23,12 @@ class ProfileBookmarkPostListFragment : Fragment() {
     private var profileBookmarkPostListAdapter: ProfileBookmarkPostListAdapter? = null
     private var glideRequestManager: RequestManager? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getProfileBookmarkPostList()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -37,11 +43,6 @@ class ProfileBookmarkPostListFragment : Fragment() {
         setRvProfileBookmarkPostListAdapter()
         setProfileBookmarkPostList()
         setAdapterLoadStateListener()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        getProfileBookmarkPostList()
     }
 
     private fun onDestroyBindingView() {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -23,6 +23,11 @@ class ProfileFolderListFragment : Fragment() {
     private val profileViewModel by activityViewModels<ProfileViewModel>()
     private var profileFolderListAdapter: ProfileFolderListAdapter?= null
     private var glideRequestManager: RequestManager?= null
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getProfileFolderList()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -66,8 +71,11 @@ class ProfileFolderListFragment : Fragment() {
         })
     }
 
-    private fun setProfileFolderList() {
+    private fun getProfileFolderList() {
         profileViewModel.requestFolderList(memberId = DayoApplication.preferences.getCurrentUser().memberId!!, true)
+    }
+
+    private fun setProfileFolderList() {
         profileViewModel.folderList.observe(viewLifecycleOwner) {
             when (it.status) {
                 Status.SUCCESS -> {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
@@ -101,6 +101,7 @@ class ProfileFragment : Fragment() {
         requireActivity().findViewById<ConstraintLayout>(R.id.layout_bottom_navigation_main).visibility =
             View.GONE
         setRvProfileFolderListAdapter()
+        getProfileFolderList()
         setProfileFolderList()
         setOtherProfileOptionClickListener()
         getOtherProfileDescription()
@@ -229,11 +230,14 @@ class ProfileFragment : Fragment() {
         })
     }
 
-    private fun setProfileFolderList() {
+    private fun getProfileFolderList() {
         profileViewModel.requestFolderList(
             memberId = profileViewModel.profileMemberId,
             isMine = false
         )
+    }
+
+    private fun setProfileFolderList() {
         profileViewModel.folderList.observe(viewLifecycleOwner) {
             when (it.status) {
                 Status.SUCCESS -> {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
@@ -23,6 +23,12 @@ class ProfileLikePostListFragment : Fragment() {
     private var profileLikePostListAdapter: ProfileLikePostListAdapter? = null
     private var glideRequestManager: RequestManager? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getProfileLikePostList()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -39,10 +45,6 @@ class ProfileLikePostListFragment : Fragment() {
         setAdapterLoadStateListener()
     }
 
-    override fun onResume() {
-        super.onResume()
-        getProfileLikePostList()
-    }
     private fun onDestroyBindingView() {
         glideRequestManager = null
         profileLikePostListAdapter = null

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/search/SearchResultFragment.kt
@@ -30,6 +30,12 @@ class SearchResultFragment : Fragment() {
     private var searchTagResultPostAdapter: SearchTagResultPostAdapter? = null
     private var glideRequestManager: RequestManager? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null)
+            getSearchTagList(searchViewModel.searchKeyword)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
@@ -70,7 +76,6 @@ class SearchResultFragment : Fragment() {
     private fun setSearchResult() {
         loadingPost()
         binding.tvSearchResultKeywordInput.setText(searchViewModel.searchKeyword)
-        getSearchTagList(searchViewModel.searchKeyword)
     }
 
     private fun setSearchEditTextListener() {


### PR DESCRIPTION
## 내용 및 작업사항
- 게시글 상세보기로 이동한 뒤 뒤로가기를 통해 글 목록으로 다시 돌아온 경우 이전의 스크롤이 유지되도록 설정
   - 기본적으로 저장되도록 설정되어 있으나, 홈화면에 해당하는 Dayo Pick과 New의 경우만 그 설정이 유지되지 않아 `stateRestorationPolicy` 설정 추가
   - `savedInstanceState`의 값을 확인해 null로 확인되면 Fragment 최초 로딩으로 간주해 게시글 리스트를 받아올 수 있도록 처리 이외의 경우에는 Referesh하는 경우에만 게시글 목록을 갱신하도록 처리

- ProfileFragment, NotificationFragment 의 경우 별도의 사전 처리 과정에 의해 현재 미구현 상태

## 참고
- resolved: #458 