### PR TITLE
Add user profile image to notification list items

### DIFF
--- a/data/src/main/java/daily/dayo/data/datasource/remote/alarm/AlarmResponse.kt
+++ b/data/src/main/java/daily/dayo/data/datasource/remote/alarm/AlarmResponse.kt
@@ -30,5 +30,7 @@ data class AlarmDto(
     @SerializedName("memberId")
     val memberId: String?,
     @SerializedName("postId")
-    val postId: Long?
+    val postId: Long?,
+    @SerializedName("profileImage")
+    val profileImage: String?,
 )

--- a/data/src/main/java/daily/dayo/data/mapper/AlarmMapper.kt
+++ b/data/src/main/java/daily/dayo/data/mapper/AlarmMapper.kt
@@ -13,6 +13,7 @@ fun AlarmDto.toNotification(): Notification {
         image = image,
         nickname = nickname,
         memberId = memberId,
-        postId = postId
+        postId = postId,
+        profileImage = profileImage,
     )
 }

--- a/domain/src/main/java/daily/dayo/domain/model/Notification.kt
+++ b/domain/src/main/java/daily/dayo/domain/model/Notification.kt
@@ -9,5 +9,6 @@ data class Notification(
     val image: String?,
     val nickname: String?,
     val memberId: String?,
-    val postId: Long?
+    val postId: Long?,
+    val profileImage: String?,
 )

--- a/presentation/src/main/java/daily/dayo/presentation/screen/notification/NotificationScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/notification/NotificationScreen.kt
@@ -136,6 +136,7 @@ fun NotificationContent(
                     nickname = "",
                     memberId = "",
                     postId = 0,
+                    profileImage = "",
                 )
             )
         )
@@ -310,6 +311,7 @@ fun NotificationView(
         nickname = "",
         memberId = "",
         postId = 0,
+        profileImage = "",
     ),
     context: Context = LocalContext.current,
     onClick: () -> Unit = {},
@@ -353,7 +355,7 @@ fun NotificationView(
             modifier = Modifier.weight(1f),
         ) {
             RoundImageView(
-                imageUrl = "", // TODO USER IMAGE Format: ${BuildConfig.BASE_URL}/images/
+                imageUrl = "${BuildConfig.BASE_URL}/images/${notification.profileImage!!}",
                 context = context,
                 modifier = Modifier
                     .size(28.dp)


### PR DESCRIPTION
## 작업사항
- 알림 리스트에서 알림을 보낸 유저 프로필 노출에 대한 반영
   - Notification data model에 대한 필드값 추가

## 참고
- #654 