### PR TITLE
#533 [layout] Common Top Navigation

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
@@ -1,0 +1,97 @@
+package daily.dayo.presentation.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import daily.dayo.presentation.R
+import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.White_FFFFFF
+import daily.dayo.presentation.theme.h3
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopNavigation(
+    title: String = "",
+    leftIcon: @Composable () -> Unit = {},
+    rightIcon: @Composable () -> Unit = {},
+    titleAlignment: TopNavigationAlign = TopNavigationAlign.LEFT
+) {
+    when (titleAlignment) {
+        TopNavigationAlign.LEFT -> {
+            TopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = White_FFFFFF,
+                    titleContentColor = Gray1_313131,
+                ),
+                navigationIcon = leftIcon,
+                actions = { rightIcon() },
+                title = {
+                    Text(text = title, maxLines = 1, style = MaterialTheme.typography.h3)
+                }
+            )
+        }
+
+        TopNavigationAlign.CENTER -> {
+            CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = White_FFFFFF,
+                    titleContentColor = Gray1_313131,
+                ),
+                navigationIcon = leftIcon,
+                actions = { rightIcon() },
+                title = {
+                    Text(text = title, maxLines = 1, style = MaterialTheme.typography.h3)
+                }
+            )
+        }
+    }
+}
+
+enum class TopNavigationAlign {
+    LEFT, CENTER
+}
+
+@Preview
+@Composable
+fun PreviewTopNavigation() {
+    Column {
+        // Default 정렬 사용 예시
+        TopNavigation(
+            title = "Title",
+            leftIcon = {
+                IconButton(onClick = { /* do something */ }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        )
+
+        // Center 정렬 사용 예시
+        TopNavigation(
+            title = "Title",
+            rightIcon = {
+                IconButton(onClick = { /* do something */ }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_option),
+                        contentDescription = "Option"
+                    )
+                }
+            },
+            titleAlignment = TopNavigationAlign.CENTER
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
<img width="980" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/cd1a0db1-391e-458d-8c30-f9f40ce50d88">

+ 공통적으로 사용할 Top Navigation 만들기
+ 타이틀 텍스트를 왼쪽 혹은 오른쪽 정렬 가능
+ 피그마에 왼쪽과 오른쪽 각각 아이콘을 하나만 적용하는 경우만 존재하므로 하나씩만 적용할 수 있도록 함
+ Material3 사용을 위해 `@OptIn(ExperimentalMaterial3Api::class)` 어노테이션을 추가

### TopNavigation
```Kotlin
@Composable
fun TopNavigation(
    title: String = "",
    leftIcon: @Composable () -> Unit = {},
    rightIcon: @Composable () -> Unit = {},
    titleAlignment: TopNavigationAlign = TopNavigationAlign.LEFT
) 
```

**참고 사항**
+ title은 h3 폰트 스타일 적용
+ title 텍스트 위치가 왼쪽이나 중간에만 올 수 있으므로 enum클래스를 사용해 다른 속성을 입력할 수 없도록 함 
  
```Kotlin
  enum class TopNavigationAlign {
      LEFT, CENTER
  }
  ```


 ### 사용 예시
<img width="304" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/d8387f50-2391-4ac5-bd53-ca1eb177bbf7">



resolved: #533 
