### PR TITLE
Add exception case OAuth accounts in password reset

### DIFF
--- a/data/src/main/java/daily/dayo/data/datasource/remote/member/MemberApiService.kt
+++ b/data/src/main/java/daily/dayo/data/datasource/remote/member/MemberApiService.kt
@@ -68,6 +68,9 @@ interface MemberApiService {
     @GET("/api/v1/members/search/{email}")
     suspend fun requestCheckEmail(@Path("email") email: String): NetworkResponse<Void>
 
+    @GET("/api/v2/members/find-oauth-email/{email}")
+    suspend fun requestCheckOAuthEmail(@Path("email") email: String): NetworkResponse<Void>
+
     @GET("/api/v1/members/search/code/{email}")
     suspend fun requestCheckEmailAuth(@Path("email") email: String): NetworkResponse<MemberAuthCodeResponse>
 

--- a/data/src/main/java/daily/dayo/data/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/java/daily/dayo/data/repository/MemberRepositoryImpl.kt
@@ -155,6 +155,9 @@ class MemberRepositoryImpl @Inject constructor(
     override suspend fun requestCheckEmail(email: String): NetworkResponse<Void> =
         memberApiService.requestCheckEmail(email)
 
+    override suspend fun requestCheckOAuthEmail(email: String): NetworkResponse<Void> =
+        memberApiService.requestCheckOAuthEmail(email)
+
     override suspend fun requestCertificateEmailPasswordReset(email: String): NetworkResponse<String> =
         when (val response = memberApiService.requestCheckEmailAuth(email)) {
             is NetworkResponse.Success -> NetworkResponse.Success(response.body?.authCode)

--- a/domain/src/main/java/daily/dayo/domain/repository/MemberRepository.kt
+++ b/domain/src/main/java/daily/dayo/domain/repository/MemberRepository.kt
@@ -37,6 +37,7 @@ interface MemberRepository {
     suspend fun requestChangeReceiveAlarm(onReceiveAlarm: Boolean): NetworkResponse<Void>
     suspend fun requestLogout(): NetworkResponse<Void>
     suspend fun requestCheckEmail(email: String): NetworkResponse<Void>
+    suspend fun requestCheckOAuthEmail(email: String): NetworkResponse<Void>
     suspend fun requestCertificateEmailPasswordReset(email: String): NetworkResponse<String>
     suspend fun requestCheckCurrentPassword(password: String): NetworkResponse<Void>
     suspend fun requestChangePassword(email: String, password: String): NetworkResponse<Void>

--- a/domain/src/main/java/daily/dayo/domain/usecase/member/RequestCheckOAuthEmailUseCase.kt
+++ b/domain/src/main/java/daily/dayo/domain/usecase/member/RequestCheckOAuthEmailUseCase.kt
@@ -1,0 +1,8 @@
+package daily.dayo.domain.usecase.member
+
+import daily.dayo.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class RequestCheckOAuthEmailUseCase @Inject constructor(private val memberRepository: MemberRepository) {
+    suspend operator fun invoke(email: String) = memberRepository.requestCheckOAuthEmail(email)
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/AccountNavigator.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/AccountNavigator.kt
@@ -15,6 +15,10 @@ class AccountNavigator(
     private val currentDestination: NavDestination?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
 
+    fun navigateSignIn() {
+        navController.navigateSignIn()
+    }
+
     fun navigateSignInEmail() {
         navController.navigateSignInEmail()
     }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/AccountScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/AccountScreen.kt
@@ -48,6 +48,7 @@ internal fun AccountScreen(
                                 snackBarHostState = snackBarHostState,
                                 navController = navigator.navController,
                                 onBackClick = { navigator.popBackStack() },
+                                navigateToSignIn = { navigator.navigateSignIn() },
                                 navigateToSignInEmail = { navigator.navigateSignInEmail() },
                                 navigateToResetPassword = { navigator.navigateResetPassword() },
                                 navigateToSignUpEmail = { navigator.navigateSignUpEmail() },

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SignInNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SignInNavigation.kt
@@ -14,6 +14,12 @@ import daily.dayo.presentation.screen.rules.RuleRoute
 import daily.dayo.presentation.screen.rules.RuleType
 import kotlinx.coroutines.CoroutineScope
 
+fun NavController.navigateSignIn() {
+    this.navigate(SignInRoute.route) {
+        popUpTo(SignInRoute.route) { inclusive = true }
+    }
+}
+
 fun NavController.navigateSignInEmail() {
     this.navigate(SignInRoute.signInEmail)
 }
@@ -30,12 +36,12 @@ fun NavController.navigateProfileSetting() {
     this.navigate(SignInRoute.profileSetting)
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 fun NavGraphBuilder.signInNavGraph(
     coroutineScope: CoroutineScope,
     snackBarHostState: SnackbarHostState,
     navController: NavController,
     onBackClick: () -> Unit,
+    navigateToSignIn: () -> Unit,
     navigateToSignInEmail: () -> Unit,
     navigateToResetPassword: () -> Unit,
     navigateToSignUpEmail: () -> Unit,
@@ -77,6 +83,7 @@ fun NavGraphBuilder.signInNavGraph(
             coroutineScope = coroutineScope,
             snackBarHostState = snackBarHostState,
             onBackClick = onBackClick,
+            navigateToSignIn = navigateToSignIn,
             accountViewModel = hiltViewModel(parentStackEntry),
         )
     }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/model/EmailCertificationState.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/model/EmailCertificationState.kt
@@ -7,4 +7,5 @@ enum class EmailCertificationState {
     NOT_EXIST_EMAIL,      // 존재하지 않는 이메일로 인증 실패
     DUPLICATE_EMAIL,      // 중복된 이메일로 인증 실패
     INVALID_FORMAT,       // 잘못된 형식의 이메일로 인증 실패
+    OAUTH_EMAIL,          // 소셜계정으로 가입한 이메일로 인증 실패
 }

--- a/presentation/src/main/java/daily/dayo/presentation/viewmodel/AccountViewModel.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/viewmodel/AccountViewModel.kt
@@ -33,6 +33,7 @@ class AccountViewModel @Inject constructor(
     private val requestResignUseCase: RequestResignUseCase,
     private val requestLogoutUseCase: RequestLogoutUseCase,
     private val requestCheckEmailUseCase: RequestCheckEmailUseCase,
+    private val requestCheckOAuthEmailUseCase: RequestCheckOAuthEmailUseCase,
     private val requestCertificateEmailPasswordResetUseCase: RequestCertificateEmailPasswordResetUseCase,
     private val requestCheckCurrentPasswordUseCase: RequestCheckCurrentPasswordUseCase,
     private val requestChangePasswordUseCase: RequestChangePasswordUseCase,
@@ -77,6 +78,9 @@ class AccountViewModel @Inject constructor(
 
     private val _checkEmailSuccess = MutableStateFlow<Status>(Status.LOADING)
     val checkEmailSuccess: StateFlow<Status> get() = _checkEmailSuccess
+
+    private val _checkOAuthEmailSuccess = MutableStateFlow<Status>(Status.LOADING)
+    val checkOAuthEmailSuccess: StateFlow<Status> get() = _checkOAuthEmailSuccess
 
     private val _resetPasswordSuccess = MutableStateFlow<Status?>(null)
     val resetPasswordSuccess: StateFlow<Status?> get() = _resetPasswordSuccess
@@ -375,6 +379,27 @@ class AccountViewModel @Inject constructor(
 
                 is NetworkResponse.ApiError -> {
                     _checkEmailSuccess.emit(Status.ERROR)
+                }
+
+                else -> {}
+            }
+        }
+    }
+
+    fun requestCheckOAuthEmail(inputEmail: String) = viewModelScope.launch {
+        _checkOAuthEmailSuccess.emit(Status.LOADING)
+        requestCheckOAuthEmailUseCase(email = inputEmail).let { ApiResponse ->
+            when (ApiResponse) {
+                is NetworkResponse.Success -> {
+                    _checkOAuthEmailSuccess.emit(Status.SUCCESS)
+                }
+
+                is NetworkResponse.NetworkError -> {
+                    _checkOAuthEmailSuccess.emit(Status.ERROR)
+                }
+
+                is NetworkResponse.ApiError -> {
+                    _checkOAuthEmailSuccess.emit(Status.ERROR)
                 }
 
                 else -> {}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -465,6 +465,8 @@
     <string name="reset_password_email_certification_fail_network">네트워크 오류로 인증번호가 정상적으로 전송되지 않았어요</string>
     <string name="reset_password_email_certification_fail_time_out">제한시간을 초과했어요! 인증번호를 다시 받아주세요</string>
     <string name="reset_password_email_certification_resend_button">인증번호 재발송</string>
+    <string name="reset_password_email_certification_fail_oauth_account_dialog_title">간편 로그인 계정이에요</string>
+    <string name="reset_password_email_certification_fail_oauth_account_dialog_description">가입하셨던 소셜 계정을 이용해\n로그인해주세요</string>
 
     <string name="reset_password_new_password_title">새로운 비밀번호 입력</string>
     <string name="reset_password_new_password_sub_title">메일로 인증번호가 발송되었어요!</string>


### PR DESCRIPTION
## 작업사항
- 소셜계정으로 가입한 계정에 대한 비밀번호 찾기에 대한 예외 처리 추가
- 로그인 홈으로 돌아가는 navigate 함수 추가
- 이메일 유효여부 로직 일부 변경

## 참고
- #662 