### PR TITLE
[refactoring] Separate App with build type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,13 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
+            resValue "string", "app_name", "DAYO (Debug)"
+        }
         release {
+            resValue "string", "app_name", "DAYO"
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
             android:resource="@drawable/ic_dayo_logo" />
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.daily.dayo.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
## 구현 사항
- Debug와 Release에 대해 BuildType의 구분을 활용해 Build Varient를 변경할때, 별도의 앱으로 설치될 수 있도록 설정

## 주의사항
- Debug의 경우 패키지명이 suffix로 뒤에 추가됨에 따라, 새로운 `google-services.json`로 교체 필요