### PR TITLE
Fix showing initial search result when navigating back from later searches

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
@@ -141,6 +141,7 @@ internal fun MainScreen(
                                             memberId
                                         )
                                     },
+                                    navController = navigator.navController,
                                 )
                                 writeNavGraph(
                                     snackBarHostState = snackBarHostState,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchNavigation.kt
@@ -22,7 +22,8 @@ fun NavGraphBuilder.searchNavGraph(
     onBackClick: () -> Unit,
     onSearch: (String) -> Unit,
     onProfileClick: (String) -> Unit,
-    onPostClick: (Long) -> Unit
+    onPostClick: (Long) -> Unit,
+    navController: NavController,
 ) {
     composable(route = SearchRoute.route) {
         SearchRoute(
@@ -40,7 +41,8 @@ fun NavGraphBuilder.searchNavGraph(
             searchKeyword = searchKeyword,
             onBackClick = onBackClick,
             onPostClick = onPostClick,
-            onClickProfile = onProfileClick
+            onClickProfile = onProfileClick,
+            navController = navController,
         )
     }
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -101,9 +102,10 @@ internal fun SearchResultRoute(
     onBackClick: () -> Unit,
     onPostClick: (Long) -> Unit,
     onClickProfile: (String) -> Unit,
+    navController: NavController,
     searchViewModel: SearchViewModel = hiltViewModel(),
     followViewModel: FollowViewModel = hiltViewModel(),
-    accountViewModel: AccountViewModel = hiltViewModel()
+    accountViewModel: AccountViewModel = hiltViewModel(),
 ) {
     val searchKeywordResultsTag = searchViewModel.searchTagList.collectAsLazyPagingItems()
     val searchKeywordResultsUser = searchViewModel.searchUserList.collectAsLazyPagingItems()
@@ -132,9 +134,12 @@ internal fun SearchResultRoute(
         searchKeywordResultsUserTotalCount = searchKeywordResultsUserTotalCount,
         onBackClick = onBackClick,
         onPostClick = onPostClick,
-        onSearchClick = { keyword ->
-            searchViewModel.searchKeyword(keyword, SearchHistoryType.TAG)
-            searchViewModel.searchKeyword(keyword, SearchHistoryType.USER)
+        onSearchClick = { newKeyword ->
+            navController.navigate(SearchRoute.resultSearch(newKeyword)) {
+                launchSingleTop = true
+                popUpTo(SearchRoute.route) { inclusive = false } // 이전 결과 화면 스택에서 제거
+                restoreState = true
+            }
         },
         onFollowClick = { memberId, isFollower ->
             followViewModel.requestFollow(


### PR DESCRIPTION
## 작업 목표
- 최초 키워드 검색 이후, 타 키워드 검색후에도 상세페이지로 이동후 검색결과 화면으로 돌아오는 경우 항상 최초 키워드 검색화면이 표시되는 현상 해결
## 작업 사항
- 검색결과 이동시에 searchKeyword를 이용해 route를 설정해 이동하는데, 최초 키워드 검색 이후 이를 갱신하지 않아서 생기는 문제에 대한 해결
   - Composable 내부에서 viewmodel의 searchKeyword 함수만 호출함에따라, NavBackStackEntry의 param searchkeyword는 그대로 남아있고, 상세페이지에서 돌아가는 경우 다시 그 값으로 recomposition 되기 때문에 발생했던 문제
- 기존에 viewModel을 이용해 검색 결과를 갱신하던 방식에서 기존의 route에 searchKeyword를 설정하는 방식을 활용해, 검색할때마다 route인자를 변경해 화면전환을 통해 결과값을 보여주고, 직전 키워드 검색 화면은 Stack에서 제거함으로써 해결

## 참고
- #660 