### PR TITLE
#475 [bug] Don't validate when keeping nickname

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -158,65 +158,76 @@ class ProfileEditFragment : Fragment() {
                         }${getString(R.string.my_profile_edit_nickname_edittext_count)}"
                     }
 
-                    if (trimBlankText(s).length < 2) { // 닉네임 길이 검사 1
+                    if (trimBlankText(s) == profileSettingViewModel.profileInfo.value?.nickname) { // 기존 닉네임과 동일한 경우
                         setEditTextTheme(
-                            getString(R.string.my_profile_edit_nickname_message_length_fail_min),
-                            false
+                            "",
+                            true
                         )
-                        ButtonActivation.setTextViewButtonInactive(
-                            requireContext(),
-                            btnProfileEditComplete
-                        )
-                    } else if (trimBlankText(s).length > 10) { // 닉네임 길이 검사 2
-                        setEditTextTheme(
-                            getString(R.string.my_profile_edit_nickname_message_length_fail_max),
-                            false
-                        )
-                        ButtonActivation.setTextViewButtonInactive(
+                        ButtonActivation.setTextViewButtonActive(
                             requireContext(),
                             btnProfileEditComplete
                         )
                     } else {
-                        if (Pattern.matches(
-                                "^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$",
-                                trimBlankText(s)
-                            )
-                        ) {
-                            profileSettingViewModel.requestCheckNicknameDuplicate(
-                                trimBlankText(
-                                    binding.etProfileEditNickname.text
-                                )
-                            )
-                            profileSettingViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
-                                if (isDuplicate) {
-                                    setEditTextTheme(
-                                        getString(R.string.my_profile_edit_nickname_message_success),
-                                        true
-                                    )
-                                    ButtonActivation.setTextViewButtonActive(
-                                        requireContext(),
-                                        btnProfileEditComplete
-                                    )
-                                } else {
-                                    setEditTextTheme(
-                                        getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
-                                        false
-                                    )
-                                    ButtonActivation.setTextViewButtonInactive(
-                                        requireContext(),
-                                        btnProfileEditComplete
-                                    )
-                                }
-                            }
-                        } else {
+                        if (trimBlankText(s).length < 2) { // 닉네임 길이 검사 1
                             setEditTextTheme(
-                                getString(R.string.my_profile_edit_nickname_message_format_fail),
+                                getString(R.string.my_profile_edit_nickname_message_length_fail_min),
                                 false
                             )
                             ButtonActivation.setTextViewButtonInactive(
                                 requireContext(),
                                 btnProfileEditComplete
                             )
+                        } else if (trimBlankText(s).length > 10) { // 닉네임 길이 검사 2
+                            setEditTextTheme(
+                                getString(R.string.my_profile_edit_nickname_message_length_fail_max),
+                                false
+                            )
+                            ButtonActivation.setTextViewButtonInactive(
+                                requireContext(),
+                                btnProfileEditComplete
+                            )
+                        } else {
+                            if (Pattern.matches(
+                                    "^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|a-z|A-Z|0-9|]+\$",
+                                    trimBlankText(s)
+                                )
+                            ) {
+                                profileSettingViewModel.requestCheckNicknameDuplicate(
+                                    trimBlankText(
+                                        binding.etProfileEditNickname.text
+                                    )
+                                )
+                                profileSettingViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
+                                    if (isDuplicate) {
+                                        setEditTextTheme(
+                                            getString(R.string.my_profile_edit_nickname_message_success),
+                                            true
+                                        )
+                                        ButtonActivation.setTextViewButtonActive(
+                                            requireContext(),
+                                            btnProfileEditComplete
+                                        )
+                                    } else {
+                                        setEditTextTheme(
+                                            getString(R.string.my_profile_edit_nickname_message_duplicate_fail),
+                                            false
+                                        )
+                                        ButtonActivation.setTextViewButtonInactive(
+                                            requireContext(),
+                                            btnProfileEditComplete
+                                        )
+                                    }
+                                }
+                            } else {
+                                setEditTextTheme(
+                                    getString(R.string.my_profile_edit_nickname_message_format_fail),
+                                    false
+                                )
+                                ButtonActivation.setTextViewButtonInactive(
+                                    requireContext(),
+                                    btnProfileEditComplete
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,7 +213,7 @@
     <string name="my_profile_edit_nickname_message_success">사용할 수 있는 닉네임이에요.</string>
     <string name="my_profile_edit_nickname_message_format_fail">닉네임에는 한글, 영문, 숫자만 사용할 수 있어요.</string>
     <string name="my_profile_edit_nickname_message_length_fail_min">닉네임을 2글자 이상 입력해주세요.</string>
-    <string name="my_profile_edit_nickname_message_length_fail_max">닉네임을 10글자 이하로 가능해요.</string>
+    <string name="my_profile_edit_nickname_message_length_fail_max">닉네임은 10글자 이하로 가능해요.</string>
     <string name="my_profile_edit_nickname_message_duplicate_fail">이미 사용중인 닉네임이에요.</string>
     <string name="my_profile_edit_image_select_gallery">앨범에서 선택</string>
     <string name="my_profile_edit_image_reset">프로필 사진 초기화</string>


### PR DESCRIPTION
## 작업 내용
+ 기존 닉네임과 동일할 시 닉네임 중복 체크를 하지 않고, 완료 버튼이 활성화되도록 변경

resolved : #475 