### PR TITLE
[bug] Gradle caching is no longer valid in CI

### DIFF
--- a/.github/workflows/Android-release CI.yml
+++ b/.github/workflows/Android-release CI.yml
@@ -11,6 +11,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
@@ -20,15 +30,6 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/Android-release CI.yml
+++ b/.github/workflows/Android-release CI.yml
@@ -21,7 +21,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## 내용 및 작업 사항
<img width="922" alt="스크린샷 2023-09-06 오후 11 34 57" src="https://github.com/Daily-DAYO/DAYO_Android/assets/65344669/03a60c73-1614-42ff-9bc5-579042c9e7b7">
- Gradle caching 과정에서 더이상 지원되지 않는 오픈소스 제거 및 새로운 버전으로 업데이트
- 캐싱작업을 Branch 체크아웃 하자마자 JDK 및 SDK 설치 등의 다른 작업들이 실행되기 이전에 체크하도록 순서 변경
- CI 작업에 대한 release 및 debug 버전 구분을 위한 파일 이름 명확화

## 참고
- resolved: #518 