### PR TITLE
[layout] Common Text Fields

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ kotlin {
 android {
     defaultConfig {
         applicationId "com.daily.dayo"
-        compileSdk 33
+        compileSdk 34
         minSdkVersion 26
         targetSdkVersion 33
         versionCode 20000

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -20,7 +20,7 @@ kotlin {
 
 android {
     namespace 'daily.dayo.presentation'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 26
@@ -95,7 +95,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.10.1'
-    implementation("androidx.compose.material3:material3")
+
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     // Java language implementation
@@ -108,6 +108,9 @@ dependencies {
     implementation("androidx.activity:activity-ktx:$activity_version")
 
     // Jetpack Compose
+    // Material
+    implementation("androidx.compose.material3:material3")
+    implementation ("androidx.compose.material:material-icons-extended:1.5.3")
     // Android Studio Preview support
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/presentation/src/main/java/daily/dayo/presentation/view/FilledTextField.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FilledTextField.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.Gray2_767B83
 import daily.dayo.presentation.theme.Gray4_C5CAD2
 import daily.dayo.presentation.theme.Gray5_E8EAEE
 import daily.dayo.presentation.theme.Gray6_F0F1F3
@@ -160,7 +161,7 @@ fun FilledTimerField(
         isError = isError,
         supportingText = { if (isError) Text(text = errorMessage) else Text(text = "") },
         textStyle = TextStyle(textAlign = textAlign, color = Gray1_313131),
-        trailingIcon = { Text(text = "${String.format("%02d", (timeLeft / 60) % 60)}:${String.format("%02d", timeLeft % 60)}") },
+        trailingIcon = { Text(text = "${String.format("%02d", (timeLeft / 60) % 60)}:${String.format("%02d", timeLeft % 60)}", color = Gray2_767B83) },
         colors = TextFieldDefaults.colors(
             errorSupportingTextColor = Red_FF4545,
             focusedIndicatorColor = PrimaryGreen_23C882,

--- a/presentation/src/main/java/daily/dayo/presentation/view/FilledTextField.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FilledTextField.kt
@@ -1,0 +1,220 @@
+package daily.dayo.presentation.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.Gray4_C5CAD2
+import daily.dayo.presentation.theme.Gray5_E8EAEE
+import daily.dayo.presentation.theme.Gray6_F0F1F3
+import daily.dayo.presentation.theme.PrimaryGreen_23C882
+import daily.dayo.presentation.theme.Red_FF4545
+import kotlinx.coroutines.delay
+
+@Composable
+fun FilledTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String = "",
+    placeholder: String = "",
+    isError: Boolean = false,
+    errorMessage: String = "",
+    trailingIcon: (@Composable () -> Unit)? = null,
+    textAlign: TextAlign = TextAlign.Left
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = if (label != "") {
+            { Text(text = label) }
+        } else null,
+        placeholder = { Text(text = placeholder) },
+        isError = isError,
+        supportingText = { if (isError) Text(text = errorMessage) else Text(text = "") },
+        textStyle = TextStyle(textAlign = textAlign, color = Gray1_313131),
+        colors = TextFieldDefaults.colors(
+            errorSupportingTextColor = Red_FF4545, // 에러 메시지
+            focusedIndicatorColor = PrimaryGreen_23C882, // 밑줄
+            unfocusedIndicatorColor = Gray6_F0F1F3,
+            errorIndicatorColor = Red_FF4545,
+            unfocusedContainerColor = Color.Transparent, // 배경
+            disabledContainerColor = Color.Transparent,
+            errorContainerColor = Color.Transparent,
+            focusedContainerColor = Color.Transparent,
+            unfocusedLabelColor = Color.Transparent, // 라벨
+            focusedLabelColor = Gray4_C5CAD2,
+            errorLabelColor = Red_FF4545,
+            focusedPlaceholderColor = Gray5_E8EAEE, // 힌트
+            unfocusedPlaceholderColor = Gray5_E8EAEE,
+            disabledPlaceholderColor = Gray5_E8EAEE
+        ),
+        trailingIcon = if (isError) {
+            { Icon(imageVector = Icons.Filled.Cancel, contentDescription = "error", tint = Red_FF4545) }
+        } else trailingIcon
+    )
+}
+
+@Composable
+fun FilledPasswordField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String = "",
+    placeholder: String = "",
+    isError: Boolean = false,
+    errorMessage: String = "",
+    textAlign: TextAlign = TextAlign.Left
+) {
+    var passwordHidden by rememberSaveable { mutableStateOf(true) }
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = if (label != "") {
+            { Text(text = label) }
+        } else null,
+        placeholder = { Text(text = placeholder) },
+        isError = isError,
+        supportingText = { if (isError) Text(text = errorMessage) else Text(text = "") },
+        textStyle = TextStyle(textAlign = textAlign, color = Gray1_313131),
+        colors = TextFieldDefaults.colors(
+            errorSupportingTextColor = Red_FF4545,
+            focusedIndicatorColor = PrimaryGreen_23C882,
+            unfocusedIndicatorColor = Gray6_F0F1F3,
+            errorIndicatorColor = Red_FF4545,
+            unfocusedContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Transparent,
+            errorContainerColor = Color.Transparent,
+            focusedContainerColor = Color.Transparent,
+            unfocusedLabelColor = Color.Transparent,
+            focusedLabelColor = Gray4_C5CAD2,
+            errorLabelColor = Red_FF4545,
+            focusedPlaceholderColor = Gray5_E8EAEE,
+            unfocusedPlaceholderColor = Gray5_E8EAEE,
+            disabledPlaceholderColor = Gray5_E8EAEE
+        ),
+        visualTransformation = if (passwordHidden) PasswordVisualTransformation() else VisualTransformation.None,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        trailingIcon = {
+            if (isError) {
+                Icon(imageVector = Icons.Filled.Cancel, contentDescription = "error", tint = Red_FF4545)
+            } else {
+                IconButton(onClick = { passwordHidden = !passwordHidden }) {
+                    val iconColor = if (passwordHidden) Gray5_E8EAEE else PrimaryGreen_23C882
+                    val description = if (passwordHidden) "Show password" else "Hide password"
+                    Icon(imageVector = Icons.Filled.Visibility, contentDescription = description, tint = iconColor)
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun FilledTimerField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    seconds: Int,
+    isPaused: Boolean,
+    label: String = "",
+    placeholder: String = "",
+    isError: Boolean = false,
+    errorMessage: String = "",
+    textAlign: TextAlign = TextAlign.Left,
+) {
+    var timeLeft by rememberSaveable { mutableStateOf(seconds) }
+    LaunchedEffect(key1 = timeLeft, key2 = isPaused) {
+        while (timeLeft > 0 && !isPaused) {
+            delay(1000L)
+            timeLeft--
+        }
+    }
+
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = if (label != "") {
+            { Text(text = label) }
+        } else null,
+        placeholder = { Text(text = placeholder) },
+        isError = isError,
+        supportingText = { if (isError) Text(text = errorMessage) else Text(text = "") },
+        textStyle = TextStyle(textAlign = textAlign, color = Gray1_313131),
+        trailingIcon = { Text(text = "${String.format("%02d", (timeLeft / 60) % 60)}:${String.format("%02d", timeLeft % 60)}") },
+        colors = TextFieldDefaults.colors(
+            errorSupportingTextColor = Red_FF4545,
+            focusedIndicatorColor = PrimaryGreen_23C882,
+            unfocusedIndicatorColor = Gray6_F0F1F3,
+            errorIndicatorColor = Red_FF4545,
+            unfocusedContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Transparent,
+            errorContainerColor = Color.Transparent,
+            focusedContainerColor = Color.Transparent,
+            unfocusedLabelColor = Color.Transparent,
+            focusedLabelColor = Gray4_C5CAD2,
+            errorLabelColor = Red_FF4545,
+            focusedPlaceholderColor = Gray5_E8EAEE,
+            unfocusedPlaceholderColor = Gray5_E8EAEE,
+            disabledPlaceholderColor = Gray5_E8EAEE
+        )
+    )
+}
+
+@Preview
+@Composable
+fun PreviewTextField() {
+    Column {
+        // Default 사용 예시
+        val text = rememberSaveable { mutableStateOf("") }
+        val isError = text.value == "error"
+        FilledTextField(
+            value = text.value,
+            onValueChange = { textValue -> text.value = textValue },
+            label = "Text",
+            isError = isError,
+            errorMessage = "error",
+            placeholder = "text를 입력하세요"
+        )
+
+        // Password 사용 예시
+        val password = rememberSaveable { mutableStateOf("") }
+        FilledPasswordField(
+            value = password.value,
+            onValueChange = { textValue -> password.value = textValue },
+            placeholder = "비밀번호를 입력하세요"
+        )
+
+        // Timer 사용 예시
+        val timerText = rememberSaveable { mutableStateOf("") }
+        var isPaused by rememberSaveable { mutableStateOf(false) }
+        FilledTimerField(
+            value = timerText.value,
+            onValueChange = { textValue -> timerText.value = textValue },
+            seconds = 60,
+            isPaused = isPaused,
+            label = "Number",
+            isError = isError,
+            errorMessage = "error",
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
![image](https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/9f932c2b-e998-4141-8aea-c4537fa47438)

+ 요구 사항에 따라 공통적으로 사용할 FilledTextField만들기
+ Icon도 변경할 수 있어야합니다.
+ 위의 모든 상황에 대해 설정할 수 있도록 했습니다. 
+ Material Icon 라이브러리를 추가했습니다

### 1. 일반적인 TextField
```kotlin
@Composable
fun FilledTextField(
    value: String,
    onValueChange: (String) -> Unit,
    label: String = "",
    placeholder: String = "",
    isError: Boolean = false,
    errorMessage: String = "",
    trailingIcon: (@Composable () -> Unit)? = null,
    textAlign: TextAlign = TextAlign.Left
) 
``` 
- value, onValueChange만 필수 매개변수
- trailingIcon설정으로 우측 아이콘을 설정할 수 있음

### 2. 비밀번호 입력을 위한 TextField
```kotlin
@Composable
fun FilledPasswordField(
    value: String,
    onValueChange: (String) -> Unit,
    label: String = "",
    placeholder: String = "",
    isError: Boolean = false,
    errorMessage: String = "",
    textAlign: TextAlign = TextAlign.Left
) 
```
- value, onValueChange만 필수 매개변수
- Figma상에 이미지는 없지만 password 입력 시 별도로 text가 숨겨져야하므로 따로 구현함
- 우측 아이콘을 이용해 비밀번호를 숨기거나 볼 수 있도록 구현되어 있음

### 3. 타이머가 있는 TextField
```kotlin
@Composable
fun FilledTimerField(
    value: String,
    onValueChange: (String) -> Unit,
    seconds: Int,
    isPaused: Boolean,
    label: String = "",
    placeholder: String = "",
    isError: Boolean = false,
    errorMessage: String = "",
    textAlign: TextAlign = TextAlign.Left,
) 
```
- value, onValueChange, seconds, isPaused가 필수 매개변수
- 호출 시 초단위 시간을 입력하면 00:00의 형태로 시간이 표시됨
- isPaused가 true이거나 0초에 중지

### 사용 예시
`@Preview`로 사용 예시를 추가해두었습니다.

<img width="311" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/aff2fd44-16a1-4cfb-a24c-363ae6dbaebd">



디자인이 변경되거나 사용하면서 추가적으로 필요한 부분이 있다면 변경될 수 있습니다!

resolved : #531 