### PR TITLE
[bug] Add code to exclude obfuscation related to networking

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -41,6 +41,13 @@
 # ==================================
 # Retrofit
 # ==================================
+
+#ParametrizedType ClassCastException error fix
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.** { *; }
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
 -keepclasseswithmembers class * {
     @retrofit2.http.* <methods>;
 }
@@ -99,6 +106,8 @@
 -keep class com.kakao.sdk.**.model.* { <fields>; }
 -keep class * extends com.google.gson.TypeAdapter
 
--keep class com.daily.dayo.data.datasource.remote.**.* { *; }
+-keepattributes Signature #
 -keep class * implements java.io.Serializable { *; }
 -keepclassmembers enum * { *; }
+-keep class daily.dayo.data.datasource.remote.**.* { *; }
+-keep class daily.dayo.domain.model.* { *; }


### PR DESCRIPTION
## 내용 및 작업사항
- Release버전에서 Retrofit과 관련되어 난독화 진행시 Crash가 발생함에 따라, 관련된 코드에 대해 난독화 제외 처리
- 모듈화하면서 정상적으로 난독화 제외되었던 파일이 제외되지 않고 있던 부분에 대해, 제외될 수 있도록 처리

## 참고
- https://github.com/square/retrofit/issues/3751#issuecomment-1515817159
- resolved: #511 