### PR TITLE
[bug] Fix image with unsupported extensions being uploaded.

### DIFF
--- a/app/src/main/java/com/daily/dayo/common/image/ImageResizeUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/image/ImageResizeUtil.kt
@@ -1,4 +1,4 @@
-package com.daily.dayo.common
+package com.daily.dayo.common.image
 
 import android.graphics.Bitmap
 

--- a/app/src/main/java/com/daily/dayo/common/image/ImageResizeUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/image/ImageResizeUtil.kt
@@ -1,12 +1,17 @@
 package com.daily.dayo.common.image
 
 import android.graphics.Bitmap
+import android.media.ThumbnailUtils
 
 object ImageResizeUtil {
+    const val USER_PROFILE_THUMBNAIL_RESIZE_SIZE = 320
+    const val POST_IMAGE_RESIZE_SIZE = 1080
+
     fun resizeBitmap(
         originalBitmap: Bitmap,
         resizedWidth: Int = 480,
-        resizedHeight: Int = 480, ): Bitmap {
+        resizedHeight: Int = 480,
+    ): Bitmap {
         var bmpWidth = originalBitmap.width.toFloat()
         var bmpHeight = originalBitmap.height.toFloat()
 
@@ -26,4 +31,13 @@ object ImageResizeUtil {
         return Bitmap.createScaledBitmap(originalBitmap, bmpWidth.toInt(), bmpHeight.toInt(), true)
     }
 
+    fun Bitmap.cropCenterBitmap(): Bitmap {
+        val dimension = getSquareCropDimensionForBitmap(this)
+        return ThumbnailUtils.extractThumbnail(this, dimension, dimension)
+    }
+
+    private fun getSquareCropDimensionForBitmap(bitmap: Bitmap): Int {
+        //use the smallest dimension of the image to crop to
+        return Math.min(bitmap.width, bitmap.height)
+    }
 }

--- a/app/src/main/java/com/daily/dayo/common/image/ImageUploadUtil.kt
+++ b/app/src/main/java/com/daily/dayo/common/image/ImageUploadUtil.kt
@@ -1,0 +1,17 @@
+package com.daily.dayo.common.image
+
+import android.net.Uri
+import com.daily.dayo.DayoApplication
+
+object ImageUploadUtil {
+    private val PERMIT_IMAGE_EXTENSIONS = listOf("jpg", "jpeg", "png", "webp")
+
+    // Get Image Extension
+    val Uri.extension: String
+        get() = DayoApplication.applicationContext().contentResolver
+            .getType(this)
+            .toString()
+            .split("/")[1]
+
+    val String.isPermitExtension: Boolean get() = this in PERMIT_IMAGE_EXTENSIONS
+}

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -41,7 +41,9 @@ import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
-import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.image.ImageResizeUtil
+import com.daily.dayo.common.image.ImageResizeUtil.USER_PROFILE_THUMBNAIL_RESIZE_SIZE
+import com.daily.dayo.common.image.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 
 @AndroidEntryPoint
@@ -302,10 +304,11 @@ class SignupEmailSetProfileFragment : Fragment() {
             var profileImgFile: File? = null
             profileImgFile = if (this::userProfileImageString.isInitialized) {
                 setUploadImagePath(userProfileImageExtension)
+                val originalBitmap = userProfileImageString.toUri().toBitmap().cropCenterBitmap()
                 val resizedBitmap = ImageResizeUtil.resizeBitmap(
-                    originalBitmap = userProfileImageString.toUri().toBitmap(),
-                    resizedWidth = 100,
-                    resizedHeight = 100
+                    originalBitmap = originalBitmap,
+                    resizedWidth = USER_PROFILE_THUMBNAIL_RESIZE_SIZE,
+                    resizedHeight = USER_PROFILE_THUMBNAIL_RESIZE_SIZE
                 )
                 bitmapToFile(resizedBitmap, imagePath)
             } else { // 기본 프로필 사진으로 설정

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileFragment.kt
@@ -109,6 +109,7 @@ class SignupEmailSetProfileFragment : Fragment() {
                     HideKeyBoardUtil.hide(requireContext(), binding.etSignupEmailSetProfileNickname)
                     true
                 }
+
                 else -> false
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/account/signup/SignupEmailSetProfileImageOptionFragment.kt
@@ -10,15 +10,19 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.view.*
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.BuildConfig
+import com.daily.dayo.R
 import com.daily.dayo.databinding.FragmentSignupEmailSetProfileImageOptionBinding
 import com.daily.dayo.common.dialog.DefaultDialogConfigure
 import com.daily.dayo.common.autoCleared
+import com.daily.dayo.common.image.ImageUploadUtil.extension
+import com.daily.dayo.common.image.ImageUploadUtil.isPermitExtension
 import com.daily.dayo.common.setOnDebounceClickListener
 import java.io.File
 import java.io.IOException
@@ -91,8 +95,16 @@ class SignupEmailSetProfileImageOptionFragment : DialogFragment() {
             // 호출된 갤러리에서 이미지 선택시, data의 data속성으로 해당 이미지의 Uri 전달
             val uri = data?.data!!
             // 이미지 파일과 함께, 파일 확장자도 같이 저장
-            val fileExtension = requireContext().contentResolver.getType(uri).toString().split("/")[1]
-            setMyProfileImage(uri.toString(), fileExtension)
+            if (uri.extension.isPermitExtension) {
+                setMyProfileImage(uri.toString(), uri.extension)
+            } else {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.write_post_upload_alert_message_image_fail_file_extension),
+                    Toast.LENGTH_SHORT
+                ).show()
+                findNavController().popBackStack()
+            }
         }
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
@@ -21,7 +21,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.daily.dayo.R
 import com.daily.dayo.common.ButtonActivation
-import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.image.ImageResizeUtil
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.autoCleared
 import com.daily.dayo.common.dialog.LoadingAlertDialog

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -28,8 +28,11 @@ import com.daily.dayo.DayoApplication
 import com.daily.dayo.R
 import com.daily.dayo.common.*
 import com.daily.dayo.common.GlideLoadUtil.PROFILE_EDIT_USER_THUMBNAIL_SIZE
+import com.daily.dayo.common.image.ImageResizeUtil.USER_PROFILE_THUMBNAIL_RESIZE_SIZE
+import com.daily.dayo.common.image.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ReplaceUnicode.trimBlankText
 import com.daily.dayo.common.dialog.LoadingAlertDialog
+import com.daily.dayo.common.image.ImageResizeUtil
 import com.daily.dayo.databinding.FragmentProfileEditBinding
 import com.daily.dayo.presentation.viewmodel.ProfileSettingViewModel
 import kotlinx.coroutines.*
@@ -334,11 +337,11 @@ class ProfileEditFragment : Fragment() {
             null
         } else { // 2. 프로필 사진을 다른 사진으로 변경 한 경우
             setUploadImagePath(userProfileImageExtension)
-            val originalBitmap = userProfileImageString.toUri().toBitmap()
+            val originalBitmap = userProfileImageString.toUri().toBitmap().cropCenterBitmap()
             val resizedBitmap = ImageResizeUtil.resizeBitmap(
                 originalBitmap = originalBitmap,
-                resizedWidth = 100,
-                resizedHeight = 100
+                resizedWidth = USER_PROFILE_THUMBNAIL_RESIZE_SIZE,
+                resizedHeight = USER_PROFILE_THUMBNAIL_RESIZE_SIZE
             )
             bitmapToFile(resizedBitmap, imagePath)
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -104,6 +104,7 @@ class ProfileEditFragment : Fragment() {
                     HideKeyBoardUtil.hide(requireContext(), binding.etProfileEditNickname)
                     true
                 }
+
                 else -> false
             }
         }
@@ -200,7 +201,9 @@ class ProfileEditFragment : Fragment() {
                                         binding.etProfileEditNickname.text
                                     )
                                 )
-                                profileSettingViewModel.isNicknameDuplicate.observe(viewLifecycleOwner) { isDuplicate ->
+                                profileSettingViewModel.isNicknameDuplicate.observe(
+                                    viewLifecycleOwner
+                                ) { isDuplicate ->
                                     if (isDuplicate) {
                                         setEditTextTheme(
                                             getString(R.string.my_profile_edit_nickname_message_success),
@@ -305,6 +308,7 @@ class ProfileEditFragment : Fragment() {
                                     "My Profile Update",
                                     "CANCELLED"
                                 )
+
                                 null -> {
                                     profileSettingViewModel.requestProfile(memberId = DayoApplication.preferences.getCurrentUser().memberId!!)
                                     findNavController().navigateUp()

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileEditImageOptionFragment.kt
@@ -10,14 +10,18 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.view.*
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import com.daily.dayo.BuildConfig
+import com.daily.dayo.R
 import com.daily.dayo.common.dialog.DefaultDialogConfigure
 import com.daily.dayo.common.autoCleared
+import com.daily.dayo.common.image.ImageUploadUtil.extension
+import com.daily.dayo.common.image.ImageUploadUtil.isPermitExtension
 import com.daily.dayo.common.setOnDebounceClickListener
 import com.daily.dayo.databinding.FragmentProfileEditImageOptionBinding
 import java.io.File
@@ -106,9 +110,16 @@ class ProfileEditImageOptionFragment : DialogFragment() {
                 // 호출된 갤러리에서 이미지 선택시, data의 data속성으로 해당 이미지의 Uri 전달
                 val uri = data?.data!!
                 // 이미지 파일과 함께, 파일 확장자도 같이 저장
-                val fileExtension =
-                    requireContext().contentResolver.getType(uri).toString().split("/")[1]
-                setMyProfileImage(uri.toString(), fileExtension)
+                if (uri.extension.isPermitExtension) {
+                    setMyProfileImage(uri.toString(), uri.extension)
+                } else {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.write_post_upload_alert_message_image_fail_file_extension),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    findNavController().popBackStack()
+                }
             } else {
                 findNavController().popBackStack()
             }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/write/WriteImageOptionFragment.kt
@@ -158,8 +158,6 @@ class WriteImageOptionFragment : DialogFragment() {
                     }
                     // 선택한 갯수 만큼 loop
                     while (count > 0) {
-                        uriIdx++
-                        count--
                         remainingNum = 5 - writeViewModel.postImageUriList.size()
                         if (remainingNum > 0 && uriIdx < data.clipData!!.itemCount) {
                             val imageUri = data.clipData!!.getItemAt(uriIdx).uri
@@ -173,6 +171,9 @@ class WriteImageOptionFragment : DialogFragment() {
                                 ).show()
                             }
                         } else break
+
+                        uriIdx++
+                        count--
                     }
                     displayLoadingDialog()
                     findNavController().popBackStack()

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -9,7 +9,9 @@ import androidx.lifecycle.viewModelScope
 import com.daily.dayo.BuildConfig
 import com.daily.dayo.DayoApplication
 import com.daily.dayo.common.Event
-import com.daily.dayo.common.ImageResizeUtil
+import com.daily.dayo.common.image.ImageResizeUtil
+import com.daily.dayo.common.image.ImageResizeUtil.POST_IMAGE_RESIZE_SIZE
+import com.daily.dayo.common.image.ImageResizeUtil.cropCenterBitmap
 import com.daily.dayo.common.ListLiveData
 import com.daily.dayo.common.Resource
 import com.daily.dayo.common.toBitmap
@@ -105,12 +107,12 @@ class WriteViewModel @Inject constructor(
         val resizedImages = async {
             postImageUriList.value?.map { item ->
                 val postImageBitmap =
-                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)
+                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)?.cropCenterBitmap()
                 val resizedImageBitmap = postImageBitmap?.let {
                     ImageResizeUtil.resizeBitmap(
                         originalBitmap = it,
-                        resizedWidth = 480,
-                        resizedHeight = 480
+                        resizedWidth = POST_IMAGE_RESIZE_SIZE,
+                        resizedHeight = POST_IMAGE_RESIZE_SIZE
                     )
                 }
                 resizedImageBitmap.toFile(uploadImagePath)

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -107,7 +107,8 @@ class WriteViewModel @Inject constructor(
         val resizedImages = async {
             postImageUriList.value?.map { item ->
                 val postImageBitmap =
-                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)?.cropCenterBitmap()
+                    item.toUri().toBitmap(DayoApplication.applicationContext().contentResolver)
+                        ?.cropCenterBitmap()
                 val resizedImageBitmap = postImageBitmap?.let {
                     ImageResizeUtil.resizeBitmap(
                         originalBitmap = it,
@@ -194,12 +195,15 @@ class WriteViewModel @Inject constructor(
                     is NetworkResponse.Success -> {
                         Resource.success(ApiResponse.body?.data?.map { it.toFolder() })
                     }
+
                     is NetworkResponse.NetworkError -> {
                         Resource.error(ApiResponse.exception.toString(), null)
                     }
+
                     is NetworkResponse.ApiError -> {
                         Resource.error(ApiResponse.error.toString(), null)
                     }
+
                     is NetworkResponse.UnknownError -> {
                         Resource.error(ApiResponse.throwable.toString(), null)
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="write_post_upload_alert_message_empty_folder">폴더를 선택해 주세요</string>
     <string name="write_post_upload_alert_message_edittext_length_fail_max">내용은 200자까지 작성할 수 있어요.</string>
     <string name="write_post_upload_alert_message_image_fail_max">사진은 5장까지만 선택 가능합니다.</string>
+    <string name="write_post_upload_alert_message_image_fail_file_extension">jpg, jpeg, png, webp 형식의 이미지 파일만 업로드 가능합니다.</string>
     <string name="write_post_upload_alert_message_image_fail_null">사진 가져오기에 실패했습니다. 다시 선택해주세요</string>
     <string name="write_post_upload_alert_message_loading">게시글을 올리고 있어요! 잠시만 기다려주세요.</string>
     <string name="write_post_upload_alert_message_fail">게시글을 업로드 할 수 없어요. 다시 시도해주세요.</string>


### PR DESCRIPTION
## 내용
- 지원하지 않는 확장자를 가진 이미지 파일이 업로드 되는 문제 해결

## 작업사항
- 이미지 관련 Extension 등이 존재하는 패키지 생성
- jpg, jpeg, png, webp의 확장자를 가진 이미지 파일만 업로드할 수 있도록 구현
   - 관련 확장함수를 구현해 이미지를 업로드 하는 곳에서 공통적으로 사용
   - 이미지 확장자가 맞지 않는 이미지 업로드 시도시 경고 토스트 출력
- 업로드하려고 하는 이미지가 5장 이상인 경우 이미지 확장자가 맞지 않는 이미지를 제외하고 나머지에 대해 업로드하기 위해 업로드 개수를 카운팅하는 로직 변경

## 참고
- resolved: #485 