### PR TITLE
[feature] Apply changes as update to Android SDK 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             buildConfigField("String", "BASE_URL", properties['BASE_URL_RELEASE'])
@@ -132,9 +132,8 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.1"
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-android-compiler:2.38.1"
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-android-compiler:2.44"
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // Coroutines
@@ -182,4 +181,16 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
+    testImplementation "com.google.truth:truth:1.1"
+    // For Robolectric tests.
+    testImplementation("com.google.dagger:hilt-android-testing:2.44")
+    // For instrumented tests.
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.44")
+    // ...with Kotlin.
+    kaptTest("com.google.dagger:hilt-android-compiler:2.44")
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1"
+
+//    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,13 +22,13 @@ sentry {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.daily.dayo"
         minSdkVersion 26
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,13 @@
     package="com.daily.dayo">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature android:name="android.hardware.camera" android:required="true" />
 
     <application

--- a/app/src/main/java/com/daily/dayo/presentation/activity/MainActivity.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/activity/MainActivity.kt
@@ -1,41 +1,149 @@
 package com.daily.dayo.presentation.activity
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Rect
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.MotionEvent
 import android.view.View
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
+import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.databinding.ActivityMainBinding
 import com.daily.dayo.presentation.fragment.home.HomeFragmentDirections
+import com.daily.dayo.presentation.viewmodel.SettingNotificationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
+    private val settingNotificationViewModel by viewModels<SettingNotificationViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        checkCurrentNotification()
         initBottomNavigation()
         setBottomNaviVisibility()
         disableBottomNaviTooltip()
         getNotificationData()
+        askNotificationPermission()
     }
 
-    private fun getNotificationData(){
+    private fun checkCurrentNotification() {
+        if (!NotificationManagerCompat.from(this).areNotificationsEnabled()) {
+            Toast.makeText(
+                this,
+                getString(R.string.permission_fail_message_notification),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    private fun getNotificationData() {
         val extraFragment = intent.getStringExtra("ExtraFragment")
-        if(extraFragment!=null && extraFragment == "Notification"){
+        if (extraFragment != null && extraFragment == "Notification") {
             val postId = intent.getStringExtra("PostId")?.toInt()
             val memberId = intent.getStringExtra("MemberId")
-            if(postId!=null) findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToPostFragment(postId = postId))
-            else if(memberId!=null) findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToProfileFragment(memberId = memberId))
+            if (postId != null) findNavController().navigate(
+                HomeFragmentDirections.actionHomeFragmentToPostFragment(
+                    postId = postId
+                )
+            )
+            else if (memberId != null) findNavController().navigate(
+                HomeFragmentDirections.actionHomeFragmentToProfileFragment(
+                    memberId = memberId
+                )
+            )
             else findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToNotificationFragment())
+        }
+    }
+
+    private val permissionLauncherNotification =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            val deniedList: List<String> = permissions.filter {
+                !it.value
+            }.map {
+                it.key
+            }
+
+            when {
+                deniedList.isNotEmpty() -> {
+                    DayoApplication.preferences.notiDevicePermit = false
+                    DayoApplication.preferences.notiNoticePermit = false
+                    val map = deniedList.groupBy { permission ->
+                        if (shouldShowRequestPermissionRationale(permission)) getString(R.string.permission_fail_second) else getString(
+                            R.string.permission_fail_final
+                        )
+                    }
+                    map[getString(R.string.permission_fail_second)]?.let {
+                        // request denied , request again
+                        Toast.makeText(
+                            this,
+                            getString(R.string.permission_fail_message_notification),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        ActivityCompat.requestPermissions(
+                            this,
+                            notificationPermission,
+                            1000
+                        )
+                    }
+                    map[getString(R.string.permission_fail_final)]?.let {
+                        Intent().apply {
+                            action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                            putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+                        }
+                        Toast.makeText(
+                            this,
+                            getString(R.string.permission_fail_final_message_notification),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+                else -> {
+                    //All request are permitted
+                    // 알림 최초 허용시에 모든 알림 허용처리
+                    DayoApplication.preferences.notiDevicePermit = true
+                    DayoApplication.preferences.notiNoticePermit = true
+                    settingNotificationViewModel.registerDeviceToken()
+                    settingNotificationViewModel.requestReceiveAlarm()
+                }
+            }
+        }
+
+    private fun askNotificationPermission() {
+        // This is only necessary for API level >= 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                // FCM SDK (and your app) can post notifications.
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                // TODO: display an educational UI explaining to the user the features that will be enabled
+                // by them granting the POST_NOTIFICATION permission. This UI should provide the user
+                // "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
+                // If the user selects "No thanks," allow the user to continue without notifications.
+            } else {
+                // Directly ask for the permission
+                permissionLauncherNotification.launch(notificationPermission)
+            }
         }
     }
 
@@ -44,7 +152,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun findNavController(): NavController {
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         return navHostFragment.navController
     }
 
@@ -60,7 +169,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
         // WriteFragment
-        binding.bottomNavigationMainBar.setItemOnTouchListener( R.id.WriteFragment,
+        binding.bottomNavigationMainBar.setItemOnTouchListener(R.id.WriteFragment,
             object : View.OnTouchListener {
                 var rect = Rect()
                 var isInside = true
@@ -74,7 +183,8 @@ class MainActivity : AppCompatActivity() {
                             return true
                         }
                         MotionEvent.ACTION_MOVE -> {
-                            isInside = rect.contains(v!!.left + event.x.toInt(), v.top + event.y.toInt())
+                            isInside =
+                                rect.contains(v!!.left + event.x.toInt(), v.top + event.y.toInt())
                             binding.bottomNavigationMainBar.clearFocus()
                             return false
                         }
@@ -104,5 +214,9 @@ class MainActivity : AppCompatActivity() {
                 true
             }
         }
+    }
+
+    companion object {
+        val notificationPermission = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeDayoPickAdapter.kt
@@ -167,18 +167,18 @@ class HomeDayoPickAdapter(
 
                 this.removeAllAnimatorListeners()
                 this.addAnimatorListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(animation: Animator?) {
+                    override fun onAnimationStart(animation: Animator) {
                         this@with.setOnDebounceClickListener(0L) {}
                     }
 
-                    override fun onAnimationEnd(animation: Animator?) {
+                    override fun onAnimationEnd(animation: Animator) {
                         this@with.setOnDebounceClickListener(0L) {
                             clickListener?.likePostClick(post = post)
                         }
                     }
 
-                    override fun onAnimationCancel(animation: Animator?) {}
-                    override fun onAnimationRepeat(animation: Animator?) {}
+                    override fun onAnimationCancel(animation: Animator) {}
+                    override fun onAnimationRepeat(animation: Animator) {}
                 })
 
                 if (post.heart) this.playAnimation()

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/HomeNewAdapter.kt
@@ -163,18 +163,18 @@ class HomeNewAdapter(
 
                 this.removeAllAnimatorListeners()
                 this.addAnimatorListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(animation: Animator?) {
+                    override fun onAnimationStart(animation: Animator) {
                         this@with.setOnDebounceClickListener(0L) {}
                     }
 
-                    override fun onAnimationEnd(animation: Animator?) {
+                    override fun onAnimationEnd(animation: Animator) {
                         this@with.setOnDebounceClickListener(0L) {
                             clickListener?.likePostClick(post = post)
                         }
                     }
 
-                    override fun onAnimationCancel(animation: Animator?) {}
-                    override fun onAnimationRepeat(animation: Animator?) {}
+                    override fun onAnimationCancel(animation: Animator) {}
+                    override fun onAnimationRepeat(animation: Animator) {}
                 })
 
                 if (post.heart) this.playAnimation()

--- a/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/adapter/PostImageSliderAdapter.kt
@@ -95,13 +95,13 @@ class PostImageSliderAdapter(
             }
             binding.lottiePostHeart.let { bigLikeLottie ->
                 bigLikeLottie.addAnimatorListener(object : Animator.AnimatorListener {
-                    override fun onAnimationStart(animation: Animator?) {}
-                    override fun onAnimationEnd(animation: Animator?) {
+                    override fun onAnimationStart(animation: Animator) {}
+                    override fun onAnimationEnd(animation: Animator) {
                         bigLikeLottie.visibility = View.GONE
                     }
 
-                    override fun onAnimationCancel(animation: Animator?) {}
-                    override fun onAnimationRepeat(animation: Animator?) {}
+                    override fun onAnimationCancel(animation: Animator) {}
+                    override fun onAnimationRepeat(animation: Animator) {}
                 })
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileImageOptionFragment.kt
@@ -67,10 +67,7 @@ class SignupEmailSetProfileImageOptionFragment : DialogFragment() {
     private fun setImageSelectGalleryClickListener(){
         binding.layoutSignupEmailSetProfileImageOptionSelectGallery.setOnDebounceClickListener {
             requestOpenGallery.launch(
-                arrayOf(
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
+                PERMISSIONS_GALLERY
             )
         }
     }
@@ -102,11 +99,7 @@ class SignupEmailSetProfileImageOptionFragment : DialogFragment() {
     private fun setImageTakePhotoClickListener() {
         binding.layoutSignupEmailSetProfileImageOptionTakePhoto.setOnDebounceClickListener {
             requestOpenCamera.launch(
-                arrayOf(
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
+                PERMISSIONS_CAMERA
             )
         }
     }
@@ -151,5 +144,32 @@ class SignupEmailSetProfileImageOptionFragment : DialogFragment() {
         findNavController().previousBackStackEntry?.savedStateHandle?.set("userProfileImageString", ImageString)
         findNavController().previousBackStackEntry?.savedStateHandle?.set("fileExtension", fileExtension)
         findNavController().popBackStack()
+    }
+
+    companion object {
+        val PERMISSIONS_CAMERA = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
+        val PERMISSIONS_GALLERY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingEditImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingEditImageOptionFragment.kt
@@ -97,11 +97,7 @@ class FolderSettingEditImageOptionFragment : DialogFragment() {
     private fun setImageTakePhotoClickListener() {
         binding.layoutFolderSettingEditImageOptionCamera.setOnDebounceClickListener {
             requestOpenCamera.launch(
-                arrayOf(
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
+                PERMISSIONS_CAMERA
             )
         }
     }
@@ -155,5 +151,21 @@ class FolderSettingEditImageOptionFragment : DialogFragment() {
     private fun setFolderCoverImage(coverImageUri: String) {
         findNavController().previousBackStackEntry?.savedStateHandle?.set("imageUri", coverImageUri)
         findNavController().popBackStack()
+    }
+
+    companion object {
+        val PERMISSIONS_CAMERA = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
     }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditImageOptionFragment.kt
@@ -76,10 +76,7 @@ class ProfileEditImageOptionFragment : DialogFragment() {
     private fun setImageSelectGalleryClickListener() {
         binding.layoutMyProfileEditImageOptionSelectGallery.setOnDebounceClickListener {
             requestOpenGallery.launch(
-                arrayOf(
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
+                PERMISSIONS_GALLERY
             )
         }
     }
@@ -120,11 +117,7 @@ class ProfileEditImageOptionFragment : DialogFragment() {
     private fun setImageTakePhotoClickListener() {
         binding.layoutMyProfileEditImageOptionCamera.setOnDebounceClickListener {
             requestOpenCamera.launch(
-                arrayOf(
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
+                PERMISSIONS_CAMERA
             )
         }
     }
@@ -185,5 +178,32 @@ class ProfileEditImageOptionFragment : DialogFragment() {
             fileExtension
         )
         findNavController().popBackStack()
+    }
+
+    companion object {
+        val PERMISSIONS_CAMERA = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
+        val PERMISSIONS_GALLERY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,16 @@
     <string name="time_month_ago">달 전</string>
     <string name="time_year_ago">년 전</string>
 
+    <!-- Device Permission -->
+    <string name="permission_fail_message_camera">카메라 권한을 허용하지 않으면 사진을 등록할 수 없습니다</string>
+    <string name="permission_fail_final_message_camera">카메라를 통해 사진을 등록하려면 설정에서 카메라 권한을 허용으로 변경해주세요</string>
+    <string name="permission_fail_message_gallery">파일 권한을 허용하지 않으면 사진을 등록할 수 없습니다</string>
+    <string name="permission_fail_final_message_gallery">갤러리를 통해 사진을 등록하려면 설정에서 파일 권한을 허용으로 변경해주세요</string>
+    <string name="permission_fail_message_notification">알림 권한을 허용하지 않으면 정상적 사용이 불가능할 수 있습니다</string>
+    <string name="permission_fail_final_message_notification">설정에서 알림을 허용으로 변경해주세요</string>
+    <string name="permission_fail_second">DENIED</string>
+    <string name="permission_fail_final">EXPLAINED</string>
+
     <!-- OnBoarding -->
     <string name="onboarding_first_message">인기가 많은 다꾸들을 구경할 수 있어요</string>
     <string name="onboarding_second_message">내 취향의 다꾸러들을 팔로우하고 모아볼 수 있어요</string>


### PR DESCRIPTION
## 내용 및 작업사항
- 기존 `compileSDK`및 `targetSDK`가 31로 되어있던 부분 33으로 조정
- Android 33으로 넘어가면서 변경된 권한 적용
   - 기존 옵트아웃이였던 알림 권한이 옵트인으로 적용됨에 따라 알림을 요청하는 기능에 대해 MainActivity에서 명시적으로 요청하도록 구현
   - 알림에 대해 아무런 설정을 하지 않거나 거부한 경우 새로 앱을 시작하는 경우 혹은 앱 내부의 알림 설정 페이지로 들어가는 경우에 알림 허용에 대한 메시지를 보여줄 수 있도록 구현
   - 알림을 허용한 경우에만 서버에서 알림을 보내줄 수 있도록 설정하는 request를 보내도록 구현
   - 기존 사진 및 카메라 권한에 대한 세부화에 따른 요청 권한 추가 명시 및 이전 버전과의 분기 처리 추가
      - 해당하는 페이지들에 대해 Android SDK 33 이전과 이후로 분기처리해 권한을 요청할 수 있도록 수정

## 참고
- resolved: #466 