### PR TITLE
[feature] Add customizable button texts, null cancel handling, and condional view rendering

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
@@ -32,12 +32,14 @@ import daily.dayo.presentation.view.DayoTextButton
 fun ConfirmDialog(
     title: String,
     description: String,
-    onClickConfirm: () -> Unit,
-    onClickCancel: () -> Unit,
-    modifier: Modifier = Modifier
+    onClickConfirm: () -> Unit, // onClickConfirm is required
+    modifier: Modifier = Modifier,
+    onClickCancel: (() -> Unit)? = {},
+    onClickConfirmText: String = stringResource(id = R.string.confirm),
+    onClickCancelText: String = stringResource(id = R.string.cancel),
 ) {
     Dialog(
-        onDismissRequest = onClickCancel
+        onDismissRequest = onClickCancel ?: onClickConfirm,
     ) {
         Surface(
             modifier = modifier
@@ -55,8 +57,10 @@ fun ConfirmDialog(
                     color = Gray7_F6F6F7
                 )
                 DialogActionButton(
-                    onClickConfirm,
-                    onClickCancel
+                    onClickConfirmText = onClickConfirmText,
+                    onClickConfirm = onClickConfirm,
+                    onClickCancelText = onClickCancelText,
+                    onClickCancel = onClickCancel
                 )
             }
         }
@@ -72,40 +76,51 @@ private fun DialogHeader(title: String, description: String) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        Text(
-            text = title,
-            color = Dark,
-            textAlign = TextAlign.Center,
-            style = DayoTheme.typography.b3
-        )
+        if (title.isNotBlank()) {
+            Text(
+                text = title,
+                color = Dark,
+                textAlign = TextAlign.Center,
+                style = DayoTheme.typography.b3
+            )
+        }
 
-        Text(
-            text = description,
-            color = Gray2_767B83,
-            textAlign = TextAlign.Center,
-            style = DayoTheme.typography.caption4
-        )
+        if (description.isNotBlank()) {
+            Text(
+                text = description,
+                color = Gray2_767B83,
+                textAlign = TextAlign.Center,
+                style = DayoTheme.typography.caption4
+            )
+        }
     }
 }
 
 @Composable
-private fun DialogActionButton(onClickConfirm: () -> Unit, onClickCancel: () -> Unit) {
+private fun DialogActionButton(
+    onClickConfirm: () -> Unit,
+    onClickCancel: (() -> Unit)? = {},
+    onClickConfirmText: String = stringResource(id = R.string.confirm),
+    onClickCancelText: String = stringResource(id = R.string.cancel),
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        DayoTextButton(
-            text = stringResource(id = R.string.cancel),
-            onClick = onClickCancel,
-            modifier = Modifier.weight(1f),
-            textAlign = TextAlign.Center,
-            textStyle = DayoTheme.typography.b5.copy(Gray3_9FA5AE)
-        )
+        if (onClickCancel != null) {
+            DayoTextButton(
+                text = onClickCancelText,
+                onClick = onClickCancel,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                textStyle = DayoTheme.typography.b5.copy(Gray3_9FA5AE)
+            )
+        }
 
         DayoTextButton(
-            text = stringResource(id = R.string.confirm),
+            text = onClickConfirmText,
             onClick = onClickConfirm,
             modifier = Modifier.weight(1f),
             textAlign = TextAlign.Center,
@@ -118,6 +133,9 @@ private fun DialogActionButton(onClickConfirm: () -> Unit, onClickCancel: () -> 
 @Composable
 private fun PreviewConfirmDialog() {
     DayoTheme {
-        ConfirmDialog("title", "description", {}, {})
+        ConfirmDialog("title", "description",
+            onClickConfirm = {},
+            onClickCancel = {}
+        )
     }
 }


### PR DESCRIPTION
# 작업 사항
- Confirm, Cancel 버튼에 대한 텍스트 변경이 가능하도록 parameter 추가
- onClickCancel이 없는 상황에 대해 null로 설정 할 수도록 처리해, onClickConfrim만 보이는 단순 알림 Dialog에서 사용 가능하도록 처리
   - 기존 Dialog가 Dismiss되는 경우 onClickCancel이 호출되도록하는 것은 유지하되, onClickCancel이 null인 경우 onClickConfirm이 호출되도록 처리
   - onClickConfirm은 non-nullable처리를 통해 버튼이 모두 없는 Dialog가 되지 않도록 처리 (ConfirmDialog 네이밍과 맞지않음)
- title 혹은 description의 text가 blank인 경우 view를 그리지 않도록 처리해, 불필요한 공백 등이 보이지 않도록 처리

# 참고
- #628 