### PR TITLE
[bug] Override system back button press action

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.DAYO">
+        android:theme="@style/Theme.DAYO"
+        android:enableOnBackInvokedCallback="true">
         <meta-data android:name="io.sentry.dsn" android:value="https://7f03a2b5d1c24582bfca11c28231a45f@o4504230448136192.ingest.sentry.io/4504230448988160" />
         <!-- Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
            We recommend adjusting this value in production. -->

--- a/presentation/src/main/java/daily/dayo/presentation/activity/LoginActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/LoginActivity.kt
@@ -6,12 +6,14 @@ import android.os.Bundle
 import android.util.Log
 import android.view.ViewTreeObserver
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import daily.dayo.presentation.databinding.ActivityLoginBinding
 import daily.dayo.presentation.viewmodel.AccountViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import daily.dayo.presentation.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -27,11 +29,32 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSystemBackClickListener()
         observeNetworkException()
         observeApiException()
         autoLogin()
         loginSuccess()
         setSplash()
+    }
+
+    private fun setSystemBackClickListener() {
+        this.onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    val navHostFragment =
+                        supportFragmentManager.findFragmentById(R.id.nav_host_fragment)
+                    val backStackEntryCount =
+                        navHostFragment?.childFragmentManager?.backStackEntryCount
+
+                    if (backStackEntryCount == 0) {
+                        this@LoginActivity.finish()
+                    } else {
+                        navHostFragment?.childFragmentManager?.popBackStack()
+                    }
+                }
+            }
+        )
     }
 
     private fun setFCM() {

--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import android.provider.Settings
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -36,13 +37,33 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
+        setSystemBackClickListener()
         checkCurrentNotification()
         initBottomNavigation()
         setBottomNaviVisibility()
         disableBottomNaviTooltip()
         getNotificationData()
         askNotificationPermission()
+    }
+
+    private fun setSystemBackClickListener() {
+        this.onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    val navHostFragment =
+                        supportFragmentManager.findFragmentById(R.id.nav_host_fragment)
+                    val backStackEntryCount =
+                        navHostFragment?.childFragmentManager?.backStackEntryCount
+
+                    if (backStackEntryCount == 0) {
+                        this@MainActivity.finish()
+                    } else {
+                        findNavController().popBackStack()
+                    }
+                }
+            }
+        )
     }
 
     private fun checkCurrentNotification() {


### PR DESCRIPTION
## 내용 및 작업사항
- LoginActivity및 MainActivity에서 디바이스에서의 Back Button을 누르는 동작을 가로채 `popBackStack()` 동작이 이뤄지도록 설정
   - backStackEntry의 개수를 확인해 backStack에 아무것도 없으면 앱이 종료되도록 설정
   - 기존에 페이지간 트랜지션이 완료되기 이전에 시스템의 Back Event가 또 다시 발생하면 정상적으로 `popBackStack()`이 동작하지 않던점을 오버라이드가 되도록 설정해 해결
- AndroidManifest에서 enableOnBackInvokedCallback에 대해 true 설정
   - API 33이상을 지원하는 경우 해당 속성을 true로 설정해야 시스템의 Back Event를 가로챌 수 있음에 따라 설정

## 참고
- resolved: #520 