### PR TITLE
[layout] Fix Setting User Information

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCompleteFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordCompleteFragment.kt
@@ -33,7 +33,7 @@ class FindAccountPasswordCompleteFragment : Fragment() {
     private fun setNextClickListener() {
         binding.btnFindAccountPasswordCompleteNext.setOnDebounceClickListener {
             findNavController().navigateSafe(
-                currentDestinationId = R.id.FindAccountPasswordCheckEmailFragment,
+                currentDestinationId = R.id.FindAccountPasswordCompleteFragment,
                 action = R.id.action_findAccountPasswordCompleteFragment_to_loginEmailFragment
             )
         }

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/account/findAccount/FindAccountPasswordNewPasswordFragment.kt
@@ -208,7 +208,7 @@ class FindAccountPasswordNewPasswordFragment : Fragment() {
         binding.btnFindAccountPasswordNewPasswordNext.setOnDebounceClickListener {
             Navigation.findNavController(it).navigateSafe(
                 currentDestinationId = R.id.FindAccountPasswordNewPasswordFragment,
-                action = R.id.action_findAccountPasswordNewPasswordConfirmationFragment_to_findAccountPasswordCompleteFragment,
+                action = R.id.action_findAccountPasswordNewPasswordFragment_to_findAccountPasswordNewPasswordConfirmationFragment,
                 args = FindAccountPasswordNewPasswordFragmentDirections.actionFindAccountPasswordNewPasswordFragmentToFindAccountPasswordNewPasswordConfirmationFragment(
                     args.email,
                     trimBlankText(binding.etFindAccountPasswordNewPasswordUserPassword.text)

--- a/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/fragment/mypage/profile/ProfileEditFragment.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
@@ -64,6 +65,7 @@ class ProfileEditFragment : Fragment() {
     ): View? {
         binding = FragmentProfileEditBinding.inflate(inflater, container, false)
         glideRequestManager = Glide.with(this)
+        setKeyboardMode()
         initializeLoadingDialog()
         return binding.root
     }
@@ -86,6 +88,10 @@ class ProfileEditFragment : Fragment() {
 
     private fun onDestroyBindingView() {
         glideRequestManager = null
+    }
+
+    private fun setKeyboardMode() {
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
     }
 
     private fun setHideKeyboard() {

--- a/presentation/src/main/java/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -70,7 +70,7 @@ class AccountViewModel @Inject constructor(
     private val _checkEmailSuccess = MutableLiveData<Boolean>()
     val checkEmailSuccess get() = _checkEmailSuccess
 
-    private val _checkCurrentPasswordSuccess = MutableLiveData<Boolean>()
+    private val _checkCurrentPasswordSuccess = MutableLiveData<Event<Boolean>>()
     val checkCurrentPasswordSuccess get() = _checkCurrentPasswordSuccess
 
     private val _changePasswordSuccess = MutableLiveData<Boolean>()
@@ -338,15 +338,15 @@ class AccountViewModel @Inject constructor(
         requestCheckCurrentPasswordUseCase(password = inputPassword).let { ApiResponse ->
             when (ApiResponse) {
                 is NetworkResponse.Success -> {
-                    _checkCurrentPasswordSuccess.postValue(true)
+                    _checkCurrentPasswordSuccess.postValue(Event(true))
                 }
                 is NetworkResponse.NetworkError -> {
                     _isErrorExceptionOccurred.postValue(Event(true))
-                    _checkCurrentPasswordSuccess.postValue(false)
+                    _checkCurrentPasswordSuccess.postValue(Event(false))
                 }
                 is NetworkResponse.ApiError -> {
                     _isApiErrorExceptionOccurred.postValue(Event(true))
-                    _checkCurrentPasswordSuccess.postValue(false)
+                    _checkCurrentPasswordSuccess.postValue(Event(false))
                 }
                 else -> {}
             }

--- a/presentation/src/main/res/layout/fragment_find_account_password_check_email.xml
+++ b/presentation/src/main/res/layout/fragment_find_account_password_check_email.xml
@@ -12,9 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="?actionBarSize"
         android:elevation="24dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_height="43dp">
 
         <ImageButton
             android:id="@+id/btn_find_account_password_check_email_back"
@@ -29,96 +28,111 @@
             tools:ignore="ContentDescription" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_find_account_password_check_email_contents"
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="18dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toTopOf="@id/layout_find_account_password_check_email_next"
         app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_check_email_action_bar">
 
-        <TextView
-            android:id="@+id/tv_find_account_password_check_email_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="44dp"
-            android:text="@string/find_account_password_title"
-            android:textColor="@color/gray_1_313131"
-            android:textSize="22dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_find_account_password_check_email_description"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/find_account_password_check_email_description"
-            android:textColor="@color/gray_1_313131"
-            android:textSize="14dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_check_email_title" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_find_account_password_check_email_user_input"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_find_account_password_check_email_contents"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="61dp"
-            android:hint="@string/email_address_example"
-            android:textColorHint="@color/gray_4_C5CAD2"
-            app:boxBackgroundColor="@android:color/transparent"
-
-            app:boxBackgroundMode="outline"
-            app:boxStrokeColor="@color/gray_5_E8EAEE"
-            app:boxStrokeWidthFocused="1dp"
-            app:endIconMode="custom"
-            app:endIconTint="@android:color/transparent"
-
-            app:endIconTintMode="src_over"
-            app:errorIconDrawable="@drawable/ic_check_x_sign"
-            app:errorIconTint="@android:color/transparent"
-
-            app:errorIconTintMode="src_over"
-            app:errorTextColor="@color/red_FF4545"
-            app:hintAnimationEnabled="false"
-            app:hintEnabled="true"
-
-            app:hintTextColor="@color/gray_3_9FA5AE"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_check_email_title">
+            app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_check_email_action_bar">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_find_account_password_check_email_user_input"
-                style="@style/WriteEditTextStyle"
+            <TextView
+                android:id="@+id/tv_find_account_password_check_email_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="44dp"
+                android:text="@string/find_account_password_title"
+                android:textColor="@color/gray_1_313131"
+                android:textSize="22dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_find_account_password_check_email_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/find_account_password_check_email_description"
+                android:textColor="@color/gray_3_9FA5AE"
+                android:textSize="14dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_check_email_title" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/layout_find_account_password_check_email_user_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/edittext_background_remove_padding"
-                android:imeOptions="actionDone"
-                android:inputType="textEmailAddress"
-                android:paddingStart="0dp"
-                android:paddingTop="14dp"
-                android:singleLine="true"
-                android:textColor="@color/gray_1_313131"
-                android:textSize="17dp" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_marginTop="61dp"
+                android:hint="@string/email_address_example"
+                android:textColorHint="@color/gray_4_C5CAD2"
+                app:boxBackgroundColor="@android:color/transparent"
+
+                app:boxBackgroundMode="outline"
+                app:boxStrokeColor="@color/gray_5_E8EAEE"
+                app:boxStrokeWidthFocused="1dp"
+                app:endIconMode="custom"
+                app:endIconTint="@android:color/transparent"
+
+                app:endIconTintMode="src_over"
+                app:errorIconDrawable="@drawable/ic_check_x_sign"
+                app:errorIconTint="@android:color/transparent"
+
+                app:errorIconTintMode="src_over"
+                app:errorTextColor="@color/red_FF4545"
+                app:hintAnimationEnabled="false"
+                app:hintEnabled="true"
+
+                app:hintTextColor="@color/gray_3_9FA5AE"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_check_email_description">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_find_account_password_check_email_user_input"
+                    style="@style/WriteEditTextStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/edittext_background_remove_padding"
+                    android:imeOptions="actionDone"
+                    android:inputType="textEmailAddress"
+                    android:paddingStart="0dp"
+                    android:paddingTop="14dp"
+                    android:singleLine="true"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="17dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/layout_find_account_password_check_email_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/white_FFFFFF"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_find_account_password_check_email_next"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
+            android:layout_margin="18dp"
             android:background="@drawable/button_default_signup_next_button_inactive"
             android:enabled="false"
+            android:stateListAnimator="@null"
             android:text="@string/get_certificate_code"
+            android:textAlignment="center"
             android:textColor="@color/white_FFFFFF"
             android:textSize="16dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:textStyle="bold" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_find_account_password_check_email_certificate.xml
+++ b/presentation/src/main/res/layout/fragment_find_account_password_check_email_certificate.xml
@@ -2,191 +2,214 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
     </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white_FFFFFF"
         tools:context=".presentation.fragment.account.findAccount.FindAccountPasswordCheckEmailCertificateFragment">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_login_email_find_password_certificate_action_bar"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
             android:elevation="24dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            tools:layout_height="43dp">
+
             <ImageButton
                 android:id="@+id/btn_login_email_find_password_certificate_back"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
                 android:src="@drawable/ic_back_sign"
-                tools:ignore="ContentDescription"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                android:paddingHorizontal="18dp"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_login_email_find_password_certificate_contents"
-            android:layout_width="0dp"
+        <ScrollView
+            android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/layout_login_email_find_password_certificate_action_bar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp">
-            <TextView
-                android:id="@+id/tv_login_email_find_password_certificate_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/find_account_password_title"
-                android:textSize="22dp"
-                android:textColor="@color/gray_1_313131"
-                android:includeFontPadding="false"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="51dp"/>
-
-            <TextView
-                android:id="@+id/tv_login_email_find_password_certificate_description"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/email_address_certificate_description"
-                android:textSize="14dp"
-                android:textColor="@color/gray_1_313131"
-                android:includeFontPadding="false"
-                app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_title"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="12dp"/>
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_login_email_find_password_certificate_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_login_email_find_password_certificate_action_bar">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_login_email_find_password_certificate_user_input_contents"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-
-                app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_title"
-                app:layout_constraintStart_toStartOf="parent"
+                android:id="@+id/layout_login_email_find_password_certificate_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="13dp"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="61dp">
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layout_login_email_find_password_certificate_user_input"
-                    android:layout_width="match_parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_login_email_find_password_certificate_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_login_email_find_password_certificate_title"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:boxBackgroundMode="outline"
-                    android:hint="@string/email_address_certificate_title"
-                    app:hintEnabled="true"
-                    app:hintTextColor="@color/gray_3_9FA5AE"
-                    android:textColorHint="@color/gray_4_C5CAD2"
-                    app:hintAnimationEnabled="false"
-
-                    app:endIconMode="custom"
-                    app:endIconTint="@android:color/transparent"
-                    app:endIconTintMode="src_over"
-
-                    app:errorTextColor="@color/red_FF4545"
-                    app:errorIconDrawable="@drawable/ic_check_x_sign"
-                    app:errorIconTint="@android:color/transparent"
-                    app:errorIconTintMode="src_over"
-
-                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_marginTop="44dp"
+                    android:includeFontPadding="false"
+                    android:text="@string/find_account_password_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" >
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/et_login_email_find_password_certificate_user_input"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_login_email_find_password_certificate_description"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:includeFontPadding="false"
+                    android:text="@string/email_address_certificate_description"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="14dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_title" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_login_email_find_password_certificate_user_input_contents"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+
+                    android:layout_marginTop="61dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_description">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_login_email_find_password_certificate_user_input"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        style="@style/WriteEditTextStyle"
-                        android:background="@drawable/edittext_background_remove_padding"
-                        android:textSize="17dp"
-                        android:inputType="number"
+                        android:hint="@string/email_address_certificate_title"
+                        android:textColorHint="@color/gray_4_C5CAD2"
+                        app:boxBackgroundMode="outline"
+                        app:endIconMode="custom"
+                        app:endIconTint="@android:color/transparent"
+                        app:endIconTintMode="src_over"
+
+                        app:errorIconDrawable="@drawable/ic_check_x_sign"
+                        app:errorIconTint="@android:color/transparent"
+                        app:errorIconTintMode="src_over"
+
+                        app:errorTextColor="@color/red_FF4545"
+                        app:hintAnimationEnabled="false"
+                        app:hintEnabled="true"
+                        app:hintTextColor="@color/gray_3_9FA5AE"
+
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/et_login_email_find_password_certificate_user_input"
+                            style="@style/WriteEditTextStyle"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/edittext_background_remove_padding"
+                            android:imeOptions="actionDone"
+                            android:inputType="number"
+                            android:paddingStart="0dp"
+                            android:paddingTop="14dp"
+                            android:singleLine="true"
+                            android:textColor="@color/gray_1_313131"
+                            android:textSize="17dp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <TextView
+                        android:id="@+id/tv_login_email_find_password_certificate_timer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="18dp"
+                        android:layout_marginEnd="4dp"
                         android:textColor="@color/gray_1_313131"
-                        android:singleLine="true"
-                        android:imeOptions="actionDone"
-                        android:paddingTop="14dp"
-                        android:paddingStart="0dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-                <TextView
-                    android:id="@+id/tv_login_email_find_password_certificate_timer"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="12dp"
-                    android:textColor="@color/gray_1_313131"
-                    app:layout_constraintTop_toTopOf="@id/layout_login_email_find_password_certificate_user_input"
-                    app:layout_constraintEnd_toEndOf="@id/layout_login_email_find_password_certificate_user_input"
-                    android:layout_marginTop="18dp"
-                    android:layout_marginEnd="4dp"
-                    tools:text="03:00" />
-                <TextView
-                    android:id="@+id/tv_login_email_find_password_certificate_resend"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/email_address_certificate_resend"
-                    android:textSize="12dp"
-                    android:textColor="@color/gray_2_767B83"
-                    app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_timer"
-                    app:layout_constraintEnd_toEndOf="@id/layout_login_email_find_password_certificate_user_input"
-                    android:paddingVertical="9dp"
-                    android:paddingHorizontal="3dp"
-                    android:layout_marginTop="14dp"/>
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                        android:textSize="12dp"
+                        app:layout_constraintEnd_toEndOf="@id/layout_login_email_find_password_certificate_user_input"
+                        app:layout_constraintTop_toTopOf="@id/layout_login_email_find_password_certificate_user_input"
+                        tools:text="03:00" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_login_email_find_password_certificate_confirmation_user_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:boxBackgroundMode="outline"
+                    <TextView
+                        android:id="@+id/tv_login_email_find_password_certificate_resend"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="14dp"
+                        android:paddingHorizontal="3dp"
+                        android:paddingVertical="9dp"
+                        android:text="@string/email_address_certificate_resend"
+                        android:textColor="@color/gray_2_767B83"
+                        android:textSize="12dp"
+                        app:layout_constraintEnd_toEndOf="@id/layout_login_email_find_password_certificate_user_input"
+                        app:layout_constraintTop_toBottomOf="@id/tv_login_email_find_password_certificate_timer" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-                android:hint="@string/email"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-                android:textColorHint="@color/gray_3_9FA5AE"
-                app:hintAnimationEnabled="false"
-
-                app:endIconMode="custom"
-                app:endIconTint="@android:color/transparent"
-                app:endIconTintMode="src_over"
-
-                app:layout_constraintTop_toBottomOf="@id/layout_login_email_find_password_certificate_user_input_contents"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="13dp">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_login_email_find_password_certificate_confirmation_user_input"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_login_email_find_password_certificate_confirmation_user_input"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/WriteEditTextStyle"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:enabled="false"
-                    android:inputType="textEmailAddress"
-                    android:text="@{email}"
-                    android:textSize="17dp"
-                    android:textColor="@color/gray_1_313131"
-                    android:paddingTop="14dp"
-                    android:paddingStart="0dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginTop="13dp"
+
+                    android:hint="@string/email"
+                    android:textColorHint="@color/gray_3_9FA5AE"
+                    app:boxBackgroundMode="outline"
+                    app:endIconMode="custom"
+                    app:endIconTint="@android:color/transparent"
+
+                    app:endIconTintMode="src_over"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+                    app:layout_constraintTop_toBottomOf="@id/layout_login_email_find_password_certificate_user_input_contents">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_login_email_find_password_certificate_confirmation_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:enabled="false"
+                        android:inputType="textEmailAddress"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:text="@{email}"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_login_email_find_password_certificate_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_login_email_find_password_certificate_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
-                android:enabled="false"
-                android:text="@string/email_address_certificate"
-                android:textSize="16dp"
-                android:textStyle="bold"
-                android:textColor="@color/white_FFFFFF"
+                android:layout_margin="18dp"
                 android:background="@drawable/button_default_signup_next_button_inactive"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/email_address_certificate"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_find_account_password_complete.xml
+++ b/presentation/src/main/res/layout/fragment_find_account_password_complete.xml
@@ -13,10 +13,11 @@
         android:layout_height="?actionBarSize"
         android:elevation="24dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintVertical_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:layout_height="43dp">
+
         <ImageButton
             android:id="@+id/btn_find_account_password_complete_back"
             android:layout_width="wrap_content"
@@ -97,10 +98,6 @@
             android:textStyle="bold"
             android:textColor="@color/white_FFFFFF"
             android:background="@drawable/button_default_signup_next_button_active"
-            app:layout_constraintTop_toBottomOf="@id/guideline_find_account_password_complete_message_image_bottom"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintVertical_bias="1.0"/>
+            app:layout_constraintBottom_toBottomOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_find_account_password_new_password.xml
+++ b/presentation/src/main/res/layout/fragment_find_account_password_new_password.xml
@@ -2,11 +2,14 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
     </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -18,102 +21,112 @@
             android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
             android:elevation="24dp"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_height="43dp">
+
             <ImageButton
                 android:id="@+id/btn_find_account_password_new_password_back"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
                 android:src="@drawable/ic_back_sign"
-                tools:ignore="ContentDescription"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                android:paddingHorizontal="18dp"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_find_account_password_new_password_contents"
+        <ScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_action_bar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp">
-            <TextView
-                android:id="@+id/tv_find_account_password_new_password_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/find_account_password_new_password_title"
-                android:textSize="22dp"
-                android:textColor="@color/gray_1_313131"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                app:layout_constraintHorizontal_bias="0.0"
-                android:layout_marginTop="44dp"/>
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_find_account_password_new_password_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_action_bar">
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_find_account_password_new_password_user_password"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_find_account_password_new_password_contents"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:boxBackgroundMode="outline"
-
-                app:passwordToggleEnabled="true"
-                android:hint="@string/signup_email_set_password_message_length_fail_min"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:hintAnimationEnabled="false"
-
-                app:errorTextColor="@color/red_FF4545"
-                app:counterEnabled="false"
-                app:counterMaxLength="16"
-                app:counterTextColor="@color/red_FF4545"
-
-                app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_new_password_title"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                android:layout_marginTop="53dp" >
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_find_account_password_new_password_user_password"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_find_account_password_new_password_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="44dp"
+                    android:text="@string/find_account_password_new_password_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_find_account_password_new_password_user_password"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/WriteEditTextStyle"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:textSize="17dp"
-                    android:textColor="@color/gray_1_313131"
-                    android:inputType="textPassword"
-                    android:singleLine="true"
-                    android:imeOptions="actionDone"
-                    android:paddingTop="14dp"
-                    android:paddingStart="0dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginTop="53dp"
+
+                    android:hint="@string/signup_email_set_password_message_length_fail_min"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:counterEnabled="false"
+                    app:counterMaxLength="16"
+                    app:counterTextColor="@color/red_FF4545"
+
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_new_password_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_find_account_password_new_password_user_password"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_find_account_password_new_password_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_find_account_password_new_password_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_inactive"
                 android:enabled="false"
+                android:stateListAnimator="@null"
                 android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
                 android:textSize="16dp"
                 android:textStyle="bold"
-                android:textColor="@color/white_FFFFFF"
-                android:background="@drawable/button_default_signup_next_button_inactive"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="1.0"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                app:layout_constraintVertical_bias="1.0" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_find_account_password_new_password_confirmation.xml
+++ b/presentation/src/main/res/layout/fragment_find_account_password_new_password_confirmation.xml
@@ -2,10 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
+
         <variable
             name="password"
             type="String" />
@@ -16,141 +19,144 @@
         android:layout_height="match_parent"
         android:background="@color/white_FFFFFF"
         tools:context=".presentation.fragment.account.findAccount.FindAccountPasswordNewPasswordConfirmationFragment">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_find_account_password_new_password_confirmation_action_bar"
             android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
             android:elevation="24dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintVertical_bias="0.0">
+            tools:layout_height="43dp">
+
             <ImageButton
                 android:id="@+id/btn_find_account_password_new_password_confirmation_back"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
                 android:src="@drawable/ic_back_sign"
-                tools:ignore="ContentDescription"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
-                android:paddingHorizontal="18dp" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_find_account_password_new_password_confirmation_contents"
+        <ScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_confirmation_action_bar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp">
-            <TextView
-                android:id="@+id/tv_find_account_password_new_password_confirmation_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/find_account_password_new_password_title"
-                android:textSize="22dp"
-                android:textColor="@color/gray_1_313131"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                app:layout_constraintHorizontal_bias="0.0"
-                android:layout_marginTop="44dp" />
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_find_account_password_new_password_confirmation_user_input"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_find_account_password_new_password_confirmation_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_confirmation_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_find_account_password_new_password_confirmation_contents"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:boxBackgroundMode="outline"
-
-                app:passwordToggleEnabled="true"
-                android:hint="@string/signup_email_set_password_confirmation_edittext_hint"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:hintAnimationEnabled="false"
-
-                app:errorTextColor="@color/red_FF4545"
-
-                app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_new_password_confirmation_title"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                android:layout_marginTop="53dp" >
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_find_account_password_new_password_confirmation_user_input"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tv_find_account_password_new_password_confirmation_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="44dp"
+                    android:text="@string/find_account_password_new_password_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_find_account_password_new_password_confirmation_user_input"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/WriteEditTextStyle"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:textSize="17dp"
-                    android:textColor="@color/gray_1_313131"
-                    android:inputType="textPassword"
-                    android:singleLine="true"
-                    android:imeOptions="actionDone"
-                    android:paddingTop="14dp"
-                    android:paddingStart="0dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginTop="53dp"
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_find_account_password_new_password_confirmation_user_password"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:boxBackgroundMode="outline"
+                    android:hint="@string/signup_email_set_password_confirmation_edittext_hint"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
 
-                app:passwordToggleEnabled="true"
-                android:hint="@string/password"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:hintAnimationEnabled="false"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+                    app:layout_constraintTop_toBottomOf="@id/tv_find_account_password_new_password_confirmation_title"
+                    app:passwordToggleEnabled="true">
 
-                app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_confirmation_user_input"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                android:layout_marginTop="44dp" >
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_find_account_password_new_password_confirmation_user_password"
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_find_account_password_new_password_confirmation_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_find_account_password_new_password_confirmation_user_password"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/WriteEditTextStyle"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:enabled="false"
-                    android:inputType="textPassword"
-                    android:text="@{password}"
-                    android:textSize="17dp"
-                    android:textColor="@color/gray_1_313131"
-                    android:paddingTop="14dp"
-                    android:paddingStart="0dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginTop="44dp"
+
+                    android:hint="@string/password"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_find_account_password_new_password_confirmation_user_input"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_find_account_password_new_password_confirmation_user_password"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:enabled="false"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:text="@{password}"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_find_account_password_new_password_confirmation_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_find_account_password_new_password_confirmation_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
-                android:enabled="false"
-                android:text="@string/next"
-                android:textSize="16dp"
-                android:textStyle="bold"
-                android:textColor="@color/white_FFFFFF"
+                android:layout_margin="18dp"
                 android:background="@drawable/button_default_signup_next_button_inactive"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintVertical_bias="1.0"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_login_email.xml
+++ b/presentation/src/main/res/layout/fragment_login_email.xml
@@ -14,7 +14,8 @@
         android:elevation="24dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_height="43dp">
 
         <ImageButton
             android:id="@+id/btn_login_email_back"
@@ -28,191 +29,201 @@
             tools:ignore="ContentDescription" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_login_email_contents"
-        android:layout_width="0dp"
+    <ScrollView
+        android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginHorizontal="18dp"
-        android:layout_marginBottom="18dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toTopOf="@id/layout_btn_login_email_next"
         app:layout_constraintTop_toBottomOf="@id/layout_login_email_action_bar">
 
-        <TextView
-            android:id="@+id/tv_login_email_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="2dp"
-            android:layout_marginTop="44dp"
-            android:includeFontPadding="false"
-            android:text="@string/login"
-            android:textColor="@color/gray_1_313131"
-            android:textSize="22dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_login_email_address_contents"
+            android:id="@+id/layout_login_email_contents"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="2dp"
-            android:layout_marginTop="62dp"
+            android:layout_marginHorizontal="18dp"
+            android:layout_marginBottom="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_login_email_title">
+            app:layout_constraintTop_toBottomOf="@id/layout_login_email_action_bar">
 
             <TextView
-                android:id="@+id/tv_login_email_address_title"
-                android:layout_width="match_parent"
+                android:id="@+id/tv_login_email_title"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="2dp"
+                android:layout_marginTop="32dp"
                 android:includeFontPadding="false"
-                android:text="@string/email"
-                android:textColor="@color/gray_3_9FA5AE"
-                android:textSize="12dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0"
+                android:text="@string/login"
+                android:textColor="@color/gray_1_313131"
+                android:textSize="22dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_login_email_address"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_login_email_address_contents"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/hint_login_email_address"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:boxBackgroundMode="outline"
-                app:endIconMode="custom"
-                app:endIconTint="@android:color/transparent"
-
-                app:endIconTintMode="src_over"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="true"
-
+                android:layout_marginHorizontal="2dp"
+                android:layout_marginTop="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_login_email_address_title">
+                app:layout_constraintTop_toBottomOf="@id/tv_login_email_title">
 
-                <EditText
-                    android:id="@+id/et_login_email_address"
-                    style="@style/WriteEditTextStyle"
+                <TextView
+                    android:id="@+id/tv_login_email_address_title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:inputType="textEmailAddress"
-                    android:paddingVertical="0dp"
-                    android:paddingStart="0dp"
-                    android:singleLine="true"
-                    android:textColor="@color/gray_1_313131"
-                    android:textColorHint="@color/gray_4_C5CAD2"
-                    android:textSize="17dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:includeFontPadding="false"
+                    android:text="@string/email"
+                    android:textColor="@color/gray_3_9FA5AE"
+                    android:textSize="12dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_login_email_password_contents"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="2dp"
-            android:layout_marginTop="44dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_login_email_address_contents">
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_login_email_address"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_login_email_address"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:endIconMode="custom"
+                    app:endIconTint="@android:color/transparent"
+
+                    app:endIconTintMode="src_over"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_login_email_address_title">
+
+                    <EditText
+                        android:id="@+id/et_login_email_address"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:inputType="textEmailAddress"
+                        android:paddingVertical="0dp"
+                        android:paddingStart="0dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textColorHint="@color/gray_4_C5CAD2"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_login_email_password_contents"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="2dp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_login_email_address_contents">
+
+                <TextView
+                    android:id="@+id/tv_login_email_password_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:text="@string/password"
+                    android:textColor="@color/gray_3_9FA5AE"
+                    android:textSize="12dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_login_email_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_login_email_password"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_login_email_password_title"
+                    app:passwordToggleEnabled="true">
+
+                    <EditText
+                        android:id="@+id/et_login_email_password"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:inputType="textPassword"
+                        android:paddingVertical="0dp"
+                        android:paddingStart="0dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textColorHint="@color/gray_4_C5CAD2"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
-                android:id="@+id/tv_login_email_password_title"
-                android:layout_width="0dp"
+                android:id="@+id/tv_login_email_forgot_password"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="start"
-                android:text="@string/password"
+                android:layout_marginTop="5dp"
+                android:lineHeight="12.36dp"
+                android:paddingHorizontal="3dp"
+                android:paddingVertical="11dp"
+                android:text="@string/login_email_forget"
                 android:textColor="@color/gray_3_9FA5AE"
+                android:textFontWeight="400"
                 android:textSize="12dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toBottomOf="@id/layout_login_email_password_contents" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_login_email_password"
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/tv_login_email_signup"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:hint="@string/hint_login_email_password"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:boxBackgroundMode="outline"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="true"
+                android:layout_marginTop="168dp"
+                android:lineHeight="12.36dp"
+                android:text="@string/login_email_signup"
+                android:textColor="@color/gray_4_C5CAD2"
+                android:textFontWeight="400"
+                android:textSize="12dp"
+                app:layout_constraintTop_toBottomOf="@id/tv_login_email_forgot_password"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-
+                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_login_email_password_title"
-                app:passwordToggleEnabled="true">
-
-                <EditText
-                    android:id="@+id/et_login_email_password"
-                    style="@style/WriteEditTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:inputType="textPassword"
-                    android:paddingVertical="0dp"
-                    android:paddingStart="0dp"
-                    android:singleLine="true"
-                    android:textColor="@color/gray_1_313131"
-                    android:textColorHint="@color/gray_4_C5CAD2"
-                    android:textSize="17dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintVertical_bias="1.0" />
         </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 
-        <TextView
-            android:id="@+id/tv_login_email_forgot_password"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:lineHeight="12.36dp"
-            android:paddingHorizontal="3dp"
-            android:paddingVertical="11dp"
-            android:text="@string/login_email_forget"
-            android:textColor="@color/gray_3_9FA5AE"
-            android:textFontWeight="400"
-            android:textSize="12dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_login_email_password_contents"
-            app:layout_constraintVertical_bias="0.0" />
+    <LinearLayout
+        android:id="@+id/layout_btn_login_email_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/white_FFFFFF"
+        app:layout_constraintBottom_toBottomOf="parent">
 
-        <TextView
-            android:id="@+id/tv_login_email_signup"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="38dp"
-            android:lineHeight="12.36dp"
-            android:text="@string/login_email_signup"
-            android:textColor="@color/gray_4_C5CAD2"
-            android:textFontWeight="400"
-            android:textSize="12dp"
-            app:layout_constraintBottom_toTopOf="@id/btn_login_email_next"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_login_email_password_contents"
-            app:layout_constraintVertical_bias="1.0" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_login_email_next"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
-            android:background="@drawable/button_default_signup_next_button_inactive"
-            android:enabled="false"
-            android:text="@string/login"
-            android:textColor="@color/white_FFFFFF"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_login_email_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/button_default_signup_next_button_inactive"
+        android:enabled="false"
+        android:stateListAnimator="@null"
+        android:text="@string/login"
+        android:textColor="@color/white_FFFFFF"
+        android:textSize="16dp"
+        android:layout_margin="18dp"
+        android:textAlignment="center"
+        android:textStyle="bold"
+        app:layout_constraintVertical_bias="1.0" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_profile_edit.xml
+++ b/presentation/src/main/res/layout/fragment_profile_edit.xml
@@ -4,123 +4,148 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="daily.dayo.presentation.fragment.mypage.profile.ProfileEditFragment"
-    android:background="@color/white_FFFFFF">
+    android:background="@color/white_FFFFFF"
+    tools:context="daily.dayo.presentation.fragment.mypage.profile.ProfileEditFragment">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_profile_edit_action_bar"
         android:layout_width="0dp"
         android:layout_height="?actionBarSize"
         android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_height="43dp">
+
         <ImageButton
             android:id="@+id/btn_profile_edit_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="18dp"
+            android:layout_marginBottom="15dp"
             android:background="@android:color/transparent"
             android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginBottom="15dp"
-            android:layout_marginStart="18dp"/>
+            tools:ignore="ContentDescription" />
+
         <TextView
             android:id="@+id/tv_profile_edit_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/my_profile_edit_title"
+            android:textColor="@color/black_000000"
             android:textSize="15dp"
             android:textStyle="bold"
-            android:textColor="@color/black_000000"
-            app:layout_constraintTop_toTopOf="@id/btn_profile_edit_back"
             app:layout_constraintBottom_toBottomOf="@id/btn_profile_edit_back"
             app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"/>
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_profile_edit_back" />
+
         <TextView
             android:id="@+id/btn_profile_edit_complete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/complete"
-            android:textSize="14dp"
-            android:textColor="@color/gray_4_C5CAD2"
+            android:layout_marginEnd="16dp"
             android:background="@android:color/transparent"
-            app:layout_constraintTop_toTopOf="@id/btn_profile_edit_back"
+            android:text="@string/complete"
+            android:textColor="@color/gray_4_C5CAD2"
+            android:textSize="14dp"
             app:layout_constraintBottom_toBottomOf="@id/btn_profile_edit_back"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginEnd="16dp" />
+            app:layout_constraintTop_toTopOf="@id/btn_profile_edit_back" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_profile_edit_user_img"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/layout_profile_edit_action_bar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="80dp">
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/img_profile_edit_user_image"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
-            android:src="@drawable/ic_user_profile_image_empty"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
-        <ImageView
-            android:id="@+id/img_profile_edit_camera_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/ic_camera_button"
-            app:layout_constraintBottom_toBottomOf="@id/img_profile_edit_user_image"
-            app:layout_constraintEnd_toEndOf="@id/img_profile_edit_user_image" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_profile_edit_user_nickname"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/layout_profile_edit_user_img"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="80dp"
-        android:layout_marginHorizontal="25dp">
-        <EditText
-            android:id="@+id/et_profile_edit_nickname"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:hint="@string/my_profile_edit_nickname_edittext_hint"
-            android:textSize="16dp"
-            android:textColor="@color/gray_1_313131"
-            android:textColorHint="@color/gray_4_C5CAD2"
-            android:maxLength="10"
-            android:singleLine="true"
-            android:theme="@style/EditTextStyle"
-            android:gravity="center"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
-        <TextView
-            android:id="@+id/tv_profile_edit_nickname_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="12dp"
-            android:textColor="@color/gray_4_C5CAD2"
-            app:layout_constraintTop_toBottomOf="@id/et_profile_edit_nickname"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginEnd="5dp"
-            tools:text="0 / 10"/>
-        <TextView
-            android:id="@+id/tv_profile_edit_nickname_message"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="12dp"
-            android:textColor="#FF4545"
-            android:visibility="invisible"
-            app:layout_constraintTop_toBottomOf="@id/et_profile_edit_nickname"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:text="닉네임에는 한글, 영문, 숫자만 사용할 수 있어요."/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="0dp"
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_profile_edit_action_bar">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_profile_edit_user_contents"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="18dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_profile_edit_user_img"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="80dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/img_profile_edit_user_image"
+                    android:layout_width="100dp"
+                    android:layout_height="100dp"
+                    android:src="@drawable/ic_user_profile_image_empty"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:shapeAppearanceOverlay="@style/roundedImageViewRounded" />
+
+                <ImageView
+                    android:id="@+id/img_profile_edit_camera_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_camera_button"
+                    app:layout_constraintBottom_toBottomOf="@id/img_profile_edit_user_image"
+                    app:layout_constraintEnd_toEndOf="@id/img_profile_edit_user_image" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_profile_edit_user_nickname"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="25dp"
+                android:layout_marginTop="72dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_profile_edit_user_img">
+
+                <EditText
+                    android:id="@+id/et_profile_edit_nickname"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:hint="@string/my_profile_edit_nickname_edittext_hint"
+                    android:maxLength="10"
+                    android:singleLine="true"
+                    android:textColor="@color/gray_1_313131"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    android:textSize="16dp"
+                    android:theme="@style/EditTextStyle"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_profile_edit_nickname_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="5dp"
+                    android:textColor="@color/gray_4_C5CAD2"
+                    android:textSize="12dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/et_profile_edit_nickname"
+                    tools:text="0 / 10" />
+
+                <TextView
+                    android:id="@+id/tv_profile_edit_nickname_message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="#FF4545"
+                    android:textSize="12dp"
+                    android:visibility="invisible"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/et_profile_edit_nickname"
+                    tools:text="닉네임에는 한글, 영문, 숫자만 사용할 수 있어요." />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_setting_change_password_current.xml
+++ b/presentation/src/main/res/layout/fragment_setting_change_password_current.xml
@@ -7,18 +7,14 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/white_FFFFFF" >
+        android:background="@color/white_FFFFFF">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_setting_change_password_current_action_bar"
             android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0">
+            tools:layout_height="43dp">
 
             <ImageButton
                 android:id="@+id/btn_setting_change_password_current_back"
@@ -34,93 +30,110 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintVertical_bias="0.5"
                 tools:ignore="ContentDescription" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_setting_change_password_current_contents"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_current_action_bar">
 
             <TextView
-                android:id="@+id/tv_setting_change_password_current_title"
+                android:id="@+id/tv_setting_change_password_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="44dp"
-                android:lineHeight="35dp"
-                android:text="@string/setting_change_password_current_title"
+                android:text="@string/change_password"
                 android:textColor="@color/gray_1_313131"
-                android:textFontWeight="400"
-                android:textSize="22dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_setting_change_password_current_user_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="53dp"
-
-                android:hint="@string/signup_email_set_password_message_length_fail_min"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:boxBackgroundMode="outline"
-                app:counterEnabled="false"
-                app:counterMaxLength="16"
-                app:counterTextColor="@color/red_FF4545"
-
-                app:errorTextColor="@color/red_FF4545"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_setting_change_password_current_title"
-                app:layout_constraintVertical_bias="0.0"
-                app:passwordToggleEnabled="true">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_setting_change_password_current_user_input"
-                    style="@style/WriteEditTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:imeOptions="actionDone"
-                    android:inputType="textPassword"
-                    android:paddingStart="0dp"
-                    android:paddingTop="14dp"
-                    android:singleLine="true"
-                    android:textColor="@color/gray_1_313131"
-                    android:textSize="17dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_setting_change_password_current_next"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
-                android:background="@drawable/button_default_signup_next_button_inactive"
-                android:enabled="false"
-                android:text="@string/confirm"
-                android:textColor="@color/white_FFFFFF"
                 android:textSize="16dp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="1.0" />
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_setting_change_password_current_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_current_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_setting_change_password_current_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_current_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_setting_change_password_current_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="44dp"
+                    android:lineHeight="35dp"
+                    android:text="@string/setting_change_password_current_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textFontWeight="400"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_setting_change_password_current_user_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="53dp"
+
+                    android:hint="@string/signup_email_set_password_message_length_fail_min"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:counterEnabled="false"
+                    app:counterMaxLength="16"
+                    app:counterTextColor="@color/red_FF4545"
+
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_setting_change_password_current_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_setting_change_password_current_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_setting_change_password_current_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_setting_change_password_current_next"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_active"
+                android:stateListAnimator="@null"
+                android:text="@string/confirm"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_setting_change_password_new.xml
+++ b/presentation/src/main/res/layout/fragment_setting_change_password_new.xml
@@ -15,12 +15,8 @@
             android:id="@+id/layout_setting_change_password_new_action_bar"
             android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0">
+            tools:layout_height="43dp">
 
             <ImageButton
                 android:id="@+id/btn_setting_change_password_new_back"
@@ -30,143 +26,158 @@
                 android:paddingHorizontal="18dp"
                 android:src="@drawable/ic_back_sign"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.5"
                 tools:ignore="ContentDescription" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_setting_change_password_new_contents"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp"
-            android:animateLayoutChanges="true"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_new_action_bar">
 
             <TextView
-                android:id="@+id/tv_setting_change_password_new_title"
+                android:id="@+id/tv_setting_change_password_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="44dp"
-                android:lineHeight="35dp"
-                android:text="@string/setting_change_password_new_title"
+                android:text="@string/change_password"
                 android:textColor="@color/gray_1_313131"
-                android:textFontWeight="400"
-                android:textSize="22dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_setting_change_password_new_confirmation"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="53dp"
-                android:hint="@string/password"
-
-                android:textColorHint="@color/gray_4_C5CAD2"
-                android:visibility="gone"
-                app:boxBackgroundMode="outline"
-                app:counterEnabled="false"
-                app:counterMaxLength="16"
-                app:counterTextColor="@color/red_FF4545"
-
-                app:errorTextColor="@color/red_FF4545"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_setting_change_password_new_title"
-                app:layout_constraintVertical_bias="0.0"
-                app:passwordToggleEnabled="true">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_setting_change_password_new_confirmation"
-                    style="@style/WriteEditTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:imeOptions="actionDone"
-                    android:inputType="textPassword"
-                    android:paddingStart="0dp"
-                    android:paddingTop="14dp"
-                    android:singleLine="true"
-                    android:textColor="@color/gray_1_313131"
-                    android:textSize="17dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_setting_change_password_new_user_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="53dp"
-
-                android:hint="@string/signup_email_set_password_message_length_fail_min"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                app:boxBackgroundMode="outline"
-                app:counterEnabled="false"
-                app:counterMaxLength="16"
-                app:counterTextColor="@color/red_FF4545"
-
-                app:errorTextColor="@color/red_FF4545"
-                app:hintAnimationEnabled="false"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_new_confirmation"
-                app:layout_constraintVertical_bias="0.0"
-                app:passwordToggleEnabled="true">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_setting_change_password_new_user_input"
-                    style="@style/WriteEditTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:imeOptions="actionDone"
-                    android:inputType="textPassword"
-                    android:paddingStart="0dp"
-                    android:paddingTop="14dp"
-                    android:singleLine="true"
-                    android:textColor="@color/gray_1_313131"
-                    android:textSize="17dp" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_setting_change_password_new_next"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
-                android:background="@drawable/button_default_signup_next_button_inactive"
-                android:enabled="false"
-                android:text="@string/next"
-                android:textColor="@color/white_FFFFFF"
                 android:textSize="16dp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="1.0" />
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_setting_change_password_new_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_new_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_setting_change_password_new_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                android:animateLayoutChanges="true"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_new_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_setting_change_password_new_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="44dp"
+                    android:lineHeight="35dp"
+                    android:text="@string/setting_change_password_new_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textFontWeight="400"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_setting_change_password_new_confirmation"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="53dp"
+                    android:hint="@string/password"
+
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    android:visibility="gone"
+                    app:boxBackgroundMode="outline"
+                    app:counterEnabled="false"
+                    app:counterMaxLength="16"
+                    app:counterTextColor="@color/red_FF4545"
+
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_setting_change_password_new_title"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_setting_change_password_new_confirmation"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_setting_change_password_new_user_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="53dp"
+
+                    android:hint="@string/signup_email_set_password_message_length_fail_min"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:counterEnabled="false"
+                    app:counterMaxLength="16"
+                    app:counterTextColor="@color/red_FF4545"
+
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_setting_change_password_new_confirmation"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_setting_change_password_new_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_setting_change_password_new_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_setting_change_password_new_next"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_inactive"
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_signup_email_set_email_address.xml
+++ b/presentation/src/main/res/layout/fragment_signup_email_set_email_address.xml
@@ -6,104 +6,122 @@
     android:layout_height="match_parent"
     android:background="@color/white_FFFFFF"
     tools:context="daily.dayo.presentation.fragment.account.signup.SignupEmailSetEmailAddressFragment">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_signup_email_set_email_address_action_bar"
         android:layout_width="match_parent"
         android:layout_height="?actionBarSize"
         android:elevation="24dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        tools:layout_height="43dp">
+
         <ImageButton
             android:id="@+id/btn_signup_email_set_email_address_back"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:background="@android:color/transparent"
+            android:paddingHorizontal="18dp"
             android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:paddingHorizontal="18dp"/>
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-    
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_email_address_contents"
+
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_action_bar"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="18dp">
-        <TextView
-            android:id="@+id/tv_signup_email_set_email_address_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/signup_email_set_email_address_title"
-            android:textSize="22dp"
-            android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="44dp"/>
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toTopOf="@id/layout_signup_email_set_email_address_next"
+        app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_action_bar">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_signup_email_set_email_address_user_input"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_signup_email_set_email_address_contents"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:boxBackgroundMode="outline"
-            app:boxBackgroundColor="@android:color/transparent"
-            app:boxStrokeColor="@color/gray_5_E8EAEE"
-            app:boxStrokeWidthFocused="1dp"
-
-            android:hint="@string/email_address_example"
-            app:hintEnabled="true"
-            app:hintTextColor="@color/gray_3_9FA5AE"
-            app:hintAnimationEnabled="false"
-            android:textColorHint="@color/gray_4_C5CAD2"
-
-            app:endIconMode="custom"
-            app:endIconTint="@android:color/transparent"
-            app:endIconTintMode="src_over"
-
-            app:errorTextColor="@color/red_FF4545"
-            app:errorIconDrawable="@drawable/ic_check_x_sign"
-            app:errorIconTint="@android:color/transparent"
-            app:errorIconTintMode="src_over"
-
-            app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_title"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="61dp" >
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_signup_email_set_email_address_user_input"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_signup_email_set_email_address_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:text="@string/signup_email_set_email_address_title"
+                android:textColor="@color/gray_1_313131"
+                android:textSize="22dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/layout_signup_email_set_email_address_user_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                style="@style/WriteEditTextStyle"
-                android:background="@drawable/edittext_background_remove_padding"
-                android:textSize="17dp"
-                android:textColor="@color/gray_1_313131"
-                android:singleLine="true"
-                android:inputType="textEmailAddress"
-                android:imeOptions="actionDone"
-                android:paddingTop="14dp"
-                android:paddingStart="0dp" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_marginTop="24dp"
+                android:hint="@string/email_address_example"
+                android:textColorHint="@color/gray_4_C5CAD2"
+                app:boxBackgroundColor="@android:color/transparent"
+
+                app:boxBackgroundMode="outline"
+                app:boxStrokeColor="@color/gray_5_E8EAEE"
+                app:boxStrokeWidthFocused="1dp"
+                app:endIconMode="custom"
+                app:endIconTint="@android:color/transparent"
+
+                app:endIconTintMode="src_over"
+                app:errorIconDrawable="@drawable/ic_check_x_sign"
+                app:errorIconTint="@android:color/transparent"
+
+                app:errorIconTintMode="src_over"
+                app:errorTextColor="@color/red_FF4545"
+                app:hintAnimationEnabled="false"
+                app:hintEnabled="true"
+
+                app:hintTextColor="@color/gray_3_9FA5AE"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_title">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_signup_email_set_email_address_user_input"
+                    style="@style/WriteEditTextStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/edittext_background_remove_padding"
+                    android:imeOptions="actionDone"
+                    android:inputType="textEmailAddress"
+                    android:paddingStart="0dp"
+                    android:paddingTop="14dp"
+                    android:singleLine="true"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="17dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/layout_signup_email_set_email_address_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/white_FFFFFF"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_signup_email_set_email_address_next"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
-            android:enabled="false"
-            android:text="@string/get_certificate_code"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/white_FFFFFF"
+            android:layout_margin="18dp"
             android:background="@drawable/button_default_signup_next_button_inactive"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:enabled="false"
+            android:stateListAnimator="@null"
+            android:text="@string/get_certificate_code"
+            android:textAlignment="center"
+            android:textColor="@color/white_FFFFFF"
+            android:textSize="16dp"
+            android:textStyle="bold" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_signup_email_set_email_address_certificate.xml
+++ b/presentation/src/main/res/layout/fragment_signup_email_set_email_address_certificate.xml
@@ -2,7 +2,9 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
@@ -13,181 +15,202 @@
         android:layout_height="match_parent"
         android:background="@color/white_FFFFFF"
         tools:context=".presentation.fragment.account.signup.SignupEmailSetEmailAddressCertificateFragment">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_signup_email_set_email_address_certificate_action_bar"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="?actionBarSize"
             android:elevation="24dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            tools:layout_height="43dp">
+
             <ImageButton
                 android:id="@+id/btn_signup_email_set_email_address_certificate_back"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
                 android:src="@drawable/ic_back_sign"
-                tools:ignore="ContentDescription"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                android:paddingHorizontal="18dp"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_signup_email_set_email_address_certificate_contents"
-            android:layout_width="0dp"
+        <ScrollView
+            android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_certificate_action_bar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginBottom="18dp">
-            <TextView
-                android:id="@+id/tv_signup_email_set_email_address_certificate_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/signup_email_set_email_address_title"
-                android:textSize="22dp"
-                android:textColor="@color/gray_1_313131"
-                android:includeFontPadding="false"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="51dp"/>
-
-            <TextView
-                android:id="@+id/tv_signup_email_set_email_address_certificate_description"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/email_address_certificate_description"
-                android:textSize="14dp"
-                android:textColor="@color/gray_1_313131"
-                android:includeFontPadding="false"
-                app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_title"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="12dp"/>
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_signup_email_set_email_address_certificate_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_certificate_action_bar">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_signup_email_set_email_address_certificate_user_input_contents"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-
-                app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_title"
-                app:layout_constraintStart_toStartOf="parent"
+                android:id="@+id/layout_signup_email_set_email_address_certificate_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="61dp">
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layout_signup_email_set_email_address_certificate_user_input"
-                    android:layout_width="match_parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tv_signup_email_set_email_address_certificate_title"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:boxBackgroundMode="outline"
-                    android:hint="@string/email_address_certificate_title"
-                    app:hintEnabled="true"
-                    app:hintTextColor="@color/gray_3_9FA5AE"
-                    android:textColorHint="@color/gray_4_C5CAD2"
-                    app:hintAnimationEnabled="false"
-
-                    app:endIconMode="custom"
-                    app:endIconTint="@android:color/transparent"
-                    app:endIconTintMode="src_over"
-
-                    app:errorTextColor="@color/red_FF4545"
-                    app:errorIconDrawable="@drawable/ic_check_x_sign"
-                    app:errorIconTint="@android:color/transparent"
-                    app:errorIconTintMode="src_over"
-
-                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_marginTop="32dp"
+                    android:includeFontPadding="false"
+                    android:text="@string/signup_email_set_email_address_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" >
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/et_signup_email_set_email_address_certificate_user_input"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_signup_email_set_email_address_certificate_description"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:includeFontPadding="false"
+                    android:text="@string/email_address_certificate_description"
+                    android:textColor="@color/gray_3_9FA5AE"
+                    android:textSize="14dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_title" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_signup_email_set_email_address_certificate_user_input_contents"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="25dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_description">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_signup_email_set_email_address_certificate_user_input"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        style="@style/WriteEditTextStyle"
-                        android:background="@drawable/edittext_background_remove_padding"
-                        android:inputType="number"
-                        android:textSize="17dp"
+                        android:hint="@string/email_address_certificate_title"
+                        android:textColorHint="@color/gray_4_C5CAD2"
+                        app:boxBackgroundMode="outline"
+                        app:endIconMode="custom"
+                        app:endIconTint="@android:color/transparent"
+                        app:endIconTintMode="src_over"
+
+                        app:errorIconDrawable="@drawable/ic_check_x_sign"
+                        app:errorIconTint="@android:color/transparent"
+                        app:errorIconTintMode="src_over"
+
+                        app:errorTextColor="@color/red_FF4545"
+                        app:hintAnimationEnabled="false"
+                        app:hintEnabled="true"
+                        app:hintTextColor="@color/gray_3_9FA5AE"
+
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/et_signup_email_set_email_address_certificate_user_input"
+                            style="@style/WriteEditTextStyle"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/edittext_background_remove_padding"
+                            android:imeOptions="actionDone"
+                            android:inputType="number"
+                            android:paddingStart="0dp"
+                            android:paddingTop="14dp"
+                            android:singleLine="true"
+                            android:textColor="@color/gray_1_313131"
+                            android:textSize="17dp" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <TextView
+                        android:id="@+id/tv_signup_email_set_email_address_certificate_timer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="18dp"
+                        android:layout_marginEnd="4dp"
                         android:textColor="@color/gray_1_313131"
-                        android:singleLine="true"
-                        android:imeOptions="actionDone"
-                        android:paddingTop="14dp"
-                        android:paddingStart="0dp" />
-                </com.google.android.material.textfield.TextInputLayout>
-                <TextView
-                    android:id="@+id/tv_signup_email_set_email_address_certificate_timer"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="12dp"
-                    android:textColor="@color/gray_1_313131"
-                    app:layout_constraintTop_toTopOf="@id/layout_signup_email_set_email_address_certificate_user_input"
-                    app:layout_constraintEnd_toEndOf="@id/layout_signup_email_set_email_address_certificate_user_input"
-                    android:layout_marginTop="18dp"
-                    android:layout_marginEnd="4dp"
-                    tools:text="03:00" />
-                <TextView
-                    android:id="@+id/tv_signup_email_set_email_address_certificate_resend"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/email_address_certificate_resend"
-                    android:textSize="12dp"
-                    android:textColor="@color/gray_2_767B83"
-                    app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_timer"
-                    app:layout_constraintEnd_toEndOf="@id/layout_signup_email_set_email_address_certificate_user_input"
-                    android:paddingVertical="9dp"
-                    android:paddingHorizontal="3dp"
-                    android:layout_marginTop="14dp"/>
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                        android:textSize="12dp"
+                        app:layout_constraintEnd_toEndOf="@id/layout_signup_email_set_email_address_certificate_user_input"
+                        app:layout_constraintTop_toTopOf="@id/layout_signup_email_set_email_address_certificate_user_input"
+                        tools:text="03:00" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/layout_signup_email_set_email_address_certificate_confirmation_user_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:boxBackgroundMode="outline"
+                    <TextView
+                        android:id="@+id/tv_signup_email_set_email_address_certificate_resend"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="14dp"
+                        android:paddingHorizontal="3dp"
+                        android:paddingVertical="9dp"
+                        android:text="@string/email_address_certificate_resend"
+                        android:textColor="@color/gray_2_767B83"
+                        android:textSize="12dp"
+                        app:layout_constraintEnd_toEndOf="@id/layout_signup_email_set_email_address_certificate_user_input"
+                        app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_email_address_certificate_timer" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-                android:hint="@string/email"
-                app:hintEnabled="true"
-                app:hintTextColor="@color/gray_3_9FA5AE"
-                android:textColorHint="@color/gray_3_9FA5AE"
-                app:hintAnimationEnabled="false"
-
-                app:endIconMode="custom"
-                app:endIconTint="@android:color/transparent"
-                app:endIconTintMode="src_over"
-
-                app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_certificate_user_input_contents"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="13dp">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/et_signup_email_set_email_address_certificate_confirmation_user_input"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_signup_email_set_email_address_certificate_confirmation_user_input"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/WriteEditTextStyle"
-                    android:background="@drawable/edittext_background_remove_padding"
-                    android:enabled="false"
-                    android:inputType="textEmailAddress"
-                    android:text="@{email}"
-                    android:textSize="17dp"
-                    android:textColor="@color/gray_1_313131"
-                    android:paddingTop="14dp"
-                    android:paddingStart="0dp" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginTop="8dp"
+
+                    android:hint="@string/email"
+                    android:textColorHint="@color/gray_3_9FA5AE"
+                    app:boxBackgroundMode="outline"
+                    app:endIconMode="custom"
+                    app:endIconTint="@android:color/transparent"
+
+                    app:endIconTintMode="src_over"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_email_address_certificate_user_input_contents">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_signup_email_set_email_address_certificate_confirmation_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:enabled="false"
+                        android:inputType="textEmailAddress"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:text="@{email}"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_signup_email_set_email_address_certificate_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_signup_email_set_email_address_certificate_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:stateListAnimator="@null"
-                android:enabled="false"
-                android:text="@string/email_address_certificate"
-                android:textSize="16dp"
-                android:textStyle="bold"
-                android:textColor="@color/white_FFFFFF"
+                android:layout_margin="18dp"
                 android:background="@drawable/button_default_signup_next_button_inactive"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/email_address_certificate"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_signup_email_set_password.xml
+++ b/presentation/src/main/res/layout/fragment_signup_email_set_password.xml
@@ -2,109 +2,130 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
     </data>
-<androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white_FFFFFF"
-    tools:context=".presentation.fragment.account.signup.SignupEmailSetPasswordFragment">
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_password_action_bar"
-        android:layout_width="match_parent"
-        android:layout_height="?actionBarSize"
-        android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <ImageButton
-            android:id="@+id/btn_signup_email_set_password_back"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:paddingHorizontal="18dp"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_password_contents"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_action_bar"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="18dp">
-        <TextView
-            android:id="@+id/tv_signup_email_set_password_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/signup_email_set_password_title"
-            android:textSize="22dp"
-            android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="44dp"/>
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF"
+        tools:context=".presentation.fragment.account.signup.SignupEmailSetPasswordFragment">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_signup_email_set_password_user_password"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_signup_email_set_password_action_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:elevation="24dp"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_height="43dp">
+
+            <ImageButton
+                android:id="@+id/btn_signup_email_set_password_back"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
+                android:src="@drawable/ic_back_sign"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_signup_email_set_password_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_signup_email_set_password_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_signup_email_set_password_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:text="@string/signup_email_set_password_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_signup_email_set_password_user_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+
+                    android:hint="@string/signup_email_set_password_message_length_fail_min"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:counterEnabled="false"
+                    app:counterMaxLength="16"
+                    app:counterTextColor="@color/red_FF4545"
+
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_password_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_signup_email_set_password_user_password"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_signup_email_set_password_next"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:boxBackgroundMode="outline"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-            app:passwordToggleEnabled="true"
-            android:hint="@string/signup_email_set_password_message_length_fail_min"
-            app:hintEnabled="true"
-            app:hintTextColor="@color/gray_3_9FA5AE"
-            android:textColorHint="@color/gray_4_C5CAD2"
-            app:hintAnimationEnabled="false"
-
-            app:errorTextColor="@color/red_FF4545"
-            app:counterEnabled="false"
-            app:counterMaxLength="16"
-            app:counterTextColor="@color/red_FF4545"
-
-            app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_password_title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="61dp" >
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_signup_email_set_password_user_password"
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_signup_email_set_password_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                style="@style/WriteEditTextStyle"
-                android:background="@drawable/edittext_background_remove_padding"
-                android:textSize="17dp"
-                android:textColor="@color/gray_1_313131"
-                android:inputType="textPassword"
-                android:singleLine="true"
-                android:imeOptions="actionDone"
-                android:paddingTop="14dp"
-                android:paddingStart="0dp" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_signup_email_set_password_next"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/white_FFFFFF"
-            android:background="@drawable/button_default_signup_next_button_inactive"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_inactive"
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_signup_email_set_password_confirmation.xml
+++ b/presentation/src/main/res/layout/fragment_signup_email_set_password_confirmation.xml
@@ -2,140 +2,166 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
+
         <variable
             name="password"
             type="String" />
     </data>
-<androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white_FFFFFF"
-    tools:context=".presentation.fragment.account.signup.SignupEmailSetPasswordConfirmationFragment">
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_password_confirmation_action_bar"
-        android:layout_width="match_parent"
-        android:layout_height="?actionBarSize"
-        android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <ImageButton
-            android:id="@+id/btn_signup_email_set_password_confirmation_back"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:paddingHorizontal="18dp" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_password_confirmation_contents"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_confirmation_action_bar"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="18dp">
-        <TextView
-            android:id="@+id/tv_signup_email_set_password_confirmation_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/signup_email_set_password_confirmation_title"
-            android:textSize="22dp"
-            android:textColor="@color/gray_1_313131"
-            app:layout_constraintTop_toTopOf="parent"
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF"
+        tools:context=".presentation.fragment.account.signup.SignupEmailSetPasswordConfirmationFragment">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_signup_email_set_password_confirmation_action_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:elevation="24dp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="44dp" />
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_signup_email_set_password_confirmation_user_input"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_height="43dp">
+
+            <ImageButton
+                android:id="@+id/btn_signup_email_set_password_confirmation_back"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
+                android:src="@drawable/ic_back_sign"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_signup_email_set_password_confirmation_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_confirmation_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_signup_email_set_password_confirmation_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_confirmation_action_bar">
+
+                <TextView
+                    android:id="@+id/tv_signup_email_set_password_confirmation_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:text="@string/signup_email_set_password_confirmation_title"
+                    android:textColor="@color/gray_1_313131"
+                    android:textSize="22dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_signup_email_set_password_confirmation_user_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+
+                    android:hint="@string/signup_email_set_password_confirmation_edittext_hint"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:errorTextColor="@color/red_FF4545"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_password_confirmation_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_signup_email_set_password_confirmation_user_input"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:imeOptions="actionDone"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_signup_email_set_password_confirmation_user_password"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+
+                    android:hint="@string/password"
+                    android:textColorHint="@color/gray_4_C5CAD2"
+                    app:boxBackgroundMode="outline"
+                    app:hintAnimationEnabled="false"
+                    app:hintEnabled="true"
+                    app:hintTextColor="@color/gray_3_9FA5AE"
+
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_confirmation_user_input"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/et_signup_email_set_password_confirmation_user_password"
+                        style="@style/WriteEditTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:enabled="false"
+                        android:inputType="textPassword"
+                        android:paddingStart="0dp"
+                        android:paddingTop="14dp"
+                        android:text="@{password}"
+                        android:textColor="@color/gray_1_313131"
+                        android:textSize="17dp" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_signup_email_set_password_confirmation_next"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:boxBackgroundMode="outline"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-            app:passwordToggleEnabled="true"
-            android:hint="@string/signup_email_set_password_confirmation_edittext_hint"
-            app:hintEnabled="true"
-            app:hintTextColor="@color/gray_3_9FA5AE"
-            android:textColorHint="@color/gray_4_C5CAD2"
-            app:hintAnimationEnabled="false"
-
-            app:errorTextColor="@color/red_FF4545"
-
-            app:layout_constraintTop_toBottomOf="@id/tv_signup_email_set_password_confirmation_title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="61dp" >
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_signup_email_set_password_confirmation_user_input"
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_signup_email_set_password_confirmation_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                style="@style/WriteEditTextStyle"
-                android:background="@drawable/edittext_background_remove_padding"
-                android:textSize="17dp"
-                android:textColor="@color/gray_1_313131"
-                android:inputType="textPassword"
-                android:singleLine="true"
-                android:imeOptions="actionDone"
-                android:paddingTop="14dp"
-                android:paddingStart="0dp" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/layout_signup_email_set_password_confirmation_user_password"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:boxBackgroundMode="outline"
-
-            app:passwordToggleEnabled="true"
-            android:hint="@string/password"
-            app:hintEnabled="true"
-            app:hintTextColor="@color/gray_3_9FA5AE"
-            android:textColorHint="@color/gray_4_C5CAD2"
-            app:hintAnimationEnabled="false"
-
-            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_password_confirmation_user_input"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="44dp" >
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_signup_email_set_password_confirmation_user_password"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                style="@style/WriteEditTextStyle"
-                android:background="@drawable/edittext_background_remove_padding"
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_inactive"
                 android:enabled="false"
-                android:inputType="textPassword"
-                android:text="@{password}"
-                android:textSize="17dp"
-                android:textColor="@color/gray_1_313131"
-                android:paddingTop="14dp"
-                android:paddingStart="0dp" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_signup_email_set_password_confirmation_next"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/white_FFFFFF"
-            android:background="@drawable/button_default_signup_next_button_inactive"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                android:stateListAnimator="@null"
+                android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_signup_email_set_profile.xml
+++ b/presentation/src/main/res/layout/fragment_signup_email_set_profile.xml
@@ -2,131 +2,153 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <data>
+
         <variable
             name="email"
             type="String" />
+
         <variable
             name="password"
             type="String" />
     </data>
-<androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white_FFFFFF"
-    tools:context=".presentation.fragment.account.signup.SignupEmailSetProfileFragment">
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_profile_action_bar"
-        android:layout_width="match_parent"
-        android:layout_height="?actionBarSize"
-        android:elevation="24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <ImageButton
-            android:id="@+id/btn_signup_email_set_profile_back"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_back_sign"
-            tools:ignore="ContentDescription"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:paddingHorizontal="18dp"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_signup_email_set_profile_contents"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_profile_action_bar"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginBottom="18dp">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF"
+        tools:context=".presentation.fragment.account.signup.SignupEmailSetProfileFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_signup_email_set_profile_user_img"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:id="@+id/layout_signup_email_set_profile_action_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:elevation="24dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="62dp">
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/img_signup_email_set_profile_user_image"
-                android:layout_width="105dp"
-                android:layout_height="105dp"
-                app:shapeAppearanceOverlay="@style/roundedImageViewRounded"
-                android:src="@drawable/ic_user_profile_image_empty"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
-            <ImageView
-                android:id="@+id/img_signup_email_set_profile_camera_button"
+            tools:layout_height="43dp">
+
+            <ImageButton
+                android:id="@+id/btn_signup_email_set_profile_back"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_camera_button"
-                app:layout_constraintBottom_toBottomOf="@id/img_signup_email_set_profile_user_image"
-                app:layout_constraintEnd_toEndOf="@id/img_signup_email_set_profile_user_image"
-                android:padding="5dp"
-                android:layout_marginEnd="-10dp"
-                android:layout_marginBottom="-10dp"/>
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="18dp"
+                android:src="@drawable/ic_back_sign"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_signup_email_set_profile_user_nickname"
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            app:layout_constraintBottom_toTopOf="@id/layout_signup_email_set_profile_next"
+            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_profile_action_bar">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_signup_email_set_profile_contents"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="18dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_signup_email_set_profile_user_img"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="62dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/img_signup_email_set_profile_user_image"
+                        android:layout_width="105dp"
+                        android:layout_height="105dp"
+                        android:src="@drawable/ic_user_profile_image_empty"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:shapeAppearanceOverlay="@style/roundedImageViewRounded" />
+
+                    <ImageView
+                        android:id="@+id/img_signup_email_set_profile_camera_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="-10dp"
+                        android:layout_marginBottom="-10dp"
+                        android:padding="5dp"
+                        android:src="@drawable/ic_camera_button"
+                        app:layout_constraintBottom_toBottomOf="@id/img_signup_email_set_profile_user_image"
+                        app:layout_constraintEnd_toEndOf="@id/img_signup_email_set_profile_user_image" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_signup_email_set_profile_user_nickname"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="72dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_profile_user_img">
+
+                    <EditText
+                        android:id="@+id/et_signup_email_set_profile_nickname"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/edittext_background_remove_padding"
+                        android:gravity="center"
+                        android:hint="@string/my_profile_edit_nickname_edittext_hint"
+                        android:maxLength="10"
+                        android:padding="12dp"
+                        android:singleLine="true"
+                        android:textColor="@color/gray_1_313131"
+                        android:textColorHint="@color/gray_4_C5CAD2"
+                        android:textSize="17dp"
+                        android:theme="@style/EditTextStyle"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_signup_email_set_profile_nickname_message"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:textColor="@color/red_FF4545"
+                        android:textSize="12dp"
+                        android:visibility="invisible"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/et_signup_email_set_profile_nickname" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <LinearLayout
+            android:id="@+id/layout_signup_email_set_profile_next"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/layout_signup_email_set_profile_user_img"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="72dp">
-            <EditText
-                android:id="@+id/et_signup_email_set_profile_nickname"
+            android:backgroundTint="@color/white_FFFFFF"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_signup_email_set_profile_next"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:theme="@style/EditTextStyle"
-                android:background="@drawable/edittext_background_remove_padding"
-                android:gravity="center"
-                android:hint="@string/my_profile_edit_nickname_edittext_hint"
-                android:textSize="17dp"
-                android:textColor="@color/gray_1_313131"
-                android:textColorHint="@color/gray_4_C5CAD2"
-                android:maxLength="10"
-                android:singleLine="true"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:padding="12dp"/>
-            <TextView
-                android:id="@+id/tv_signup_email_set_profile_nickname_message"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="12dp"
-                android:textColor="@color/red_FF4545"
-                android:visibility="invisible"
-                app:layout_constraintTop_toBottomOf="@id/et_signup_email_set_profile_nickname"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="10dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_signup_email_set_profile_next"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stateListAnimator="@null"
-            android:enabled="false"
-            android:text="@string/next"
-            android:textSize="16dp"
-            android:textStyle="bold"
-            android:textColor="@color/white_FFFFFF"
-            android:background="@drawable/button_default_signup_next_button_inactive"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                android:layout_margin="18dp"
+                android:background="@drawable/button_default_signup_next_button_inactive"
+                android:enabled="false"
+                android:stateListAnimator="@null"
+                android:text="@string/next"
+                android:textAlignment="center"
+                android:textColor="@color/white_FFFFFF"
+                android:textSize="16dp"
+                android:textStyle="bold" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 작업 내용
+ 정보 입력 과정에서 키보드에 스크롤뷰를 적용해 edit text가 가려지는 부분 수정
  + 회원가입 화면
  + 로그인 화면
  + 로그인 시 비밀번호 재설정 화면
  + 프로필의 비밀번호 재설정 화면
  + 프로필 수정 화면
+ 비밀번호 재설정 과정에서 화면 전환이 제대로 되지 않는 문제 해결
+ 프로필 비밀번호 재설정 화면에서 현재 비밀번호 확인 시 Event wrapper를 적용해 확인 값이 지속적으로 사용되지 않도록 함
+ 프로필 비밀번호 재설정 로직 변경
  + 입력 중에는 비밀번호 검증을 하지 않도록 변경

resolved: #332 , #568 