### PR TITLE
#548 [bug] bottomSheetDialog does not expand more than half of the screen

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/BottomSheetDialog.kt
@@ -189,8 +189,8 @@ fun BottomSheetDialog(
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun getBottomSheetDialogState(
-    disableFullExpanded: Boolean = true,
-    skipHalfExpanded: Boolean = false
+    disableFullExpanded: Boolean = false,
+    skipHalfExpanded: Boolean = true
 ): ModalBottomSheetState {
     val bottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,


### PR DESCRIPTION
## 내용
- BottomSheetDialog 크기가 실행 기기의 height의 절반이상 커지지 못하는 문제 해결

## 작업 사항
- 기존에 BottomSheetDialog State를 초기화하면서, disableFullExpanded값이 true, skipHalfExpanded값이 false로 설정되어 있어, 커지지 못하고 있던 부분에 대해 기본값 수정해 Bug Fix

## 참고
- #548 