### PR TITLE
[feature] Change Image quality processing

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/ImageResizeUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/ImageResizeUtil.kt
@@ -1,12 +1,17 @@
 package com.daily.dayo.common
 
 import android.graphics.Bitmap
+import android.media.ThumbnailUtils
 
 object ImageResizeUtil {
+    const val USER_PROFILE_THUMBNAIL_RESIZE_SIZE = 320
+    const val POST_IMAGE_RESIZE_SIZE = 1080
+
     fun resizeBitmap(
         originalBitmap: Bitmap,
         resizedWidth: Int = 480,
-        resizedHeight: Int = 480, ): Bitmap {
+        resizedHeight: Int = 480,
+    ): Bitmap {
         var bmpWidth = originalBitmap.width.toFloat()
         var bmpHeight = originalBitmap.height.toFloat()
 
@@ -26,4 +31,13 @@ object ImageResizeUtil {
         return Bitmap.createScaledBitmap(originalBitmap, bmpWidth.toInt(), bmpHeight.toInt(), true)
     }
 
+    fun Bitmap.cropCenterBitmap(): Bitmap {
+        val dimension = getSquareCropDimensionForBitmap(this)
+        return ThumbnailUtils.extractThumbnail(this, dimension, dimension)
+    }
+
+    private fun getSquareCropDimensionForBitmap(bitmap: Bitmap): Int {
+        //use the smallest dimension of the image to crop to
+        return Math.min(bitmap.width, bitmap.height)
+    }
 }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -42,6 +42,8 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ImageResizeUtil.USER_PROFILE_THUMBNAIL_RESIZE_SIZE
+import com.daily.dayo.common.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 
 @AndroidEntryPoint
@@ -302,10 +304,11 @@ class SignupEmailSetProfileFragment : Fragment() {
             var profileImgFile: File? = null
             profileImgFile = if (this::userProfileImageString.isInitialized) {
                 setUploadImagePath(userProfileImageExtension)
+                val originalBitmap = userProfileImageString.toUri().toBitmap().cropCenterBitmap()
                 val resizedBitmap = ImageResizeUtil.resizeBitmap(
-                    originalBitmap = userProfileImageString.toUri().toBitmap(),
-                    resizedWidth = 100,
-                    resizedHeight = 100
+                    originalBitmap = originalBitmap,
+                    resizedWidth = USER_PROFILE_THUMBNAIL_RESIZE_SIZE,
+                    resizedHeight = USER_PROFILE_THUMBNAIL_RESIZE_SIZE
                 )
                 bitmapToFile(resizedBitmap, imagePath)
             } else { // 기본 프로필 사진으로 설정

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -28,6 +28,8 @@ import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.common.*
 import com.daily.dayo.common.GlideLoadUtil.PROFILE_EDIT_USER_THUMBNAIL_SIZE
+import com.daily.dayo.common.ImageResizeUtil.USER_PROFILE_THUMBNAIL_RESIZE_SIZE
+import com.daily.dayo.common.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.dialog.LoadingAlertDialog
 import com.daily.dayo.databinding.FragmentProfileEditBinding
@@ -334,11 +336,11 @@ class ProfileEditFragment : Fragment() {
             null
         } else { // 2. 프로필 사진을 다른 사진으로 변경 한 경우
             setUploadImagePath(userProfileImageExtension)
-            val originalBitmap = userProfileImageString.toUri().toBitmap()
+            val originalBitmap = userProfileImageString.toUri().toBitmap().cropCenterBitmap()
             val resizedBitmap = ImageResizeUtil.resizeBitmap(
                 originalBitmap = originalBitmap,
-                resizedWidth = 100,
-                resizedHeight = 100
+                resizedWidth = USER_PROFILE_THUMBNAIL_RESIZE_SIZE,
+                resizedHeight = USER_PROFILE_THUMBNAIL_RESIZE_SIZE
             )
             bitmapToFile(resizedBitmap, imagePath)
         }

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -10,6 +10,8 @@ import com.daily.dayo.BuildConfig
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.Event
 import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.ImageResizeUtil.POST_IMAGE_RESIZE_SIZE
+import com.daily.dayo.common.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ListLiveData
 import com.daily.dayo.common.Resource
 import com.daily.dayo.common.toBitmap
@@ -105,12 +107,12 @@ class WriteViewModel @Inject constructor(
         val resizedImages = async {
             postImageUriList.value?.map { item ->
                 val postImageBitmap =
-                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)
+                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)?.cropCenterBitmap()
                 val resizedImageBitmap = postImageBitmap?.let {
                     ImageResizeUtil.resizeBitmap(
                         originalBitmap = it,
-                        resizedWidth = 480,
-                        resizedHeight = 480
+                        resizedWidth = POST_IMAGE_RESIZE_SIZE,
+                        resizedHeight = POST_IMAGE_RESIZE_SIZE
                     )
                 }
                 resizedImageBitmap.toFile(uploadImagePath)


### PR DESCRIPTION
## 내용 및 참고사항
- Bitmap을 CenterCrop하는 Bitmap 확장함수 추가
   - 이미지를 업로드 하는 경우 (게시글 이미지 업로드 및 프로필 이미지 업로드) 정사각형으로 Crop한 뒤에 서버에 업로드 하도록 설정
- 지나친 이미지 리사이징으로 심각한 화질저하에 따른 리사이징 크기 수정
   - 글 이미지: 기존 `480px`에서 `1080px`로 변경
   - 프로필 이미지: 기존 `100px`에서 `320px`로 변경

## 참고
- resolved: #478 