### PR TITLE
[feature] Add Refreshing when bottom navigation bar icon is clicked

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -217,6 +217,14 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    fun setBottomNavigationIconClickListener(reselectedIconId: Int, reselectAction: () -> Unit) {
+        binding.bottomNavigationMainBar.setOnItemReselectedListener {
+            when (it.itemId) {
+                reselectedIconId -> reselectAction()
+            }
+        }
+    }
+
     companion object {
         val notificationPermission = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
     }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/feed/FeedFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/feed/FeedFragment.kt
@@ -24,12 +24,11 @@ import daily.dayo.presentation.databinding.FragmentFeedBinding
 import daily.dayo.presentation.adapter.FeedListAdapter
 import daily.dayo.presentation.viewmodel.FeedViewModel
 import daily.dayo.presentation.viewmodel.SearchViewModel
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.chip.Chip
 import dagger.hilt.android.AndroidEntryPoint
 import daily.dayo.domain.model.Post
+import daily.dayo.presentation.activity.MainActivity
 import daily.dayo.presentation.viewmodel.AccountViewModel
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class FeedFragment : Fragment() {
@@ -63,6 +62,7 @@ class FeedFragment : Fragment() {
         setFeedPostClickListener()
         setFeedEmptyButtonClickListener()
         setFeedRefreshListener()
+        setBottomNavigationIconClickListener()
     }
 
     override fun onResume() {
@@ -165,6 +165,21 @@ class FeedFragment : Fragment() {
                 Log.e(this@FeedFragment.tag, "PostId Null Exception Occurred")
                 getFeedPostList()
             }
+        }
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(R.id.FeedFragment) {
+            binding.swipeRefreshLayoutFeed.isRefreshing = true
+            getFeedPostList()
+            setScrollToTop(isSmoothScroll = true)
+        }
+    }
+
+    private fun setScrollToTop(isSmoothScroll:Boolean = false) {
+        with(binding.rvFeedPost) {
+            if (isSmoothScroll) this.smoothScrollToPosition(0)
+            else this.scrollToPosition(0)
         }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeDayoPickPostListFragment.kt
@@ -27,6 +27,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import daily.dayo.domain.model.Category
 import daily.dayo.domain.model.Post
+import daily.dayo.presentation.activity.MainActivity
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -67,6 +68,7 @@ class HomeDayoPickPostListFragment : Fragment() {
 
     override fun onResume() {
         binding.swipeRefreshLayoutDayoPickPost.isEnabled = true
+        setBottomNavigationIconClickListener()
         super.onResume()
     }
 
@@ -160,14 +162,16 @@ class HomeDayoPickPostListFragment : Fragment() {
         }
     }
 
-    private fun loadPosts(selectCategory: Category) {
+    private fun loadPosts(selectCategory: Category, isSmoothScroll: Boolean = false) {
         with(homeViewModel) {
             currentDayoPickCategory = selectCategory
             requestDayoPickPostList()
         }
 
-        if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED))
-            binding.rvDayopickPost.scrollToPosition(0)
+        if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+            if (isSmoothScroll) binding.rvDayopickPost.smoothScrollToPosition(0)
+            else binding.rvDayopickPost.scrollToPosition(0)
+        }
     }
 
     private fun setPostLikeClickListener() {
@@ -244,6 +248,20 @@ class HomeDayoPickPostListFragment : Fragment() {
                     thumbnailImgList.clear()
                     userImgList.clear()
                 }
+            }
+        }
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        val currentViewPagerPosition =
+            requireParentFragment().requireView()
+                .findViewById<ViewPager2>(R.id.pager_home_post)
+                .currentItem
+
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.HomeFragment) {
+            if (currentViewPagerPosition == HOME_DAYOPICK_PAGE_TAB_ID) {
+                binding.swipeRefreshLayoutDayoPickPost.isRefreshing = true
+                loadPosts(homeViewModel.currentDayoPickCategory, isSmoothScroll = true)
             }
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeFragment.kt
@@ -15,6 +15,9 @@ import daily.dayo.presentation.adapter.HomeFragmentPagerStateAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 
+const val HOME_DAYOPICK_PAGE_TAB_ID = 0
+const val HOME_NEW_PAGE_TAB_ID = 1
+
 @AndroidEntryPoint
 class HomeFragment : Fragment() {
     private var binding by autoCleared<FragmentHomeBinding>(onDestroy = {
@@ -83,10 +86,8 @@ class HomeFragment : Fragment() {
             binding.pagerHomePost
         ) { tab, position ->
             when (position) {
-                0 ->
-                    tab.text = "DAYO PICK"
-                1 ->
-                    tab.text = "NEW"
+                HOME_DAYOPICK_PAGE_TAB_ID -> tab.text = "DAYO PICK"
+                HOME_NEW_PAGE_TAB_ID -> tab.text = "NEW"
             }
         }
         mediator?.attach()

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/home/HomeNewPostListFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import daily.dayo.presentation.R
@@ -28,6 +29,7 @@ import daily.dayo.presentation.adapter.HomeNewAdapter
 import daily.dayo.presentation.viewmodel.HomeViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
+import daily.dayo.presentation.activity.MainActivity
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -68,6 +70,7 @@ class HomeNewPostListFragment : Fragment() {
 
     override fun onResume() {
         binding.swipeRefreshLayoutNewPost.isEnabled = true
+        setBottomNavigationIconClickListener()
         super.onResume()
     }
 
@@ -159,14 +162,16 @@ class HomeNewPostListFragment : Fragment() {
         }
     }
 
-    private fun loadPosts(selectCategory: Category) {
+    private fun loadPosts(selectCategory: Category, isSmoothScroll: Boolean = false) {
         with(homeViewModel) {
             currentNewCategory = selectCategory
             requestNewPostList()
         }
 
-        if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED))
-            binding.rvNewPost.scrollToPosition(0)
+        if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+            if (isSmoothScroll) binding.rvNewPost.smoothScrollToPosition(0)
+            else binding.rvNewPost.scrollToPosition(0)
+        }
     }
 
     private fun setPostLikeClickListener() {
@@ -235,6 +240,20 @@ class HomeNewPostListFragment : Fragment() {
                     thumbnailImgList.clear()
                     userImgList.clear()
                 }
+            }
+        }
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        val currentViewPagerPosition =
+            requireParentFragment().requireView()
+                .findViewById<ViewPager2>(R.id.pager_home_post)
+                .currentItem
+
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.HomeFragment) {
+            if (currentViewPagerPosition == HOME_NEW_PAGE_TAB_ID) {
+                binding.swipeRefreshLayoutNewPost.isRefreshing = true
+                loadPosts(homeViewModel.currentNewCategory, isSmoothScroll = true)
             }
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/MyPageFragment.kt
@@ -22,6 +22,10 @@ import daily.dayo.presentation.viewmodel.ProfileViewModel
 import com.google.android.material.tabs.TabLayoutMediator
 import daily.dayo.presentation.viewmodel.AccountViewModel
 
+const val FOLDERS_TAB_ID = 0
+const val LIKES_TAB_ID = 1
+const val BOOKMARKS_TAB_ID = 2
+
 class MyPageFragment : Fragment() {
     private var binding by autoCleared<FragmentMyPageBinding> { onDestroyBindingView() }
     private val accountViewModel by activityViewModels<AccountViewModel>()
@@ -75,6 +79,12 @@ class MyPageFragment : Fragment() {
             ViewCompat.requestApplyInsets(layoutMyPageAppBar)
         }
     }
+    
+    fun resetAppBarScrollPosition() {
+        with(binding) {
+            layoutMyPageAppBar.setExpanded(true, true)
+        }
+    }
 
     private fun setProfileDescription() {
         profileViewModel.requestMyProfile()
@@ -123,9 +133,9 @@ class MyPageFragment : Fragment() {
 
         mediator = TabLayoutMediator(binding.tabsMyPage, binding.pagerMyPage) { tab, position ->
             when (position) {
-                0 -> tab.text = "작성한 글"
-                1 -> tab.text = "좋아요"
-                2 -> tab.text = "북마크"
+                FOLDERS_TAB_ID -> tab.text = "작성한 글"
+                LIKES_TAB_ID -> tab.text = "좋아요"
+                BOOKMARKS_TAB_ID -> tab.text = "북마크"
             }
         }
         mediator?.attach()

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileBookmarkPostListFragment.kt
@@ -6,11 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.paging.LoadState
+import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import daily.dayo.presentation.R
@@ -18,9 +16,8 @@ import daily.dayo.presentation.common.autoCleared
 import daily.dayo.presentation.databinding.FragmentProfileBookmarkPostListBinding
 import daily.dayo.presentation.adapter.ProfileBookmarkPostListAdapter
 import daily.dayo.presentation.viewmodel.ProfileViewModel
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import daily.dayo.domain.model.BookmarkPost
-import kotlinx.coroutines.Dispatchers
+import daily.dayo.presentation.activity.MainActivity
 
 class ProfileBookmarkPostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileBookmarkPostListBinding> { onDestroyBindingView() }
@@ -48,6 +45,11 @@ class ProfileBookmarkPostListFragment : Fragment() {
         setRvProfileBookmarkPostListAdapter()
         setProfileBookmarkPostList()
         setAdapterLoadStateListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setBottomNavigationIconClickListener()
     }
 
     private fun onDestroyBindingView() {
@@ -111,5 +113,27 @@ class ProfileBookmarkPostListFragment : Fragment() {
         binding.layoutProfileBookmarkPostShimmer.stopShimmer()
         binding.layoutProfileBookmarkPostShimmer.visibility = View.GONE
         binding.rvProfileBookmarkPost.visibility = View.VISIBLE
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        val currentViewPagerPosition =
+            requireParentFragment().requireView()
+                .findViewById<ViewPager2>(R.id.pager_my_page)
+                .currentItem
+
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.MyPageFragment) {
+            if (currentViewPagerPosition == BOOKMARKS_TAB_ID) {
+                getProfileBookmarkPostList()
+                setScrollToTop(isSmoothScroll = true)
+            }
+        }
+    }
+
+    private fun setScrollToTop(isSmoothScroll: Boolean = false) {
+        (requireParentFragment() as MyPageFragment).resetAppBarScrollPosition()
+        with(binding.rvProfileBookmarkPost) {
+            if (isSmoothScroll) this.smoothScrollToPosition(0)
+            else this.scrollToPosition(0)
+        }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileFolderListFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import daily.dayo.presentation.R
@@ -15,10 +16,9 @@ import daily.dayo.presentation.common.autoCleared
 import daily.dayo.presentation.databinding.FragmentProfileFolderListBinding
 import daily.dayo.presentation.adapter.ProfileFolderListAdapter
 import daily.dayo.presentation.viewmodel.ProfileViewModel
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import daily.dayo.domain.model.Folder
+import daily.dayo.presentation.activity.MainActivity
 import daily.dayo.presentation.viewmodel.AccountViewModel
-import kotlinx.coroutines.Dispatchers
 
 class ProfileFolderListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileFolderListBinding> { onDestroyBindingView() }
@@ -41,6 +41,11 @@ class ProfileFolderListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setRvProfileFolderListAdapter()
         setProfileFolderList()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setBottomNavigationIconClickListener()
     }
 
     private fun onDestroyBindingView() {
@@ -84,6 +89,28 @@ class ProfileFolderListFragment : Fragment() {
                 }
                 else -> {}
             }
+        }
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        val currentViewPagerPosition =
+            requireParentFragment().requireView()
+                .findViewById<ViewPager2>(R.id.pager_my_page)
+                .currentItem
+
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.MyPageFragment) {
+            if (currentViewPagerPosition == FOLDERS_TAB_ID) {
+                getProfileFolderList()
+                setScrollToTop(isSmoothScroll = true)
+            }
+        }
+    }
+
+    private fun setScrollToTop(isSmoothScroll: Boolean = false) {
+        (requireParentFragment() as MyPageFragment).resetAppBarScrollPosition()
+        with(binding.rvProfileFolder) {
+            if (isSmoothScroll) this.smoothScrollToPosition(0)
+            else this.scrollToPosition(0)
         }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileFragment.kt
@@ -28,7 +28,6 @@ import daily.dayo.presentation.viewmodel.ProfileViewModel
 import com.google.android.material.tabs.TabLayoutMediator
 import daily.dayo.domain.model.Folder
 import daily.dayo.presentation.viewmodel.AccountViewModel
-import kotlinx.coroutines.Dispatchers
 
 class ProfileFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileBinding> {

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileLikePostListFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.paging.LoadState
+import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import daily.dayo.presentation.R
@@ -16,9 +17,7 @@ import daily.dayo.presentation.databinding.FragmentProfileLikePostListBinding
 import daily.dayo.domain.model.LikePost
 import daily.dayo.presentation.adapter.ProfileLikePostListAdapter
 import daily.dayo.presentation.viewmodel.ProfileViewModel
-import com.google.android.material.bottomnavigation.BottomNavigationView
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import daily.dayo.presentation.activity.MainActivity
 
 class ProfileLikePostListFragment : Fragment() {
     private var binding by autoCleared<FragmentProfileLikePostListBinding>{ onDestroyBindingView() }
@@ -46,6 +45,11 @@ class ProfileLikePostListFragment : Fragment() {
         setRvProfileLikePostListAdapter()
         setProfileLikePostList()
         setAdapterLoadStateListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setBottomNavigationIconClickListener()
     }
 
     private fun onDestroyBindingView() {
@@ -105,5 +109,27 @@ class ProfileLikePostListFragment : Fragment() {
         binding.layoutProfileLikePostShimmer.stopShimmer()
         binding.layoutProfileLikePostShimmer.visibility = View.GONE
         binding.rvProfileLikePost.visibility = View.VISIBLE
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        val currentViewPagerPosition =
+            requireParentFragment().requireView()
+                .findViewById<ViewPager2>(R.id.pager_my_page)
+                .currentItem
+
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.MyPageFragment) {
+            if (currentViewPagerPosition == LIKES_TAB_ID) {
+                getProfileLikePostList()
+                setScrollToTop(isSmoothScroll = true)
+            }
+        }
+    }
+
+    private fun setScrollToTop(isSmoothScroll: Boolean = false) {
+        (requireParentFragment() as MyPageFragment).resetAppBarScrollPosition()
+        with(binding.rvProfileLikePost) {
+            if (isSmoothScroll) this.smoothScrollToPosition(0)
+            else this.scrollToPosition(0)
+        }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/notification/NotificationFragment.kt
@@ -15,9 +15,8 @@ import daily.dayo.presentation.common.autoCleared
 import daily.dayo.presentation.databinding.FragmentNotificationBinding
 import daily.dayo.presentation.adapter.NotificationListAdapter
 import daily.dayo.presentation.viewmodel.NotificationViewModel
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
+import daily.dayo.presentation.activity.MainActivity
 
 @AndroidEntryPoint
 class NotificationFragment : Fragment() {
@@ -40,6 +39,7 @@ class NotificationFragment : Fragment() {
         setNotificationListAdapter()
         setAdapterLoadStateListener()
         setAlarmList()
+        setBottomNavigationIconClickListener()
     }
 
     override fun onResume() {
@@ -92,6 +92,20 @@ class NotificationFragment : Fragment() {
                     isInitialLoad = true
                 }
             }
+        }
+    }
+
+    private fun setBottomNavigationIconClickListener() {
+        (requireActivity() as MainActivity).setBottomNavigationIconClickListener(reselectedIconId = R.id.NotificationFragment) {
+            getAlarmList()
+            setScrollToTop(isSmoothScroll = true)
+        }
+    }
+
+    private fun setScrollToTop(isSmoothScroll: Boolean = false) {
+        with(binding.rvNotificationList) {
+            if (isSmoothScroll) this.smoothScrollToPosition(0)
+            else this.scrollToPosition(0)
         }
     }
 }


### PR DESCRIPTION
## 내용
- Bottom Naviagtion Bar에서 현재 위치한 페이지에 대한 Icon을 클릭하는 경우, 스크롤을 최상단으로 이동시키면서 새로고침 기능 추가

## 작업 사항
- ViewPager 내부에 Fragment가 있는 경우 다른 탭이 선택되어있어 Fragment가 보이지 않음에도 아이콘을 클릭했을 때, 새로고침되는 현상을 방지하기 위해 ClickListener를 LifeCycle이 RESUME 상태일때 설정하고 PAUSE 상태가 되는 경우 해제되도록 구현
- 최상단으로 이동하는 겨웅 Smooth Scroll 되도록 구현
- SwipeRefreshLayout이 존재하는 경우, 해당 레이아웃이 새로고침될 때 나타나도록 구현
- MyPage에서 CollapsingToolbarLayout에 대해서 접혀있는 경우에 해당 레이아웃도 펼쳐지도록 구현

## 참고
- resolved: #500 