### PR TITLE
Fix Search Result invisible

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/adapter/SearchTagResultPostAdapter.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.RequestManager
 import daily.dayo.domain.model.Search
+import daily.dayo.presentation.common.GlideLoadUtil.HOME_POST_THUMBNAIL_SIZE
 import daily.dayo.presentation.common.GlideLoadUtil.loadImageView
 import daily.dayo.presentation.common.setOnDebounceClickListener
 import daily.dayo.presentation.databinding.ItemSearchResultPostBinding
@@ -64,8 +65,8 @@ class SearchTagResultPostAdapter(private val requestManager: RequestManager) :
             CoroutineScope(Dispatchers.Main).launch {
                 loadImageView(
                     requestManager = requestManager,
-                    width = binding.imgSearchResultPost.width,
-                    height = binding.imgSearchResultPost.height,
+                    width = HOME_POST_THUMBNAIL_SIZE,
+                    height = HOME_POST_THUMBNAIL_SIZE,
                     imgName = postContent?.thumbnailImage ?: "",
                     imgView = binding.imgSearchResultPost
                 )


### PR DESCRIPTION
## 작업 내용
- 검색결과 아이템의 Width, Height에 대한 값이 invisible 처리됨에 따라 값이 정상적으로 계산되지않아, 비정상적인 값으로 이미지뷰가 오버라이드되면서 검색결과가 보이지 않던 문제에 대한 해결

## 작업 사항
- 기존 이미지뷰의 width와 height로 오버라이드 하던부분을 다시 홈의 썸네일과 동일하게 상수로 오버라이드 하도록 원복

## 참고
- #581 