### PR TITLE
[feature] Create Android CD

### DIFF
--- a/.github/workflows/Android-release CD.yml
+++ b/.github/workflows/Android-release CD.yml
@@ -1,0 +1,99 @@
+name: Android-release CD.yml
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: "adopt"
+        java-version: '17'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Create google-services
+      run:
+        echo '${{ secrets.GOOGLE_SERVICES_JSON_RELEASE }}' > ./app/google-services.json
+
+    - name: Download Android keystore
+      id: android_keystore_release
+      uses: timheuer/base64-to-file@v1.2
+      with:
+        fileName: keystore-release.jks
+        fileDir: '/home/runner/work/DAYO_Android/DAYO_Android/app'
+        encodedString: ${{ secrets.KEY_STORE_ENCODED }}
+
+    - name: Create key-release.properties
+      run: |
+        echo "storeFile=${{ steps.android_keystore_release.outputs.filePath }}" > ./app/keystore-release.properties
+        echo "storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> ./app/keystore-release.properties
+        echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> ./app/keystore-release.properties
+        echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ./app/keystore-release.properties
+
+    - name: Create Properties
+      run: |
+        echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+        echo '${{ secrets.SENTRY_PROPERTIES }}' > ./sentry.properties
+        echo '${{ secrets.SENTRY_PROPERTIES }}' > ./app/src/main/resources/sentry.properties
+
+    # Build APK Release
+    - name: Build release Apk
+      run: ./gradlew clean assembleRelease
+
+    # Build AAB Release
+    - name: Build release Bundle
+      run: ./gradlew clean bundleRelease
+
+    # Upload AAB
+    - name: Upload a Build AAB Artifact
+      uses: actions/upload-artifact@v3.0.0
+      with:
+        # Artifact name
+        name: app-release.aab
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./app/build/outputs/bundle/release/app-release.aab
+        retention-days: 14
+
+    # Upload APK
+    - name: Upload a Build APK Artifact
+      uses: actions/upload-artifact@v3.0.0
+      with:
+        # Artifact name
+        name: app-release.apk
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./app/build/outputs/apk/release/app-release.apk
+        retention-days: 14
+
+    - name: Deploy to Play Store (INTERNAL) 🚀
+      uses: r0adkll/upload-google-play@v1
+      with:
+        serviceAccountJsonPlainText: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+        packageName: ${{secrets.AOS_PACKAGE_NAME}}
+        releaseFiles: ./app/build/outputs/bundle/release/app-release.aab
+        track: internal
+        status: draft


### PR DESCRIPTION
## 내용 및 작업사항
- Android 프로젝트에서 릴리즈 버전에 대한 CD(Continuous Deployment)를 구축해, 빌드 및 테스트뿐 아니라 배포도 자동화 할 수 있도록 처리
- 배포시, Google Play Console에서 내부 테스트 단계에서 Draft 상태로 작성되도록 설정해 바로 배포되는 것이 아닌, 구글 플레이 콘솔에서 패치 노트 작성 등의 과정을 거친 뒤 실제로 출시 버튼을 눌러야 내부 테스트 단계에서도 배포되도록 설정

## 참고
- 추후 업데이트 등으로 프로덕션 레벨로 배포 해야하는 경우, 내부 테스트 레벨에서 Draft로 작성되어 있는 상태로 되어있는 버전에 대해 패치 노트 작성 등의 과정 후 **내부 테스트 단계에서 출시 후**에, **버전 승급을 통해 프로덕션 단계로 배포** 할 수 있도록 설정
- resolved: #516 