### PR TITLE
[feature] Add composable function for single photo selection via gallery/camera

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/common/image/ImageUploadUtil.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/image/ImageUploadUtil.kt
@@ -1,7 +1,16 @@
 package daily.dayo.presentation.common.image
 
+import android.Manifest
 import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.net.Uri
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.core.content.ContextCompat
 
 object ImageUploadUtil {
     private val PERMIT_IMAGE_EXTENSIONS = listOf("jpg", "jpeg", "png", "webp")
@@ -13,4 +22,93 @@ object ImageUploadUtil {
             .split("/")[1]
 
     val String.isPermitExtension: Boolean get() = this in PERMIT_IMAGE_EXTENSIONS
+}
+
+@Composable
+fun launchGallery(
+    context: Context,
+    onImageSelected: (Uri?) -> Unit,
+    onPermissionDenied: () -> Unit
+): () -> Unit {
+    val galleryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        onImageSelected(uri)
+    }
+
+    val imagePermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            galleryLauncher.launch("image/*")
+        } else {
+            onPermissionDenied()
+        }
+    }
+
+    val openGallery: () -> Unit = {
+        val hasPermission = ContextCompat.checkSelfPermission(
+            context,
+            imagePermission
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (hasPermission) {
+            galleryLauncher.launch("image/*")
+        } else {
+            permissionLauncher.launch(imagePermission)
+        }
+    }
+
+    return openGallery
+}
+
+@Composable
+fun launchCamera(
+    context: Context,
+    onImageCaptured: (Bitmap?) -> Unit,
+    onPermissionDenied: () -> Unit
+): () -> Unit {
+    // 1) 카메라 결과를 받을 Launcher
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicturePreview()
+    ) { bitmap: Bitmap? ->
+        onImageCaptured(bitmap)
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            // 권한 허용 시 카메라 실행
+            cameraLauncher.launch(null)
+        } else {
+            onPermissionDenied()
+        }
+    }
+
+    // 3) 외부에서 이 함수를 호출하면,
+    //    - 권한이 없으면 요청,
+    //    - 권한이 있으면 카메라 실행
+    val openCamera: () -> Unit = {
+        val hasPermission = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (hasPermission) {
+            // 이미 권한이 있으면 곧바로 카메라 실행
+            cameraLauncher.launch(null)
+        } else {
+            // 권한 없으면 요청
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    return openCamera
 }


### PR DESCRIPTION
## 목적
- 기존 사진 선택시 갤러리 및 카메라 호출에 대한 처리를 각 Composable function 내부에서 처리함으로써 처리 로직이 상이한 문제 제거
- 권한 허용 및 미디어(갤러리/카메라) 로드에 대한 로직은 시스템 종속적이므로 중복코드 발생이 필연적이므로 이를 공통화 처리

## 작업 내용
- 갤러리 및 카메라 로드시 `launchGallery` `launchCamera`를 통해 호출할 수 있도록 구현
- 미디어 관련 권한 허용 요청상태에서 권한 허용시 바로 미디어가 보여질 수 있도록 처리
- 선택/촬영한 이미지에 대한 로직과 권한 미허용시에 대한 action은 이를 호출하는 composable function에서 처리할 수있도록 구현

## 참고 사항
- 현재 단일 사진에 대한 갤러리 호출만 가능한 상태로, 추후 여러장의 사진에 대한 갤러리 호출 function 추가 예정
- 갤러리 이미지 선택에 대한 UI 개선 여부에 따라서 추후 메소드 내부 동작은 변경될 수 있으나, 전체적인 interface는 유지