### PR TITLE
Update Compose and compileSdk version, migrate deprecated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone git@github.com:Daily-DAYO/DAYO_Android.git
 
 ## Application Version
 - minSdkVersion : 26<br>
-- targetSdkVersion : 33
+- targetSdkVersion : 35
 
 ## Git Convention
 - Create issue<br>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,11 +26,12 @@ kotlin {
 }
 
 android {
+    compileSdk rootProject.ext.compileSdkVersion
+
     defaultConfig {
         applicationId "com.daily.dayo"
-        compileSdk 35
-        minSdkVersion 26
-        targetSdkVersion 35
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 20000
         versionName "2.0.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,9 +28,9 @@ kotlin {
 android {
     defaultConfig {
         applicationId "com.daily.dayo"
-        compileSdk 34
+        compileSdk 35
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 20000
         versionName "2.0.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ buildscript {
         compose_version = '1.4.6'
         nav_version = '2.6.0'
         paging_version = "3.2.0"
+        targetSdkVersion = 35
+        compileSdkVersion = 35
+        minSdkVersion = 26
     }
     repositories {
         google()

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -14,10 +14,10 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 
 android {
     namespace 'daily.dayo.data'
-    compileSdk 35
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdk 26
+        minSdk rootProject.ext.minSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -14,7 +14,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 
 android {
     namespace 'daily.dayo.data'
-    compileSdk 33
+    compileSdk 35
 
     defaultConfig {
         minSdk 26

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -20,7 +20,7 @@ kotlin {
 
 android {
     namespace 'daily.dayo.presentation'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 26
@@ -86,9 +86,10 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     // Compose
-    def composeBom = platform("androidx.compose:compose-bom:2023.06.01")
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
+    Dependency composeBom = platform('androidx.compose:compose-bom:2025.05.00')
+    implementation composeBom
+    testImplementation composeBom
+    androidTestImplementation composeBom
     implementation "androidx.compose.material:material:1.5.4"
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -104,7 +105,6 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.10.1'
-    implementation("androidx.compose.material3:material3")
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     // Java language implementation
@@ -119,7 +119,7 @@ dependencies {
     // Jetpack Compose
     // Material
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:material-icons-extended:1.5.3")
+    implementation("androidx.compose.material:material-icons-extended")
     // Android Studio Preview support
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
@@ -127,13 +127,13 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     // Optional - Integration with activities
-    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.activity:activity-compose:1.10.1")
     // Optional - Integration with LiveData
     implementation("androidx.compose.runtime:runtime-livedata")
     // Optional - Integration with RxJava
     implementation("androidx.compose.runtime:runtime-rxjava2")
     // To use constraintlayout in compose
-    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.1.1")
 
     // Jetpack Navigation
     // Java language implementation
@@ -148,7 +148,7 @@ dependencies {
     androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
     // Jetpack Compose Integration
     implementation "androidx.navigation:navigation-compose:$nav_version"
-    implementation "androidx.hilt:hilt-navigation-compose:1.1.0"
+    implementation "androidx.hilt:hilt-navigation-compose:1.2.0"
 
     // ViewPager2
     implementation "androidx.viewpager2:viewpager2:1.0.0"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -20,10 +20,10 @@ kotlin {
 
 android {
     namespace 'daily.dayo.presentation'
-    compileSdk 35
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdk 26
+        minSdk rootProject.ext.minSdkVersion
         versionCode 10000
         versionName "1.0.0"
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
@@ -1,5 +1,7 @@
 package daily.dayo.presentation.screen.settings
 
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
@@ -113,7 +115,11 @@ private fun SettingsScreen(
     ) { contentPadding ->
         val scrollState = rememberScrollState()
         val context = LocalContext.current
-        val appVersion = context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0)).versionName ?: ""
+        val appVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0)).versionName
+        } else {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        } ?: ""
 
         val settingMenus = listOf(
             SettingItem(R.string.setting_menu_change_password, R.drawable.ic_setting_password_change, onClickMenu = onPasswordChangeClick),

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
@@ -113,7 +113,7 @@ private fun SettingsScreen(
     ) { contentPadding ->
         val scrollState = rememberScrollState()
         val context = LocalContext.current
-        val appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+        val appVersion = context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0)).versionName ?: ""
 
         val settingMenus = listOf(
             SettingItem(R.string.setting_menu_change_password, R.drawable.ic_setting_password_change, onClickMenu = onPasswordChangeClick),

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
@@ -113,7 +113,7 @@ private fun SettingsScreen(
     ) { contentPadding ->
         val scrollState = rememberScrollState()
         val context = LocalContext.current
-        val appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        val appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
 
         val settingMenus = listOf(
             SettingItem(R.string.setting_menu_change_password, R.drawable.ic_setting_password_change, onClickMenu = onPasswordChangeClick),

--- a/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,13 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.IconButton
-import androidx.compose.material.LocalContentColor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.ripple.LocalRippleTheme
-import androidx.compose.material.ripple.RippleAlpha
-import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
@@ -28,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -186,49 +180,27 @@ fun NoRippleIconButton(
     interactionSource: MutableInteractionSource = MutableInteractionSource(),
     additionalComponent: @Composable (() -> Unit)? = null
 ) {
-    CompositionLocalProvider(
-        LocalRippleTheme provides object : RippleTheme {
-            @Composable
-            override fun defaultColor(): Color {
-                return RippleTheme.defaultRippleColor(
-                    contentColor = LocalContentColor.current,
-                    lightTheme = !isSystemInDarkTheme()
-                )
-            }
-
-            @Composable
-            override fun rippleAlpha(): RippleAlpha {
-                val defaultAlpha = RippleTheme.defaultRippleAlpha(
-                    contentColor = LocalContentColor.current,
-                    lightTheme = !isSystemInDarkTheme()
-                )
-                return RippleAlpha(
-                    pressedAlpha = defaultAlpha.pressedAlpha,
-                    focusedAlpha = 0f,
-                    draggedAlpha = defaultAlpha.draggedAlpha,
-                    hoveredAlpha = defaultAlpha.hoveredAlpha
-                )
-            }
-        }
+    IconButton(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = iconButtonModifier
+            .defaultMinSize(1.dp, 1.dp)
+            .indication(
+                interactionSource = interactionSource,
+                indication = null
+            )
     ) {
-        IconButton(
-            onClick = onClick,
-            modifier = iconButtonModifier
-                .defaultMinSize(1.dp, 1.dp)
-                .indication(interactionSource = interactionSource, indication = null)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Icon(
-                    modifier = iconModifier,
-                    painter = iconPainter,
-                    contentDescription = iconContentDescription,
-                    tint = iconTintColor
-                )
-                additionalComponent?.invoke()
-            }
+            Icon(
+                painter = iconPainter,
+                contentDescription = iconContentDescription,
+                tint = iconTintColor,
+                modifier = iconModifier
+            )
+            additionalComponent?.invoke()
         }
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Chip.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Chip.kt
@@ -1,12 +1,12 @@
 package daily.dayo.presentation.view
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -39,11 +39,10 @@ fun Chip(
             )
         },
         shape = RoundedCornerShape(100.dp),
-        border = AssistChipDefaults.assistChipBorder(
-            borderColor = color,
-            borderWidth = 1.dp,
-            disabledBorderColor = Gray6_F0F1F3
-        ),
+        border = if (enabled) BorderStroke(
+            width = 1.dp,
+            color = color
+        ) else BorderStroke(width = 1.dp, color = Gray6_F0F1F3),
         colors = AssistChipDefaults.assistChipColors(
             containerColor = White_FFFFFF,
             disabledContainerColor = White_FFFFFF

--- a/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
@@ -27,8 +27,8 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TextFieldDefaults.TextFieldDecorationBox
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
@@ -238,7 +238,7 @@ fun CommentView(
                     // reply comment
                     Row(
                         modifier = Modifier.clickableSingle(
-                            indication = rememberRipple(bounded = false, radius = 8.dp),
+                            indication = ripple(bounded = false, radius = 8.dp),
                             interactionSource = remember { MutableInteractionSource() },
                             onClick = { onClickReply(Pair(parentCommentId, comment)) }),
                         verticalAlignment = Alignment.CenterVertically
@@ -269,7 +269,7 @@ fun CommentView(
                         style = DayoTheme.typography.b6.copy(Gray3_9FA5AE),
                         modifier = Modifier
                             .clickableSingle(
-                                indication = rememberRipple(bounded = false, radius = 8.dp),
+                                indication = ripple(bounded = false, radius = 8.dp),
                                 interactionSource = remember { MutableInteractionSource() },
                                 onClick = if (isMine) {
                                     { onClickDelete(comment.commentId) }
@@ -330,7 +330,7 @@ fun CommentMentionSearchView(userResults: LazyPagingItems<SearchUser>, onClickFo
                         .fillMaxWidth()
                         .padding(vertical = 4.dp)
                         .clickableSingle(
-                            indication = rememberRipple(bounded = false, radius = 8.dp, color = Gray7_F6F6F7),
+                            indication = ripple(bounded = false, radius = 8.dp, color = Gray7_F6F6F7),
                             interactionSource = remember { MutableInteractionSource() },
                             onClick = { onClickFollowUser(user) }
                         ),

--- a/presentation/src/main/java/daily/dayo/presentation/view/DetailPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/DetailPostView.kt
@@ -20,11 +20,11 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -238,7 +238,7 @@ fun DetailPostView(
                 imageVector = ImageVector.vectorResource(id = if (post.heart) R.drawable.ic_heart_filled else R.drawable.ic_heart_outlined),
                 modifier = Modifier
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = onClickLikePost
                     ),
@@ -257,7 +257,7 @@ fun DetailPostView(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_comment),
                 modifier = Modifier
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = onClickComment
                     ),
@@ -277,7 +277,7 @@ fun DetailPostView(
                 modifier = Modifier
                     .padding(vertical = 8.dp)
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = onClickBookmark
                     ),

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -26,11 +26,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -254,7 +254,7 @@ fun FeedPostView(
                     .padding(end = 8.dp)
                     .padding(vertical = 8.dp)
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = onClickLikePost
                     ),
@@ -267,7 +267,7 @@ fun FeedPostView(
                 modifier = Modifier
                     .padding(8.dp)
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = { post.postId?.let { onClickComment(it) } }
                     ),
@@ -281,7 +281,7 @@ fun FeedPostView(
                 modifier = Modifier
                     .padding(vertical = 8.dp)
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = onClickBookmark
                     ),

--- a/presentation/src/main/java/daily/dayo/presentation/view/HomePostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/HomePostView.kt
@@ -14,9 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.ripple.rememberRipple
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -88,7 +87,7 @@ fun HomePostView(
                     .padding(bottom = 12.dp, end = 11.dp)
                     .align(Alignment.BottomEnd)
                     .clickableSingle(
-                        indication = rememberRipple(bounded = false),
+                        indication = ripple(bounded = false),
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = { onClickLikePost() }
                     ),


### PR DESCRIPTION
## 작업사항
- Compose 라이브러리 버전 업데이트 및 업데이트간 Deprecated된 API 메소드들에 대한 리팩토링
   - ripple 관련 코드 변경
   - Chip-border 설정 코드 변경
- Compose 라이브러리 버전 업데이트로 인한 compileSdk 35로 상향

## 참고
- #645 