### PR TITLE
#535 [layout] Common Buttons

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
@@ -1,26 +1,43 @@
 package daily.dayo.presentation.view
 
+import android.graphics.Color
 import android.util.Size
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.Gray2_767B83
 import daily.dayo.presentation.theme.Gray4_C5CAD2
 import daily.dayo.presentation.theme.Gray5_E8EAEE
 import daily.dayo.presentation.theme.PrimaryGreen_23C882
 import daily.dayo.presentation.theme.PrimaryL3_F2FBF7
 import daily.dayo.presentation.theme.White_FFFFFF
+import daily.dayo.presentation.theme.b3
 import daily.dayo.presentation.theme.b5
+import daily.dayo.presentation.theme.b6
+import daily.dayo.presentation.theme.caption3
 
 @Composable
 fun FilledButton(
@@ -29,7 +46,6 @@ fun FilledButton(
     icon: @Composable (() -> Unit)? = null,
     enabled: Boolean = true,
     isTonal: Boolean = false,
-    isRoundedCorner: Boolean = false,
     size: Size? = null
 ) {
     val buttonColors = if (isTonal)
@@ -52,28 +68,146 @@ fun FilledButton(
         onClick = { onClick() },
         colors = buttonColors,
         enabled = enabled,
-        shape = if (isRoundedCorner) RoundedCornerShape(8.dp) else ButtonDefaults.shape,
         modifier = if (size != null) Modifier.size(size.width.dp, size.height.dp) else Modifier,
         content = {
             if (icon != null) icon()
-            Text(text = label, style = MaterialTheme.typography.b5)
+            Text(text = label, style = MaterialTheme.typography.b6)
         }
     )
 }
 
+@Composable
+fun FilledRoundedCornerButton(
+    onClick: () -> Unit,
+    label: String,
+    icon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    textStyle: TextStyle = MaterialTheme.typography.b3,
+    size: Size? = null,
+    color: ButtonColors? = null
+) {
+    val buttonColors = color
+        ?: ButtonDefaults.buttonColors(
+            containerColor = PrimaryGreen_23C882,
+            contentColor = White_FFFFFF,
+            disabledContainerColor = Gray5_E8EAEE,
+            disabledContentColor = Gray4_C5CAD2
+        )
+
+    Button(
+        onClick = { onClick() },
+        colors = buttonColors,
+        enabled = enabled,
+        shape = RoundedCornerShape(8.dp),
+        modifier = if (size != null) Modifier.size(size.width.dp, size.height.dp) else Modifier,
+        content = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (icon != null) icon()
+                Text(
+                    text = label,
+                    textAlign = TextAlign.Center,
+                    style = textStyle,
+                    modifier = if (size != null) Modifier.fillMaxWidth() else Modifier
+                )
+            }
+        },
+        contentPadding = if (icon != null) PaddingValues(horizontal = 20.dp) else ButtonDefaults.ContentPadding
+    )
+}
+
+@Composable
+fun OutlinedButton(
+    onClick: () -> Unit,
+    label: String,
+    icon: @Composable (() -> Unit)? = null,
+    size: Size? = null
+) {
+    androidx.compose.material3.OutlinedButton(
+        onClick = { onClick() },
+        border = BorderStroke(1.dp, Gray5_E8EAEE),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = White_FFFFFF,
+            contentColor = Gray2_767B83
+        ),
+        modifier = if (size != null) Modifier.size(size.width.dp, size.height.dp) else Modifier,
+        content = {
+            if (icon != null) icon()
+            Text(text = label, style = MaterialTheme.typography.b6)
+        }
+    )
+}
+
+@Composable
+fun TextButton(
+    onClick: () -> Unit,
+    text: String = "",
+    textStyle: TextStyle = MaterialTheme.typography.b6.copy(color = PrimaryGreen_23C882),
+    underline: Boolean = false
+) {
+    Text(
+        modifier = Modifier.clickable { onClick() },
+        text = text,
+        style = textStyle,
+        textDecoration = if (underline) TextDecoration.Underline else null
+    )
+}
 
 @Preview
 @Composable
 fun PreviewFilledButton() {
     Column {
         // Filled Button
-        FilledButton({}, "text")
-        FilledButton({}, "text", enabled = false)
-        FilledButton({}, "text", icon = { Icon(Icons.Filled.Add, "Add") }, isTonal = true)
+        FilledButton(onClick = {}, label = "text")
+        FilledButton(onClick = {}, label = "text", enabled = false)
+        FilledButton(onClick = {}, label = "text", icon = { Icon(Icons.Filled.Add, "Add") }, isTonal = true)
+    }
+}
 
+@Preview
+@Composable
+fun PreviewFilledRoundedButton() {
+    Column {
         // Rounded Corner Shape Button
-        FilledButton({}, "label", isRoundedCorner = true)
-        FilledButton({}, "label", isRoundedCorner = true, enabled = false)
-        FilledButton({}, "label", isRoundedCorner = true, size = Size(150, 36))
+        FilledRoundedCornerButton(onClick = {}, label = "label")
+        FilledRoundedCornerButton(onClick = {}, label = "label", enabled = false)
+        FilledRoundedCornerButton(
+            onClick = {},
+            label = "Email",
+            size = Size(300, 44),
+            color = ButtonDefaults.buttonColors(containerColor = Gray1_313131, contentColor = White_FFFFFF),
+            icon = { Icon(Icons.Filled.Email, "Email") },
+            textStyle = MaterialTheme.typography.b5
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewOutlinedButton() {
+    Column {
+        // Outlined Button
+        OutlinedButton(onClick = {}, label = "text")
+        OutlinedButton(onClick = {}, label = "text", icon = { Icon(Icons.Filled.Add, "Add") })
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = Color.WHITE.toLong())
+@Composable
+fun PreviewTextButton() {
+    Column {
+        // Text Button
+        TextButton(onClick = {}, text = "text")
+        TextButton(onClick = {}, text = "text", underline = true)
+        TextButton(onClick = {}, text = "text", textStyle = MaterialTheme.typography.b6.copy(Gray2_767B83))
+        TextButton(onClick = {}, text = "text", textStyle = MaterialTheme.typography.b6.copy(Gray4_C5CAD2))
+
+        // Underline Text Button
+        Row {
+            Text(text = "DAYO의 ", style = MaterialTheme.typography.caption3.copy(Gray4_C5CAD2))
+            TextButton(onClick = {}, text = "이용약관", textStyle = MaterialTheme.typography.caption3.copy(Gray4_C5CAD2), underline = true)
+            Text(text = "입니다.", style = MaterialTheme.typography.caption3.copy(Gray4_C5CAD2))
+        }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
@@ -1,0 +1,79 @@
+package daily.dayo.presentation.view
+
+import android.util.Size
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import daily.dayo.presentation.theme.Gray4_C5CAD2
+import daily.dayo.presentation.theme.Gray5_E8EAEE
+import daily.dayo.presentation.theme.PrimaryGreen_23C882
+import daily.dayo.presentation.theme.PrimaryL3_F2FBF7
+import daily.dayo.presentation.theme.White_FFFFFF
+import daily.dayo.presentation.theme.b5
+
+@Composable
+fun FilledButton(
+    onClick: () -> Unit,
+    label: String,
+    icon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    isTonal: Boolean = false,
+    isRoundedCorner: Boolean = false,
+    size: Size? = null
+) {
+    val buttonColors = if (isTonal)
+        ButtonDefaults.buttonColors(
+            containerColor = PrimaryL3_F2FBF7,
+            contentColor = PrimaryGreen_23C882,
+            disabledContainerColor = Gray5_E8EAEE,
+            disabledContentColor = Gray4_C5CAD2
+
+        )
+    else
+        ButtonDefaults.buttonColors(
+            containerColor = PrimaryGreen_23C882,
+            contentColor = White_FFFFFF,
+            disabledContainerColor = Gray5_E8EAEE,
+            disabledContentColor = Gray4_C5CAD2
+        )
+
+    Button(
+        onClick = { onClick() },
+        colors = buttonColors,
+        enabled = enabled,
+        shape = if (isRoundedCorner) RoundedCornerShape(8.dp) else ButtonDefaults.shape,
+        modifier = if (size != null) Modifier.size(size.width.dp, size.height.dp) else Modifier,
+        content = {
+            if (icon != null) icon()
+            Text(text = label, style = MaterialTheme.typography.b5)
+        }
+    )
+}
+
+
+@Preview
+@Composable
+fun PreviewFilledButton() {
+    Column {
+        // Filled Button
+        FilledButton({}, "text")
+        FilledButton({}, "text", enabled = false)
+        FilledButton({}, "text", icon = { Icon(Icons.Filled.Add, "Add") }, isTonal = true)
+
+        // Rounded Corner Shape Button
+        FilledButton({}, "label", isRoundedCorner = true)
+        FilledButton({}, "label", isRoundedCorner = true, enabled = false)
+        FilledButton({}, "label", isRoundedCorner = true, size = Size(150, 36))
+    }
+}


### PR DESCRIPTION
## Outlined Button
```kotlin
@Composable
fun OutlinedButton(
    onClick: () -> Unit,
    label: String,
    icon: @Composable (() -> Unit)? = null,
    size: Size? = null
)
```
### 사용 예시
<img width="151" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/fbd372af-56b5-4157-ba36-148870f15d6e">

## Filled Button
```kotlin
@Composable
fun FilledButton(
    onClick: () -> Unit,
    label: String,
    icon: @Composable (() -> Unit)? = null,
    enabled: Boolean = true,
    isTonal: Boolean = false,
    size: Size? = null
) 
```
**참고 사항**
+ fully rounded corners 형태의 버튼입니다.
+ 아이콘은 텍스트 왼쪽에 표시됩니다.
+ isTonal 속성 

material3문서에서 연한 배경색의 버튼을 tonal button이라 하고 있습니다. ((처음 알게된 사실..)
<p> <img width="500" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/6d04c5be-b39b-47ff-9063-e84accabffc6"> </p>
문서 (https://m3.material.io/components/buttons/overview) </br>
 </br>
Figma에 있는 연한 색상의 배경 버튼을 지정하고 싶을 때는 isTonal로 설정하면됩니다.

### 사용 예시
<img width="150" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/e9639e1e-d692-46a1-93b4-ae514d237f75">

## FilledRoundedCornerButton
```kotlin
@Composable
fun FilledRoundedCornerButton(
    onClick: () -> Unit,
    label: String,
    icon: @Composable (() -> Unit)? = null,
    enabled: Boolean = true,
    textStyle: TextStyle = MaterialTheme.typography.b3,
    size: Size? = null,
    color: ButtonColors? = null
)
```
**참고 사항**
+ 모서리가 둥근 사각형 형태의 버튼입니다. 
+ FilledButton과 달리 아이콘이 왼쪽 정렬됩니다. 

### 사용 예시 
<img width="451" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/64d8a797-4c6b-4133-8308-7dc7b104b104">

## TextButton
```kotlin
@Composable
fun TextButton(
    onClick: () -> Unit,
    text: String = "",
    textStyle: TextStyle = MaterialTheme.typography.b6.copy(color = PrimaryGreen_23C882),
    underline: Boolean = false
)
```
**참고 사항**
+ underline 여부를 설정할 수 있습니다. 
### 사용 예시
<img width="185" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/f9e38d59-f1f5-4cc8-96ea-456671a1e470">

resolved : #535 