### PR TITLE
[bug] Fix updated folder is not refreshed and displayed other user's information

### DIFF
--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderOptionFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderOptionFragment.kt
@@ -75,7 +75,7 @@ class FolderOptionFragment : DialogFragment()  {
         folderViewModel.requestDeleteFolder(args.folderId)
         folderViewModel.deleteSuccess.observe(viewLifecycleOwner) {
             if(it.getContentIfNotHandled() == true) {
-                findNavController().navigate(FolderOptionFragmentDirections.actionFolderOptionFragmentToProfileFragment(memberId = DayoApplication.preferences.getCurrentUser().memberId!!))
+                findNavController().navigate(FolderOptionFragmentDirections.actionFolderOptionFragmentToMyPageFragment())
             }
         }
     }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/folder/FolderSettingAddFragment.kt
@@ -94,7 +94,7 @@ class FolderSettingAddFragment : Fragment() {
             }
 
             folderViewModel.requestCreateFolder(name, privacy, subheading, thumbnailImg)
-            folderViewModel.folderAddAccess.observe(viewLifecycleOwner) {
+            folderViewModel.folderAddSuccess.observe(viewLifecycleOwner) {
                 if (it.getContentIfNotHandled() == true) {
                     findNavController().popBackStack()
                 } else if (it.getContentIfNotHandled() == false) {

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.Navigation
@@ -48,6 +49,7 @@ class MyPageFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setScrollPosition()
         setProfileDescription()
         setViewPager()
         setViewPagerChangeEvent()
@@ -63,32 +65,44 @@ class MyPageFragment : Fragment() {
             unregisterOnPageChangeCallback(pageChangeCallBack)
             adapter = null
         }
+        profileViewModel.cleanUpFolders()
+    }
+
+    private fun setScrollPosition() {
+        with(binding) {
+            ViewCompat.requestApplyInsets(layoutMyPage)
+            ViewCompat.requestApplyInsets(layoutMyPageAppBar)
+        }
     }
 
     private fun setProfileDescription() {
         profileViewModel.requestMyProfile()
         profileViewModel.profileInfo.observe(viewLifecycleOwner) {
             it?.let { profile ->
-                binding.profile = profile
+                binding.profile = profile.data
                 glideRequestManager?.let { requestManager ->
-                    loadImageViewProfile(
-                        requestManager = requestManager,
-                        width = PROFILE_USER_THUMBNAIL_SIZE,
-                        height = PROFILE_USER_THUMBNAIL_SIZE,
-                        imgName = profile.profileImg,
-                        imgView = binding.imgMyPageUserProfile
-                    )
+                    profile.data?.profileImg?.let { profileImg ->
+                        loadImageViewProfile(
+                            requestManager = requestManager,
+                            width = PROFILE_USER_THUMBNAIL_SIZE,
+                            height = PROFILE_USER_THUMBNAIL_SIZE,
+                            imgName = profileImg,
+                            imgView = binding.imgMyPageUserProfile
+                        )
+                    }
                 }
 
-                profile.memberId?.let {
-                    setFollowerCountButtonClickListener(
-                        memberId = profile.memberId,
-                        nickname = profile.nickname
-                    )
-                    setFollowingCountButtonClickListener(
-                        memberId = profile.memberId,
-                        nickname = profile.nickname
-                    )
+                profile.data?.let { profile ->
+                    profile.memberId?.let {
+                        setFollowerCountButtonClickListener(
+                            memberId = profile.memberId,
+                            nickname = profile.nickname
+                        )
+                        setFollowingCountButtonClickListener(
+                            memberId = profile.memberId,
+                            nickname = profile.nickname
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -23,11 +23,6 @@ class ProfileFolderListFragment : Fragment() {
     private val profileViewModel by activityViewModels<ProfileViewModel>()
     private var profileFolderListAdapter: ProfileFolderListAdapter?= null
     private var glideRequestManager: RequestManager?= null
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        if (savedInstanceState == null)
-            getProfileFolderList()
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -35,6 +30,7 @@ class ProfileFolderListFragment : Fragment() {
     ): View {
         binding = FragmentProfileFolderListBinding.inflate(inflater, container, false)
         glideRequestManager = Glide.with(this)
+        getProfileFolderList()
         return binding.root
     }
 

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/FolderViewModel.kt
@@ -45,7 +45,7 @@ class FolderViewModel @Inject constructor(
     val orderFolderSuccess: LiveData<Event<Boolean>> get() = _orderFolderSuccess
 
     private val _folderAddSuccess = MutableLiveData<Event<Boolean>>()
-    val folderAddAccess: LiveData<Event<Boolean>> get() = _folderAddSuccess
+    val folderAddSuccess: LiveData<Event<Boolean>> get() = _folderAddSuccess
 
     private val _folderInfo = MutableLiveData<Resource<Folder>>()
     val folderInfo: LiveData<Resource<Folder>> get() = _folderInfo

--- a/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/daily/dayo/presentation/viewmodel/ProfileViewModel.kt
@@ -43,8 +43,8 @@ class ProfileViewModel @Inject constructor(
 
     lateinit var profileMemberId: String
 
-    private val _profileInfo = MutableLiveData<Profile>()
-    val profileInfo: LiveData<Profile> get() = _profileInfo
+    private val _profileInfo = MutableLiveData<Resource<Profile>>()
+    val profileInfo: LiveData<Resource<Profile>> get() = _profileInfo
 
     private val _followSuccess = MutableLiveData<Event<Boolean>>()
     val followSuccess: LiveData<Event<Boolean>> get() = _followSuccess
@@ -71,7 +71,7 @@ class ProfileViewModel @Inject constructor(
         requestMyProfileUseCase().let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
-                    _profileInfo.postValue(ApiResponse.body?.toProfile())
+                    _profileInfo.postValue(Resource.success(ApiResponse.body?.toProfile()))
                 }
 
                 is NetworkResponse.NetworkError -> {
@@ -93,7 +93,7 @@ class ProfileViewModel @Inject constructor(
         requestOtherProfileUseCase(memberId = memberId).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
-                    _profileInfo.postValue(ApiResponse.body?.toProfile())
+                    _profileInfo.postValue(Resource.success(ApiResponse.body?.toProfile()))
                 }
 
                 is NetworkResponse.NetworkError -> {
@@ -256,5 +256,10 @@ class ProfileViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun cleanUpFolders() {
+        _profileInfo.postValue(Resource.loading(null))
+        _folderList.postValue(Resource.loading(null))
     }
 }

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -11,12 +11,14 @@
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/layout_my_page"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/gray_6_F0F1F3"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/layout_my_page_app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent">
@@ -49,7 +51,7 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/layout_my_page"
+                    android:id="@+id/layout_my_page_user_info"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="?attr/actionBarSize"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -13,12 +13,14 @@
             type="com.daily.dayo.domain.model.Profile" />
     </data>
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/layout_profile"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/gray_6_F0F1F3"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/layout_profile_app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent">
@@ -63,7 +65,7 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/layout_profile"
+                    android:id="@+id/layout_profile_user_info"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="?attr/actionBarSize"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -453,11 +453,12 @@
             android:name="folderId"
             app:argType="integer" />
         <action
-            android:id="@+id/action_folderOptionFragment_to_profileFragment"
-            app:destination="@+id/ProfileFragment"
+            android:id="@+id/action_folderOptionFragment_to_myPageFragment"
+            app:destination="@+id/MyPageFragment"
             app:enterAnim="@anim/translate_nothing"
             app:exitAnim="@anim/translate_to_right_out"
-            app:popUpTo="@id/ProfileFragment" />
+            app:popUpTo="@id/MyPageFragment"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_folderOptionFragment_to_folderEditFragment"
             app:destination="@+id/FolderEditFragment"


### PR DESCRIPTION
## 내용
- Profile 페이지에서 폴더를 들어가고 나올때, 유저정보가 나타나는 collapsingLayout에 대한 스크롤이 유지되지 않고 있던 현상에 대해 `requestApplyInset`을 통해 해결
- Profile 페이지에서 보여지는 Folder ListView에 대해서 Profile View가 Destroy될 때 folder에 대한 정보와 유저에 대한 정보를 null 처리하여 다른 사람의 프로필 페이지르 들어갈 때 이전에 본 사람의 정보가 일시적으로 보여지고 있던 현상 해결
   - 해당 과정에서 기존에 사용하고 있던 Data에 대해 Resource로 Wrapping 처리
- 폴더 삭제후, 마이페이지가 아닌 다른 사람 프로필을 보는 Fragment로 이동하고 있던 현상 수정
   - 삭제 완료후 마이 페이지로 이동할 수 있도록 설정
- folderAccess에 대한 오타를 folderSuccess로 수정

## 참고
- resolved: #495 