### PR TITLE
[chore] Update kotlin, dependency, JVM version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,12 +21,14 @@ sentry {
     setAutoUpload(true)
 }
 
-android {
-    compileSdkVersion 33
-    buildToolsVersion "30.0.3"
+kotlin {
+    jvmToolchain(17)
+}
 
+android {
     defaultConfig {
         applicationId "com.daily.dayo"
+        compileSdk 33
         minSdkVersion 26
         targetSdkVersion 33
         versionCode 10000
@@ -59,41 +61,73 @@ android {
             buildConfigField("String", "BASE_URL", properties['BASE_URL_DEBUG'])
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    composeOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+        kotlinCompilerExtensionVersion = "$compose_version"
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     buildFeatures {
         dataBinding true
         viewBinding true
+        compose = true
     }
+    namespace 'com.daily.dayo'
 }
 
 dependencies {
+    // Compose
+    def composeBom = platform("androidx.compose:compose-bom:2023.06.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    def nav_version = "2.5.3"
-    def lifecycle_version = "2.4.0"
-    def splashscreen_version = "1.0.0-beta01"
-    def lottie_version = "5.0.3"
-    def sentry_version = "6.8.0"
-    def paging_version = "3.1.1"
+    def nav_version = "2.6.0"
+    def lifecycle_version = "2.6.1"
+    def splashscreen_version = "1.0.0"
+    def lottie_version = "6.1.0"
+    def sentry_version = "6.11.0"
+    def paging_version = "3.2.0"
+    def glide_version = "4.15.1"
+    def landscapist_glide_version = "2.2.5"
 
-    // Java language implementation Navigation
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation("androidx.compose.material3:material3")
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+
+    // Jetpack Compose
+    // Android Studio Preview support
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    // UI Tests
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    // Optional - Integration with activities
+    implementation("androidx.activity:activity-compose:1.7.2")
+    // Optional - Integration with LiveData
+    implementation("androidx.compose.runtime:runtime-livedata")
+    // Optional - Integration with RxJava
+    implementation("androidx.compose.runtime:runtime-rxjava2")
+    // To use constraintlayout in compose
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
+
+    // Jetpack Navigation
+    // Java language implementation
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    // Kotlin
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-
-    // Kotlin Navigation
-    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-
     // Feature module Support
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"
-
     // Testing Navigation
     androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
+    // Jetpack Compose Integration
+    implementation("androidx.navigation:navigation-compose:$nav_version")
 
     // ViewPager2
     implementation "androidx.viewpager2:viewpager2:1.0.0"
@@ -102,52 +136,55 @@ dependencies {
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 
     // Google Material Design
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
+    // ViewModel utilities for Compose
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version")
     // LiveData
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version")
+    // Lifecycle utilities for Compose
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version")
     // Saved state module for ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version")
     // Annotation processor
     kapt("androidx.lifecycle:lifecycle-compiler:$lifecycle_version")
-    // alternately - if using Java8, use the following instead of lifecycle-compiler
-    implementation("androidx.lifecycle:lifecycle-common-java8:$lifecycle_version")
-
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
+    // optional - helpers for implementing LifecycleOwner in a Service
+    implementation("androidx.lifecycle:lifecycle-service:$lifecycle_version")
 
     // retrofit2
     implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: '2.9.0'
     implementation group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.9.0'
     implementation group: 'com.squareup.retrofit2', name: 'converter-scalars', version: '2.9.0'
     // JSON을 직렬화
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
     // 직렬화된 JSON을 객체로 역직렬화
 
     // OKHttp
-    implementation "com.squareup.okhttp3:okhttp:4.9.1"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.1"
+    implementation "com.squareup.okhttp3:okhttp:4.9.2"
+    implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.2"
     // Use for HttpLoggingInterceptor
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.9.2"
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-android-compiler:2.38.1"
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-android-compiler:2.44"
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2'
 
     // Kakao sdk
-    implementation "com.kakao.sdk:v2-user:2.8.3"
+    implementation "com.kakao.sdk:v2-user:2.9.0"
 
     // Glide
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
-    kapt 'com.github.bumptech.glide:compiler:4.11.0'
+    implementation "com.github.bumptech.glide:glide:$glide_version"
+    kapt "com.github.bumptech.glide:compiler:$glide_version"
     kapt "android.arch.lifecycle:compiler:1.1.1"
+    // Glide-For-Compose
+    implementation "com.github.skydoves:landscapist-glide:$landscapist_glide_version"
 
     // Preference
     implementation 'androidx.preference:preference-ktx:1.1.1'
@@ -156,6 +193,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:29.1.0')
     implementation 'com.google.firebase:firebase-messaging-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'
+    // 버전 올리면 java.lang.NoSuchFieldError: No instance field mDelegate of type Landroid/database/sqlite/SQLiteStatement; in class Landroidx/sqlite/db/framewo 에러 남
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 
     // Splash Screen
@@ -163,7 +201,7 @@ dependencies {
 
     // Lottie
     implementation "com.airbnb.android:lottie:$lottie_version"
-
+    implementation "com.airbnb.android:lottie-compose:$lottie_version"
     // Shimmer
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 
@@ -173,12 +211,9 @@ dependencies {
 
     // paging
     implementation "androidx.paging:paging-runtime-ktx:$paging_version"
+    // optional - Jetpack Compose integration
+    implementation "androidx.paging:paging-compose:3.2.0"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,11 @@ android {
         }
     }
 
+    buildFeatures {
+        // AGP 9.0부터 buildConfig가 사라짐에 따라 8.0에서의 임시방편
+        buildConfig = true
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.daily.dayo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.0"
-    ext.compose_version = "1.0.5"
+    ext {
+        kotlin_version = '1.8.20'
+        compose_version = '1.4.6'
+        nav_version = '2.6.0'
+    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0'
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'io.sentry:sentry-android-gradle-plugin:3.1.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version")
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44'
+        classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'io.sentry:sentry-android-gradle-plugin:3.4.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Nov 02 16:51:40 KST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 내용
- 언어 및 Gradle, JVM, 라이브러리 의존성 관련 버전 최신화를 위한 작업

## 작업사항
- 기존 Kotlin 버전을 1.6.0에서 1.8.20로 업데이트
- Kotlin Version이 1.8.20으로 업데이트됨에 따라, Compose Compiler Version을 1.4.6으로 설정
   - [Pre-release Kotlin Compatibility](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility)
- Android Gradle Plugin(AGP) 버전을 8.1로 변경
   - 현재 Stable Version이 발표된 [Android Studio Giraffe가 3.2~8.1만 지원](https://developer.android.com/build/releases/gradle-plugin)함에 따라 8.2가 아닌 8.1로 설정
   - gradle distributionUrl 8.1로 변경
- 기존 사용하던 JDK 1.8에서 17로 변경
   - JetBrains Runtime Version 17 사용
   - Build.gradle에서 기존에 1.8로 수동으로 JVM 타겟 지정했던 것을 변경
   - 이외 관련에러가 지속적으로 발생함에 따라 jvmToolChain(17) 추가
      - [Unable to set kapt jvm target version](https://youtrack.jetbrains.com/issue/KT-55947/Unable-to-set-kapt-jvm-target-version#focus=Comments-27-6805028.0-0)
- buildToolsVersion, compileSdkVersion이 SDK 33부터 Deprecated됨에 따라 삭제 및 compileSDK 33으로 대체
- 기존 사용하던 라이브러리들에 대해 Stable 버전으로 업데이트
- Compose 도입에 따른 기존 라이브러리에 Compose를 추가로 지원하는 경우 해당 내용 추가
   - Glide의 경우, [landscapist](https://github.com/skydoves/landscapist)을 통해 지원하므로 해당 라이브러리 추가
- AGP 8.0부터 BuildConfig가 기본적으로 비활성화됨에 따라 활성화하는 Flag 추가

## 참고
- resolved: #474 
- https://velog.io/@mraz3068/안드로이드-스튜디오-빌드-관련-오류JDK-version-17-1.8-11-무한-반복
- https://stackoverflow.com/a/69279771
- https://developer.android.com/build/releases/gradle-plugin