### PR TITLE
#553 [layout] Feed Screen

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -61,6 +61,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import daily.dayo.presentation.R
 import daily.dayo.presentation.databinding.ActivityMainBinding
 import daily.dayo.presentation.fragment.home.HomeFragmentDirections
+import daily.dayo.presentation.screen.feed.FeedScreen
 import daily.dayo.presentation.screen.home.HomeScreen
 import daily.dayo.presentation.theme.Gray1_313131
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -187,7 +188,7 @@ class MainActivity : AppCompatActivity() {
                 HomeScreen(navController, coroutineScope, bottomSheetState, bottomSheetContent)
             }
             composable(Screen.Feed.route) {
-
+                FeedScreen(navController)
             }
             composable(Screen.Write.route) {
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -1,56 +1,112 @@
 package daily.dayo.presentation.screen.feed
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import daily.dayo.presentation.R
 import daily.dayo.presentation.screen.home.CategoryMenu
 import daily.dayo.presentation.theme.Gray1_313131
 import daily.dayo.presentation.theme.h1
 import daily.dayo.presentation.view.CategoryHorizontalGroup
+import daily.dayo.presentation.view.FeedPostView
 import daily.dayo.presentation.view.TopNavigation
+import daily.dayo.presentation.viewmodel.FeedViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun FeedScreen(navController: NavController) {
-    Scaffold(
-        topBar = {
-            TopNavigation(
-                leftIcon = {
-                    Text(
-                        text = stringResource(id = R.string.feed),
-                        modifier = Modifier.padding(start = 18.dp),
-                        style = MaterialTheme.typography.h1.copy(
-                            color = Gray1_313131
+fun FeedScreen(
+    navController: NavController,
+    feedViewModel: FeedViewModel = hiltViewModel()
+) {
+    val feedPostList = feedViewModel.feedList.asFlow().collectAsLazyPagingItems()
+    val refreshing by feedViewModel.isRefreshing.collectAsStateWithLifecycle()
+    val pullRefreshState = rememberPullRefreshState(refreshing, { feedViewModel.loadFeedPosts() })
+
+    LaunchedEffect(true) {
+        feedViewModel.loadFeedPosts()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pullRefresh(pullRefreshState)
+    ) {
+        Scaffold(
+            topBar = {
+                TopNavigation(
+                    leftIcon = {
+                        Text(
+                            text = stringResource(id = R.string.feed),
+                            modifier = Modifier.padding(start = 18.dp),
+                            style = MaterialTheme.typography.h1.copy(
+                                color = Gray1_313131
+                            )
                         )
-                    )
+                    }
+                )
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                // category
+                val categoryMenus = listOf(
+                    CategoryMenu.All,
+                    CategoryMenu.Scheduler,
+                    CategoryMenu.StudyPlanner,
+                    CategoryMenu.PocketBook,
+                    CategoryMenu.SixHoleDiary,
+                    CategoryMenu.Digital,
+                    CategoryMenu.ETC
+                )
+                val selectedCategory = remember { mutableStateOf(categoryMenus[0]) }
+                CategoryHorizontalGroup(categoryMenus, selectedCategory, modifier = Modifier.padding(top = 8.dp, bottom = 12.dp))
+
+                // feed post list
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(32.dp),
+                    contentPadding = PaddingValues(horizontal = 18.dp, vertical = 8.dp)
+                ) {
+                    items(
+                        count = feedPostList.itemCount,
+                        key = feedPostList.itemKey()
+                    ) { index ->
+                        val feedPost = feedPostList[index]
+                        feedPost?.let { post ->
+                            FeedPostView(post = post, onClickPost = { }, onClickLikePost = { }, onClickNickname = {})
+                        }
+                    }
                 }
-            )
+            }
         }
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier.padding(innerPadding)
-        ) {
-            // Category
-            val categoryMenus = listOf(
-                CategoryMenu.All,
-                CategoryMenu.Scheduler,
-                CategoryMenu.StudyPlanner,
-                CategoryMenu.PocketBook,
-                CategoryMenu.SixHoleDiary,
-                CategoryMenu.Digital,
-                CategoryMenu.ETC
-            )
-            val selectedCategory = remember { mutableStateOf(categoryMenus[0]) }
-            CategoryHorizontalGroup(categoryMenus, selectedCategory, modifier = Modifier.padding(top = 8.dp, bottom = 12.dp))
-        }
+
+        // refresh indicator
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -103,7 +103,7 @@ fun FeedScreen(
                 // feed post list
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(32.dp),
-                    contentPadding = PaddingValues(horizontal = 18.dp, vertical = 8.dp)
+                    contentPadding = PaddingValues(vertical = 8.dp)
                 ) {
                     items(
                         count = feedPostList.itemCount,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -1,10 +1,13 @@
 package daily.dayo.presentation.screen.feed
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.ExperimentalMaterialApi
@@ -21,20 +24,29 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import daily.dayo.presentation.R
+import daily.dayo.presentation.activity.MainActivity
 import daily.dayo.presentation.screen.home.CategoryMenu
 import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.Gray3_9FA5AE
+import daily.dayo.presentation.theme.Gray4_C5CAD2
+import daily.dayo.presentation.theme.b3
+import daily.dayo.presentation.theme.caption1
 import daily.dayo.presentation.theme.h1
 import daily.dayo.presentation.view.CategoryHorizontalGroup
 import daily.dayo.presentation.view.FeedPostView
+import daily.dayo.presentation.view.FilledButton
 import daily.dayo.presentation.view.TopNavigation
 import daily.dayo.presentation.viewmodel.FeedViewModel
 
@@ -103,10 +115,39 @@ fun FeedScreen(
                         }
                     }
                 }
+
+                // empty view
+                if (feedPostList.loadState.refresh is LoadState.NotLoading && feedPostList.itemCount == 0) {
+                    FeedEmptyView(navController)
+                }
             }
         }
 
         // refresh indicator
         PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
+    }
+}
+
+@Composable
+private fun FeedEmptyView(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(imageVector = ImageVector.vectorResource(id = R.drawable.ic_feed_empty), contentDescription = null)
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(text = stringResource(id = R.string.feed_empty_title), style = MaterialTheme.typography.b3.copy(Gray3_9FA5AE))
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(text = stringResource(id = R.string.feed_empty_description), style = MaterialTheme.typography.caption1.copy(Gray4_C5CAD2))
+
+        Spacer(modifier = Modifier.height(36.dp))
+        FilledButton(onClick = {
+            navController.navigate(MainActivity.Screen.Home.route) {
+                popUpTo(navController.graph.id)
+            }
+        }, label = stringResource(id = R.string.feed_empty_button))
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -1,0 +1,56 @@
+package daily.dayo.presentation.screen.feed
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import daily.dayo.presentation.R
+import daily.dayo.presentation.screen.home.CategoryMenu
+import daily.dayo.presentation.theme.Gray1_313131
+import daily.dayo.presentation.theme.h1
+import daily.dayo.presentation.view.CategoryHorizontalGroup
+import daily.dayo.presentation.view.TopNavigation
+
+@Composable
+fun FeedScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopNavigation(
+                leftIcon = {
+                    Text(
+                        text = stringResource(id = R.string.feed),
+                        modifier = Modifier.padding(start = 18.dp),
+                        style = MaterialTheme.typography.h1.copy(
+                            color = Gray1_313131
+                        )
+                    )
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            // Category
+            val categoryMenus = listOf(
+                CategoryMenu.All,
+                CategoryMenu.Scheduler,
+                CategoryMenu.StudyPlanner,
+                CategoryMenu.PocketBook,
+                CategoryMenu.SixHoleDiary,
+                CategoryMenu.Digital,
+                CategoryMenu.ETC
+            )
+            val selectedCategory = remember { mutableStateOf(categoryMenus[0]) }
+            CategoryHorizontalGroup(categoryMenus, selectedCategory, modifier = Modifier.padding(top = 8.dp, bottom = 12.dp))
+        }
+    }
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -111,7 +111,29 @@ fun FeedScreen(
                     ) { index ->
                         val feedPost = feedPostList[index]
                         feedPost?.let { post ->
-                            FeedPostView(post = post, onClickPost = { }, onClickLikePost = { }, onClickNickname = {})
+                            FeedPostView(
+                                post = post,
+                                onClickProfile = {
+                                    // todo move to profile
+                                },
+                                onClickPost = {
+                                    // todo move to post
+                                },
+                                onClickLikePost = {
+                                    if (!post.heart) {
+                                        feedViewModel.requestLikePost(postId = post.postId!!)
+                                    } else {
+                                        feedViewModel.requestUnlikePost(postId = post.postId!!)
+                                    }
+                                },
+                                onClickBookmark = {
+                                    if (!post.bookmark!!) {
+                                        feedViewModel.requestBookmarkPost(postId = post.postId!!)
+                                    } else {
+                                        feedViewModel.requestDeleteBookmarkPost(postId = post.postId!!)
+                                    }
+                                }
+                            )
                         }
                     }
                 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/CategoryHorizontalGroup.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/CategoryHorizontalGroup.kt
@@ -1,0 +1,104 @@
+package daily.dayo.presentation.view
+
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import daily.dayo.presentation.screen.home.CategoryMenu
+import daily.dayo.presentation.theme.Gray4_C5CAD2
+import daily.dayo.presentation.theme.Gray7_F6F6F7
+import daily.dayo.presentation.theme.PrimaryGreen_23C882
+import daily.dayo.presentation.theme.PrimaryL3_F2FBF7
+import daily.dayo.presentation.theme.b5
+
+@Composable
+fun CategoryHorizontalGroup(
+    categoryMenus: List<CategoryMenu>,
+    selectedCategory: MutableState<CategoryMenu>,
+    modifier: Modifier = Modifier
+) {
+    val selectedOption = selectedCategory.component1()
+    val onOptionSelected = selectedCategory.component2()
+
+    LazyRow(
+        modifier = modifier.selectableGroup(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 18.dp)
+    ) {
+        categoryMenus.forEach { category ->
+            item {
+                val interactionSource = remember { MutableInteractionSource() }
+                val isPressed by interactionSource.collectIsPressedAsState()
+                val buttonColors = if (category == selectedOption)
+                    ButtonDefaults.buttonColors(
+                        containerColor = PrimaryL3_F2FBF7,
+                        contentColor = PrimaryGreen_23C882
+
+                    )
+                else
+                    ButtonDefaults.buttonColors(
+                        containerColor = if (isPressed) Color(0xFFE4F7ED) else Gray7_F6F6F7,
+                        contentColor = if (isPressed) PrimaryGreen_23C882 else Gray4_C5CAD2
+                    )
+
+                Button(
+                    onClick = { onOptionSelected(category) },
+                    shape = RoundedCornerShape(12.dp),
+                    colors = buttonColors,
+                    interactionSource = interactionSource,
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .height(36.dp)
+                        .selectable(
+                            selected = (category == selectedOption),
+                            onClick = { onOptionSelected(category) },
+                            role = Role.RadioButton
+                        )
+                        .indication(interactionSource = interactionSource, indication = null),
+                    content = {
+                        Text(text = category.name, style = MaterialTheme.typography.b5)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryHorizontalGroup() {
+    val categoryMenus = listOf(
+        CategoryMenu.All,
+        CategoryMenu.Scheduler,
+        CategoryMenu.StudyPlanner,
+        CategoryMenu.PocketBook,
+        CategoryMenu.SixHoleDiary,
+        CategoryMenu.Digital,
+        CategoryMenu.ETC
+    )
+    val selectedCategory = remember { mutableStateOf(categoryMenus[0]) }
+    MaterialTheme {
+        CategoryHorizontalGroup(categoryMenus, selectedCategory)
+    }
+}

--- a/presentation/src/main/java/daily/dayo/presentation/view/CategoryHorizontalGroup.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/CategoryHorizontalGroup.kt
@@ -54,7 +54,6 @@ fun CategoryHorizontalGroup(
                     ButtonDefaults.buttonColors(
                         containerColor = PrimaryL3_F2FBF7,
                         contentColor = PrimaryGreen_23C882
-
                     )
                 else
                     ButtonDefaults.buttonColors(
@@ -65,6 +64,7 @@ fun CategoryHorizontalGroup(
                 Button(
                     onClick = { onOptionSelected(category) },
                     shape = RoundedCornerShape(12.dp),
+                    contentPadding = PaddingValues(horizontal = 12.dp),
                     colors = buttonColors,
                     interactionSource = interactionSource,
                     modifier = Modifier

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -63,6 +63,7 @@ import daily.dayo.presentation.common.extension.clickableSingle
 import daily.dayo.presentation.theme.Gray1_313131
 import daily.dayo.presentation.theme.Gray2_767B83
 import daily.dayo.presentation.theme.Gray3_9FA5AE
+import daily.dayo.presentation.theme.Gray4_C5CAD2
 import daily.dayo.presentation.theme.PrimaryGreen_23C882
 import daily.dayo.presentation.theme.White_Alpha30_FFFFFF
 import daily.dayo.presentation.theme.White_FFFFFF
@@ -238,13 +239,13 @@ fun FeedPostView(
             val dec = DecimalFormat("#,###")
             Row(modifier = Modifier.weight(1f)) {
                 Text(text = stringResource(id = R.string.post_like_count_message_1), style = MaterialTheme.typography.caption1.copy(Gray2_767B83))
-                Text(text = " ${dec.format(post.heartCount)} ", style = MaterialTheme.typography.caption1.copy(PrimaryGreen_23C882))
+                Text(text = " ${dec.format(post.heartCount)} ", style = MaterialTheme.typography.caption1, color = if (post.heartCount != 0) PrimaryGreen_23C882 else Gray4_C5CAD2)
                 Text(text = stringResource(id = R.string.post_like_count_message_2), style = MaterialTheme.typography.caption1.copy(Gray2_767B83))
             }
 
             // comment count
             Row {
-                Text(text = " ${dec.format(post.commentCount)} ", style = MaterialTheme.typography.caption1.copy(PrimaryGreen_23C882))
+                Text(text = " ${dec.format(post.commentCount)} ", style = MaterialTheme.typography.caption1, color = if (post.commentCount != 0) PrimaryGreen_23C882 else Gray4_C5CAD2)
                 Text(text = stringResource(id = R.string.post_comment_count_message), style = MaterialTheme.typography.caption1.copy(Gray2_767B83))
             }
         }

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -92,6 +92,7 @@ fun FeedPostView(
             modifier = Modifier
                 .wrapContentHeight()
                 .fillMaxWidth()
+                .padding(horizontal = 18.dp)
                 .clickableSingle(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() },
@@ -131,6 +132,7 @@ fun FeedPostView(
         Box(
             modifier = Modifier
                 .padding(top = 8.dp, bottom = 4.dp)
+                .padding(horizontal = 18.dp)
                 .fillMaxWidth()
                 .aspectRatio(1f)
         ) {
@@ -156,26 +158,28 @@ fun FeedPostView(
                 }
 
                 // indicator
-                Row(
-                    modifier = Modifier
-                        .wrapContentHeight()
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(
-                        space = 4.dp,
-                        alignment = Alignment.CenterHorizontally
-                    ),
-                ) {
-                    repeat(pagerState.pageCount) { iteration ->
-                        val color = if (pagerState.currentPage == iteration) White_FFFFFF else White_Alpha30_FFFFFF
-                        Box(
-                            modifier = Modifier
-                                .clip(CircleShape)
-                                .background(color)
-                                .width(if (pagerState.currentPage == iteration) 12.dp else 6.dp)
-                                .height(6.dp)
-                        )
+                if (postImages.size > 1) {
+                    Row(
+                        modifier = Modifier
+                            .wrapContentHeight()
+                            .fillMaxWidth()
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            space = 4.dp,
+                            alignment = Alignment.CenterHorizontally
+                        ),
+                    ) {
+                        repeat(pagerState.pageCount) { iteration ->
+                            val color = if (pagerState.currentPage == iteration) White_FFFFFF else White_Alpha30_FFFFFF
+                            Box(
+                                modifier = Modifier
+                                    .clip(CircleShape)
+                                    .background(color)
+                                    .width(if (pagerState.currentPage == iteration) 12.dp else 6.dp)
+                                    .height(6.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -185,7 +189,8 @@ fun FeedPostView(
         Row(
             modifier = Modifier
                 .wrapContentHeight()
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .padding(horizontal = 18.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             // like button
@@ -233,8 +238,9 @@ fun FeedPostView(
         // post info
         Row(
             modifier = Modifier
-                .padding(top = 4.dp)
                 .fillMaxWidth()
+                .padding(top = 4.dp)
+                .padding(horizontal = 18.dp)
                 .wrapContentHeight(),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -255,7 +261,14 @@ fun FeedPostView(
 
         // post content
         if (!post.contents.isNullOrEmpty()) {
-            SeeMoreText(text = post.contents!!, minimizedMaxLines = 2, modifier = Modifier.padding(top = 12.dp), onClickPost = onClickPost)
+            SeeMoreText(
+                text = post.contents!!,
+                minimizedMaxLines = 2,
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .padding(horizontal = 18.dp),
+                onClickPost = onClickPost
+            )
         }
 
         // hashtags
@@ -269,7 +282,7 @@ fun FeedPostView(
 fun HashtagHorizontalGroup(
     hashtags: List<String>
 ) {
-    LazyRow(contentPadding = PaddingValues(vertical = 4.dp)) {
+    LazyRow(contentPadding = PaddingValues(vertical = 4.dp, horizontal = 18.dp)) {
         hashtags.forEach { hashtag ->
             item {
                 Row(

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -19,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -39,6 +41,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -254,6 +257,47 @@ fun FeedPostView(
         if (!post.contents.isNullOrEmpty()) {
             SeeMoreText(text = post.contents!!, minimizedMaxLines = 2, modifier = Modifier.padding(top = 12.dp), onClickPost = onClickPost)
         }
+
+        // hashtags
+        if (!post.hashtags.isNullOrEmpty()) {
+            HashtagHorizontalGroup(hashtags = post.hashtags!!)
+        }
+    }
+}
+
+@Composable
+fun HashtagHorizontalGroup(
+    hashtags: List<String>
+) {
+    LazyRow(contentPadding = PaddingValues(vertical = 4.dp)) {
+        hashtags.forEach { hashtag ->
+            item {
+                Row(
+                    modifier = Modifier.padding(end = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(20.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFFE4F7ED))
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_hashtag),
+                            contentDescription = null,
+                            modifier = Modifier.align(Alignment.Center),
+                            tint = PrimaryGreen_23C882
+                        )
+                    }
+                    Text(
+                        text = hashtag,
+                        style = MaterialTheme.typography.caption1.copy(PrimaryGreen_23C882),
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -342,7 +386,7 @@ private fun PreviewFeedPostView() {
                 folderId = null,
                 folderName = null,
                 comments = null,
-                hashtags = null,
+                hashtags = listOf("태그", "다요다요"),
                 bookmark = null
             ),
             onClickPost = {},

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -81,9 +81,10 @@ import java.text.DecimalFormat
 fun FeedPostView(
     post: Post,
     modifier: Modifier = Modifier,
+    onClickProfile: () -> Unit,
     onClickPost: () -> Unit,
     onClickLikePost: () -> Unit,
-    onClickNickname: () -> Unit
+    onClickBookmark: () -> Unit
 ) {
     val imageInteractionSource = remember { MutableInteractionSource() }
     Column(modifier = modifier) {
@@ -92,12 +93,7 @@ fun FeedPostView(
             modifier = Modifier
                 .wrapContentHeight()
                 .fillMaxWidth()
-                .padding(horizontal = 18.dp)
-                .clickableSingle(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                    onClick = { onClickNickname() }
-                ),
+                .padding(horizontal = 18.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -110,10 +106,23 @@ fun FeedPostView(
                     .size(36.dp)
                     .clip(shape = CircleShape)
                     .align(Alignment.CenterVertically)
+                    .clickableSingle(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = onClickProfile
+                    )
             )
             Spacer(modifier = Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                Text(text = post.nickname, style = MaterialTheme.typography.b5.copy(Gray1_313131))
+                Text(
+                    text = post.nickname,
+                    style = MaterialTheme.typography.b5.copy(Gray1_313131),
+                    modifier = Modifier.clickableSingle(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = onClickProfile
+                    )
+                )
                 Text(
                     text = categoryKR(post.category ?: Category.ETC) + " ･ " +
                             post.createDateTime?.let { TimeChangerUtil.timeChange(context = LocalContext.current, time = it) },
@@ -152,7 +161,7 @@ fun FeedPostView(
                             .clickableSingle(
                                 interactionSource = imageInteractionSource,
                                 indication = null,
-                                onClick = { onClickPost() }
+                                onClick = onClickPost
                             )
                     )
                 }
@@ -202,7 +211,7 @@ fun FeedPostView(
                     .clickableSingle(
                         indication = rememberRipple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = { onClickLikePost() }
+                        onClick = onClickLikePost
                     ),
                 contentDescription = "like",
             )
@@ -215,7 +224,7 @@ fun FeedPostView(
                     .clickableSingle(
                         indication = rememberRipple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = { onClickLikePost() }
+                        onClick = onClickPost
                     ),
                 contentDescription = "comment",
             )
@@ -229,7 +238,7 @@ fun FeedPostView(
                     .clickableSingle(
                         indication = rememberRipple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = { onClickLikePost() }
+                        onClick = onClickBookmark
                     ),
                 contentDescription = "bookmark",
             )
@@ -372,7 +381,7 @@ fun SeeMoreText(
                         )
                     else Modifier
                 )
-                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClickPost)
+                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = { onClickPost() })
                 .alpha(if (seeMoreOffset != null) 1f else 0f)
         )
     }
@@ -404,7 +413,8 @@ private fun PreviewFeedPostView() {
             ),
             onClickPost = {},
             onClickLikePost = {},
-            onClickNickname = {}
+            onClickProfile = {},
+            onClickBookmark = {}
         )
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/viewmodel/FeedViewModel.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/viewmodel/FeedViewModel.kt
@@ -19,6 +19,9 @@ import daily.dayo.domain.usecase.like.RequestUnlikePostUseCase
 import daily.dayo.domain.usecase.post.RequestFeedListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,6 +34,9 @@ class FeedViewModel @Inject constructor(
     private val requestBookmarkPostUseCase: RequestBookmarkPostUseCase,
     private val requestDeleteBookmarkPostUseCase: RequestDeleteBookmarkPostUseCase
 ) : ViewModel() {
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean>
+        get() = _isRefreshing.asStateFlow()
 
     private val _feedList = MutableLiveData<PagingData<Post>>()
     val feedList: LiveData<PagingData<Post>> get() = _feedList
@@ -40,6 +46,14 @@ class FeedViewModel @Inject constructor(
 
     private val _postBookmarked = MutableLiveData<Resource<BookmarkPostResponse>>()
     val postBookmarked: LiveData<Resource<BookmarkPostResponse>> get() = _postBookmarked
+
+    fun loadFeedPosts() {
+        viewModelScope.launch {
+            _isRefreshing.emit(true)
+            requestFeedList()
+            _isRefreshing.emit(false)
+        }
+    }
 
     fun requestFeedList() = viewModelScope.launch(Dispatchers.IO) {
         requestFeedListUseCase()

--- a/presentation/src/main/res/drawable/ic_bookmark_checked.xml
+++ b/presentation/src/main/res/drawable/ic_bookmark_checked.xml
@@ -1,12 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="19dp"
-    android:height="25dp"
-    android:viewportWidth="19"
-    android:viewportHeight="25">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
-      android:pathData="M2,1C1.4477,1 1,1.4477 1,2V23C1,23.3887 1.2253,23.7422 1.5776,23.9064C1.93,24.0706 2.3455,24.0157 2.6432,23.7657L9.5,18.006L16.3568,23.7657C16.6545,24.0157 17.07,24.0706 17.4224,23.9064C17.7747,23.7422 18,23.3887 18,23V2C18,1.4477 17.5523,1 17,1H2Z"
+      android:fillColor="#FF313131"
+      android:strokeColor="#FF313131"
+      android:strokeWidth="1.5"
       android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="@color/gray_1_313131"
-      android:strokeColor="@color/gray_1_313131"/>
+      android:pathData="M4.5 4.53c0-0.96 0.77-1.73 1.73-1.73h11.54c0.96 0 1.73 0.77 1.73 1.73v14.7c0 1.23-1.24 2.07-2.38 1.6l-4.47-1.8c-0.42-0.17-0.88-0.17-1.3 0l-4.47 1.8c-1.14 0.47-2.38-0.37-2.38-1.6V4.54Z"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_bookmark_default.xml
+++ b/presentation/src/main/res/drawable/ic_bookmark_default.xml
@@ -1,12 +1,11 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="19dp"
-    android:height="25dp"
-    android:viewportWidth="19"
-    android:viewportHeight="25">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
-      android:pathData="M2,1C1.4477,1 1,1.4477 1,2V23C1,23.3887 1.2253,23.7422 1.5776,23.9064C1.93,24.0706 2.3455,24.0157 2.6432,23.7657L9.5,18.006L16.3568,23.7657C16.6545,24.0157 17.07,24.0706 17.4224,23.9064C17.7747,23.7422 18,23.3887 18,23V2C18,1.4477 17.5523,1 17,1H2Z"
+      android:strokeColor="#FF313131"
+      android:strokeWidth="1.5"
       android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#313131"/>
+      android:pathData="M4.5 4.53c0-0.96 0.77-1.73 1.73-1.73h11.54c0.96 0 1.73 0.77 1.73 1.73v14.7c0 1.23-1.24 2.07-2.38 1.6l-4.47-1.8c-0.42-0.17-0.88-0.17-1.3 0l-4.47 1.8c-1.14 0.47-2.38-0.37-2.38-1.6V4.54Z"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_comment.xml
+++ b/presentation/src/main/res/drawable/ic_comment.xml
@@ -1,11 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="40dp"
-    android:height="40dp"
-    android:viewportWidth="40"
-    android:viewportHeight="40">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
         android:strokeColor="#FF313131"
-        android:strokeWidth="2"
+        android:strokeWidth="1.5"
         android:strokeLineJoin="round"
-        android:pathData="M18.9 29.47c0.16 0.32 0.5 0.53 0.88 0.53 0.37 0 0.7-0.2 0.88-0.53l1.78-3.37h1.37c3.84 0 6.74-3.51 6.74-7.55S27.65 11 23.81 11h-8.07C11.9 11 9 14.5 9 18.55c0 4.04 2.9 7.55 6.74 7.55h1.37l1.78 3.37Z"/>
+        android:strokeMiterLimit="10"
+        android:pathData="M19.16 3H4.86C3.27 3 2 4.24 2 5.78v9.08c0 1.52 1.27 2.77 2.84 2.77H9c0.15 0 0.3 0.07 0.39 0.19l1.98 2.5c0.27 0.36 0.8 0.37 1.08 0.03l2.18-2.55c0.1-0.11 0.23-0.18 0.38-0.18h4.16c1.57 0 2.84-1.24 2.84-2.76V5.78c0-1.53-1.27-2.77-2.84-2.77V3Z"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_hashtag.xml
+++ b/presentation/src/main/res/drawable/ic_hashtag.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="10dp"
+    android:viewportWidth="12"
+    android:viewportHeight="10">
+    <path
+        android:pathData="M5.11 0.94L2.66 9.05m6.67-8.11l-2.45 8.1M2.56 2.92L11 3.1M1 6.88L9.44 7.1"
+        android:strokeWidth="1.25"
+        android:strokeColor="#FF23C882"
+        android:strokeLineCap="round"
+        android:strokeMiterLimit="10" />
+</vector>

--- a/presentation/src/main/res/drawable/ic_heart_filled.xml
+++ b/presentation/src/main/res/drawable/ic_heart_filled.xml
@@ -1,13 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
-    android:height="22dp"
+    android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="22">
+    android:viewportHeight="24">
     <path
         android:fillColor="#FFF34D7A"
         android:strokeColor="#FFF34D7A"
-        android:strokeWidth="1"
+        android:strokeWidth="1.5"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M6.5 1C3.46 1 1 3.49 1 6.55c0 2.48 0.96 8.35 10.44 14.29C11.6 20.94 11.8 21 12 21c0.2 0 0.4-0.06 0.56-0.16C22.04 14.9 23 9.03 23 6.55 23 3.5 20.54 1 17.5 1S12 4.36 12 4.36 9.54 1 6.5 1Z"/>
+        android:pathData="M7 3C4.24 3 2 5.24 2 8c0 2.22 0.88 7.51 9.49 12.86C11.64 20.95 11.82 21 12 21s0.36-0.05 0.51-0.14C21.13 15.5 22 10.22 22 8c0-2.76-2.24-5-5-5s-5 3.03-5 3.03S9.76 3 7 3Z"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_heart_outlined.xml
+++ b/presentation/src/main/res/drawable/ic_heart_outlined.xml
@@ -1,12 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
-    android:height="23dp"
+    android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="23">
+    android:viewportHeight="24">
     <path
         android:strokeColor="#FF313131"
-        android:strokeWidth="2"
+        android:strokeWidth="1.5"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M10.94 21.68h0C11.26 21.89 11.62 22 12 22s0.74-0.11 1.06-0.31h0c4.42-2.9 6.92-5.82 8.3-8.39C22.77 10.74 23 8.58 23 7.27 23 3.86 20.36 1 17 1c-1.75 0-3.23 1-4.2 1.85-0.3 0.27-0.57 0.54-0.8 0.78-0.23-0.24-0.5-0.51-0.8-0.78C10.23 2 8.75 1 7 1 3.64 1 1 3.86 1 7.27c0 1.31 0.25 3.47 1.63 6.03 1.4 2.57 3.89 5.49 8.31 8.38Z"/>
+        android:pathData="M7 3C4.24 3 2 5.24 2 8c0 2.22 0.88 7.51 9.49 12.86C11.64 20.95 11.82 21 12 21s0.36-0.05 0.51-0.14C21.13 15.5 22 10.22 22 8c0-2.76-2.24-5-5-5s-5 3.03-5 3.03S9.76 3 7 3Z"/>
 </vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="post_like_count_message_1">이 글을</string>
     <string name="post_like_count_message_2">명이 좋아해요</string>
     <string name="post_comment_count_message">개의 댓글</string>
+    <string name="post_contents_more">더보기</string>
     <string name="post_comment_empty">아직 작성된 댓글이 없습니다.</string>
     <string name="post_comment_delete_alert_message">댓글을 삭제할까요?</string>
     <string name="post_comment_delete_alert_message_success">댓글이 삭제되었습니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
 
     <!-- Feed -->
     <string name="feed_empty_title">아직 피드에 게시물이 없어요.</string>
-    <string name="feed_empty_description">사람들을 팔로우하면\n이곳에서 게시물을 모아볼 수 있어요.</string>
+    <string name="feed_empty_description">팔로우하고 내 취향의 다꾸들을 모아보세요</string>
     <string name="feed_empty_button">팔로우하러 가기</string>
 
     <!-- Write -->

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -140,6 +140,9 @@
     <string name="post_option_report_user">사용자 신고</string>
     <string name="post_option_report_post">게시물 신고</string>
     <string name="post_option_hide">이 게시물 숨기기</string>
+    <string name="post_like_count_message_1">이 글을</string>
+    <string name="post_like_count_message_2">명이 좋아해요</string>
+    <string name="post_comment_count_message">개의 댓글</string>
     <string name="post_comment_empty">아직 작성된 댓글이 없습니다.</string>
     <string name="post_comment_delete_alert_message">댓글을 삭제할까요?</string>
     <string name="post_comment_delete_alert_message_success">댓글이 삭제되었습니다.</string>


### PR DESCRIPTION
## 작업 내용
### Feed Screen
+ 피드 상단 카테고리 가로 스크롤 구현
+ 표시할 게시글이 없을 때 표시 할 Empty View 구현
  + 팔로우하러 가기 버튼을 누르면 홈으로 이동
+ 이미지가 여러개일 시 스크롤 할 수 있도록 Pager 구현
+ 좋아요, 북마크 기능 
+ 좋아요, 댓글 개수가 0일 때와 아닐 때 색상 구분
+ 게시글 텍스트가 2줄 이상이면 더보기버튼이 나타나도록 함
+ 태그를 # 아이콘과 함께 나타내며, 가로로 스크롤 할 수 있도록 구현 

## 기타
+ 카테고리 별로 다른 리스트로 보여주는 기능은 API 추가 후 구현 예정
+ 옵션 버튼 클릭 기능은 디자인이 나온 후 구현 예정 

resolved : #546 