### PR TITLE
Add Network Error Dialog layout

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/NetworkErrorDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/NetworkErrorDialog.kt
@@ -1,0 +1,24 @@
+package daily.dayo.presentation.view.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import daily.dayo.presentation.R
+
+@Composable
+fun NetworkErrorDialog(
+    modifier: Modifier = Modifier,
+    title: String = stringResource(id = R.string.network_error_dialog_default_message),
+    description: String = "",
+    onClickRetry: () -> Unit = {},
+    onClickRetryText: String = stringResource(id = R.string.re_try),
+) {
+    ConfirmDialog(
+        title = title,
+        description = description,
+        onClickConfirm = onClickRetry,
+        modifier = modifier,
+        onClickCancel = null,
+        onClickConfirmText = onClickRetryText
+    )
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="app_version_force_update">업데이트가 필요합니다</string>
     <string name="back_sign">뒤로가기</string>
     <string name="loading_default_message">잠시만 기다려 주세요</string>
+    <string name="network_error_dialog_default_message">인터넷 연결 상태를 확인해주세요</string>
     <string name="close_sign">닫기</string>
     <string name="re_try">재시도</string>
 


### PR DESCRIPTION
## 작업 사항
- 기존 `ConfirmDialog`를 이용해 Network Error Dialog 구현
   - 별도의 레이아웃 변경사항이 없는한 onClickRetry만 호출할 네트워킹 작업에 넣으면 됨

## 참고
- #672 