### PR TITLE
[feature] Create Android CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -37,25 +37,28 @@ jobs:
            echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > ./app/google-services.json
 
       - name: Download Android keystore
-        id: android_keystore_dev
+        id: android_keystore_release
         uses: timheuer/base64-to-file@v1.2
         with:
-          fileName: keystore-dev.jks
-          fileDir: '/home/runner/work/DAYO_Android/DAYO_Android/app/android'
-          encodedString: ${{ secrets.KEY_STORE_ENCODED }} 
+          fileName: keystore-release.jks
+          fileDir: '/home/runner/work/DAYO_Android/DAYO_Android/app'
+          encodedString: ${{ secrets.KEY_STORE_ENCODED }}
 
-      - name: Create key-dev.properties
+      - name: Create key-release.properties
         run: |
-          echo "storeFile=${{ steps.android_keystore_dev.outputs.filePath }}" > ./app/android/keystore-dev.properties
-          echo "storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> ./app/android/keystore-dev.properties
-          echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> ./app/android/keystore-dev.properties
-          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ./app/android/keystore-dev.properties
+          echo "storeFile=${{ steps.android_keystore_release.outputs.filePath }}" > ./app/keystore-release.properties
+          echo "storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> ./app/keystore-release.properties
+          echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> ./app/keystore-release.properties
+          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ./app/keystore-release.properties
 
       - name: Create Properties
         run: |
           echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
           echo '${{ secrets.SENTRY_PROPERTIES }}' > ./sentry.properties
           echo '${{ secrets.SENTRY_PROPERTIES }}' > ./app/src/main/resources/sentry.properties
+
+      - name: Build assemble release apk
+        run: ./gradlew assembleRelease
 
       - name: Create android test report
         uses: asadmansr/android-test-report-action@v1.2.0

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,16 +36,26 @@ jobs:
         run:
            echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > ./app/google-services.json
 
-      - name: Create KeyStore File and Properties
+      - name: Download Android keystore
+        id: android_keystore_dev
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: keystore-dev.jks
+          fileDir: '/home/runner/work/DAYO_Android/DAYO_Android/app/android'
+          encodedString: ${{ secrets.KEY_STORE_ENCODED }} 
+
+      - name: Create key-dev.properties
         run: |
-          echo '${{ secrets.KEY_STORE_ENCODED }}' | base64 -d > ./dayo_keystore
+          echo "storeFile=${{ steps.android_keystore_dev.outputs.filePath }}" > ./app/android/keystore-dev.properties
+          echo "storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> ./app/android/keystore-dev.properties
+          echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> ./app/android/keystore-dev.properties
+          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ./app/android/keystore-dev.properties
+
+      - name: Create Properties
+        run: |
           echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
-          echo '${{ secrets.GRADLE_PROPERTIES }}' > ./gradle.properties
           echo '${{ secrets.SENTRY_PROPERTIES }}' > ./sentry.properties
           echo '${{ secrets.SENTRY_PROPERTIES }}' > ./app/src/main/resources/sentry.properties
-
-      - name: Build assemble release apk
-        run: ./gradlew assembleRelease
 
       - name: Create android test report
         uses: asadmansr/android-test-report-action@v1.2.0

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ plugins {
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
+def keystorePropertiesFile = rootProject.file("app/keystore-release.properties")
 
 sentry {
     setIncludeProguardMapping(true)
@@ -41,10 +42,13 @@ android {
 
     signingConfigs {
         release {
-            storePassword SIGNED_STORE_PASSWORD
-            keyAlias SIGNED_KEY_ALIAS
-            keyPassword SIGNED_KEY_PASSWORD
-            storeFile file(SIGNED_STORE_FILE)
+            def keystoreProperties = new Properties()
+            keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
+            storeFile file(keystoreProperties['storeFile'])
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storePassword keystoreProperties['storePassword']
         }
     }
 


### PR DESCRIPTION
## 내용 및 작업 사항
- Develop Branch에 Pull Request를 보내는 경우에 대해 자동으로 빌드 및 테스트가 실행시켜 정상적으로 통합되는지에 대해 검사
- Keystore에 대해 기존에 gradle.properties를 통해 관리하던것을 keystore-release.properties로 별도 분리
- release에 대한 keystore 파일의 명확한 이름 설정
- 업로드가 불가능한 파일및 코드들에 대해서 repository secrets로 관리

## 참고
- resolved: #509 