### PR TITLE
#536 [layout] Common Chip

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/Chip.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Chip.kt
@@ -1,0 +1,64 @@
+package daily.dayo.presentation.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.Gray5_E8EAEE
+import daily.dayo.presentation.theme.Gray6_F0F1F3
+import daily.dayo.presentation.theme.PrimaryGreen_23C882
+import daily.dayo.presentation.theme.White_FFFFFF
+import daily.dayo.presentation.theme.caption2
+
+@Composable
+fun Chip(
+    modifier: Modifier = Modifier,
+    onClickChip: (() -> Unit) = {},
+    text: String,
+    color: Color = PrimaryGreen_23C882,
+    enabled: Boolean = true
+) {
+    AssistChip(
+        onClick = onClickChip,
+        enabled = enabled,
+        label = {
+            Text(
+                text = text,
+                color = if (enabled) color else Gray5_E8EAEE,
+                style = MaterialTheme.typography.caption2
+            )
+        },
+        shape = RoundedCornerShape(100.dp),
+        border = AssistChipDefaults.assistChipBorder(
+            borderColor = color,
+            borderWidth = 1.dp,
+            disabledBorderColor = Gray6_F0F1F3
+        ),
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = White_FFFFFF,
+            disabledContainerColor = White_FFFFFF
+        ),
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+fun PreviewChip() {
+    MaterialTheme {
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Chip(text = "Text")
+            Chip(text = "Text", enabled = false)
+            Chip(text = "Text", color = Gray1_313131)
+        }
+    }
+}


### PR DESCRIPTION
## Chip
```kotlin
@Composable
fun Chip(
    modifier: Modifier = Modifier,
    onClickChip: (() -> Unit) = {},
    text: String,
    color: Color = PrimaryGreen_23C882,
    enabled: Boolean = true
)
```
**참고 사항**
+ color 설정 시 text와 border색상이 동일하게 적용됩니다.
+ disabled 상태에는 설정된 색상과 무관하게 글자와 border 모두 회색으로 표시됩니다. 

### 사용 예시
<img width="362" alt="image" src="https://github.com/Daily-DAYO/DAYO_Android/assets/30407907/bfad104f-ac55-4f94-a8cd-2fde932611b4">

resolved: #536 
