### PR TITLE
Rewarded Ad View Before Creating Folder

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ plugins {
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
+def ADS_APPLICATION_ID = properties.getProperty('ADS_APPLICATION_ID')
 def keystorePropertiesFile = rootProject.file("app/keystore-release.properties")
 
 sentry {
@@ -38,7 +39,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField ("String", "NATIVE_APP_KEY", properties['NATIVE_APP_KEY_STR'])
-        manifestPlaceholders = [NATIVE_APP_KEY: NATIVE_APP_KEY]
+        manifestPlaceholders = [
+                NATIVE_APP_KEY    : NATIVE_APP_KEY,
+                ADS_APPLICATION_ID: ADS_APPLICATION_ID
+        ]
     }
 
     signingConfigs {
@@ -115,4 +119,7 @@ dependencies {
     // Firebase
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'
+
+    // Google Ads
+    implementation 'com.google.android.gms:play-services-ads:23.6.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,11 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_dayo_logo" />
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="${ADS_APPLICATION_ID}" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/com/daily/dayo/DayoApplication.kt
+++ b/app/src/main/java/com/daily/dayo/DayoApplication.kt
@@ -2,6 +2,7 @@ package com.daily.dayo
 
 import android.app.Application
 import com.bumptech.glide.Glide
+import com.google.android.gms.ads.MobileAds
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
@@ -9,11 +10,12 @@ import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class DayoApplication : Application(){
+class DayoApplication : Application() {
     private lateinit var firebaseAnalytics: FirebaseAnalytics
     override fun onCreate() {
         super.onCreate()
         KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+        MobileAds.initialize(this)
         firebaseAnalytics = Firebase.analytics
     }
 

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -257,4 +257,7 @@ dependencies {
 //    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
     // Image Cropper
     implementation("com.vanniktech:android-image-cropper:4.6.0")
+
+    // Google Ads
+    implementation 'com.google.android.gms:play-services-ads:23.6.0'
 }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -50,10 +50,12 @@ android {
         dev {
             dimension "environment"
             buildConfigField("String", "BASE_URL", properties['BASE_URL_DEV'])
+            buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_DEV'])
         }
         prod {
             dimension "environment"
             buildConfigField("String", "BASE_URL", properties['BASE_URL_PROD'])
+            buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_PROD'])
         }
     }
     compileOptions {

--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -21,6 +21,7 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import dagger.hilt.android.AndroidEntryPoint
+import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.screen.main.MainScreen
 import daily.dayo.presentation.theme.DayoTheme
@@ -52,8 +53,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun loadRewardedAd() {
         val adRequest = AdRequest.Builder().build()
-        // TODO 테스트 광고 아이디 변경 필요
-        RewardedAd.load(this, "ca-app-pub-3940256099942544/5224354917", adRequest, object : RewardedAdLoadCallback() {
+        RewardedAd.load(this, BuildConfig.REWARDED_AD_UNIT_ID_FOLDER, adRequest, object : RewardedAdLoadCallback() {
             override fun onAdLoaded(ad: RewardedAd) {
                 rewardedAd = ad
             }

--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
@@ -15,6 +16,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import dagger.hilt.android.AndroidEntryPoint
 import daily.dayo.presentation.R
 import daily.dayo.presentation.screen.main.MainScreen
@@ -26,16 +31,52 @@ import daily.dayo.presentation.viewmodel.SettingNotificationViewModel
 class MainActivity : AppCompatActivity() {
     private val accountViewModel by viewModels<AccountViewModel>()
     private val settingNotificationViewModel by viewModels<SettingNotificationViewModel>()
+    private var rewardedAd: RewardedAd? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setSystemBackClickListener()
         checkCurrentNotification()
         getNotificationData()
         askNotificationPermission()
+        loadRewardedAd()
         setContent {
             DayoTheme {
-                MainScreen()
+                MainScreen(
+                    onAdRequest = { onRewardSuccess ->
+                        showAdIfAvailable(onRewardSuccess)
+                    }
+                )
             }
+        }
+    }
+
+    private fun loadRewardedAd() {
+        val adRequest = AdRequest.Builder().build()
+        // TODO 테스트 광고 아이디 변경 필요
+        RewardedAd.load(this, "ca-app-pub-3940256099942544/5224354917", adRequest, object : RewardedAdLoadCallback() {
+            override fun onAdLoaded(ad: RewardedAd) {
+                rewardedAd = ad
+            }
+
+            override fun onAdFailedToLoad(error: LoadAdError) {
+                rewardedAd = null
+            }
+        })
+    }
+
+    private fun showAdIfAvailable(onRewardSuccess: () -> Unit) {
+        rewardedAd?.let { ad ->
+            ad.show(this) {
+                // 광고를 끝까지 봤을 때만 호출됨
+                onRewardSuccess()
+
+                // 광고 다시 로드
+                rewardedAd = null
+                loadRewardedAd()
+            }
+        } ?: run {
+            Log.d("Ad", "The rewarded ad wasn't ready yet.")
+            loadRewardedAd()
         }
     }
 

--- a/presentation/src/main/java/daily/dayo/presentation/common/constant/FolderConstants.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/constant/FolderConstants.kt
@@ -1,0 +1,10 @@
+package daily.dayo.presentation.common.constant
+
+object FolderConstants {
+    const val FOLDER_AD_START_COUNT = 3
+    const val MAX_FOLDER_COUNT = 5
+    const val FOLDER_THUMBNAIL_SIZE = 72
+    const val FOLDER_THUMBNAIL_RADIUS_SIZE = 12
+    const val FOLDER_NAME_MAX_LENGTH = 12
+    const val FOLDER_DESCRIPTION_MAX_LENGTH = 20
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderCreateScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderCreateScreen.kt
@@ -30,6 +30,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import daily.dayo.domain.model.Privacy
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_DESCRIPTION_MAX_LENGTH
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_NAME_MAX_LENGTH
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.createLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.hideLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.resizeDialogFragment
@@ -42,8 +44,6 @@ import daily.dayo.presentation.view.DayoTextField
 import daily.dayo.presentation.view.ToggleButtonWithLabel
 import daily.dayo.presentation.view.TopNavigation
 import daily.dayo.presentation.view.TopNavigationAlign
-import daily.dayo.presentation.viewmodel.FOLDER_DESCRIPTION_MAX_LENGTH
-import daily.dayo.presentation.viewmodel.FOLDER_NAME_MAX_LENGTH
 import daily.dayo.presentation.viewmodel.FolderViewModel
 
 @Composable

--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderEditScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderEditScreen.kt
@@ -31,6 +31,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import daily.dayo.domain.model.FolderInfo
 import daily.dayo.domain.model.Privacy
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_DESCRIPTION_MAX_LENGTH
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_NAME_MAX_LENGTH
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.createLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.hideLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.resizeDialogFragment
@@ -43,8 +45,6 @@ import daily.dayo.presentation.view.DayoTextField
 import daily.dayo.presentation.view.ToggleButtonWithLabel
 import daily.dayo.presentation.view.TopNavigation
 import daily.dayo.presentation.view.TopNavigationAlign
-import daily.dayo.presentation.viewmodel.FOLDER_DESCRIPTION_MAX_LENGTH
-import daily.dayo.presentation.viewmodel.FOLDER_NAME_MAX_LENGTH
 import daily.dayo.presentation.viewmodel.FolderViewModel
 
 @Composable

--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderPostMoveScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderPostMoveScreen.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.flowWithLifecycle
 import daily.dayo.domain.model.Folder
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
-import daily.dayo.presentation.screen.write.MAX_FOLDER_COUNT
+import daily.dayo.presentation.common.constant.FolderConstants.MAX_FOLDER_COUNT
 import daily.dayo.presentation.screen.write.WriteFolderScreen
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.view.FilledRoundedCornerButton

--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderPostMoveScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderPostMoveScreen.kt
@@ -35,6 +35,7 @@ internal fun FolderPostMoveScreen(
     currentFolderId: Long,
     navigateToCreateNewFolder: () -> Unit,
     navigateBackToFolder: () -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     onBackClick: () -> Unit,
     folderViewModel: FolderViewModel = hiltViewModel()
 ) {
@@ -75,6 +76,7 @@ internal fun FolderPostMoveScreen(
             selectedFolder?.let { folderViewModel.moveSelectedPost(it) }
         },
         navigateToCreateNewFolder = navigateToCreateNewFolder,
+        onAdRequest = onAdRequest,
         onBackClick = onBackClick
     )
 }
@@ -87,6 +89,7 @@ private fun FolderPostMoveScreen(
     onFolderClick: (Long, String) -> Unit,
     onPostMoveClick: () -> Unit,
     navigateToCreateNewFolder: () -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     onBackClick: () -> Unit
 ) {
     Scaffold(
@@ -109,7 +112,8 @@ private fun FolderPostMoveScreen(
                 onFolderClick = onFolderClick,
                 navigateToCreateNewFolder = navigateToCreateNewFolder,
                 folders = folders.filterNot { it.folderId == currentFolderId },
-                currentFolderId = selectedFolder
+                currentFolderId = selectedFolder,
+                onAdRequest = onAdRequest
             )
         }
     }
@@ -125,6 +129,7 @@ private fun PreviewFolderPostMoveScreen() {
         onFolderClick = { folderId, folderName -> },
         onPostMoveClick = {},
         navigateToCreateNewFolder = {},
+        onAdRequest = {},
         onBackClick = {}
     )
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
@@ -150,10 +150,11 @@ internal fun MainScreen(
                                     onTagClick = { navigator.navigateWriteTag() },
                                     onWriteFolderClick = { navigator.navigateWriteFolder() },
                                     onWriteFolderNewClick = { navigator.navigateWriteFolderNew() },
+                                    onAdRequest = onAdRequest,
                                     bottomSheetState = bottomSheetState,
                                     bottomSheetContent = { content ->
                                         bottomSheetContent = content
-                                    },
+                                    }
                                 )
                                 myPageNavGraph(
                                     navController = navigator.navController,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
@@ -64,6 +64,7 @@ import daily.dayo.presentation.viewmodel.ProfileViewModel
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 internal fun MainScreen(
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     navigator: MainNavigator = rememberMainNavigator(),
     profileViewModel: ProfileViewModel = hiltViewModel()
 ) {
@@ -185,6 +186,7 @@ internal fun MainScreen(
                                             folderId
                                         )
                                     },
+                                    onAdRequest = onAdRequest,
                                     navigateBackToFolder = { folderId ->
                                         navigator.navigateBackToFolder(
                                             folderId

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
@@ -75,6 +75,7 @@ fun MyPageScreen(
     onBookmarkClick: () -> Unit,
     onFolderClick: (Long) -> Unit,
     onFolderCreateClick: () -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     profileViewModel: ProfileViewModel = hiltViewModel(),
     folderViewModel: FolderViewModel = hiltViewModel()
 ) {
@@ -109,7 +110,12 @@ fun MyPageScreen(
                 item(span = { GridItemSpan(2) }) {
                     MyPageDiaryHeader(
                         isCreateFolderEnabled = folderList.value?.data?.size?.let { it < MAX_FOLDER_COUNT } ?: false,
-                        onFolderCreateClick = onFolderCreateClick
+                        onFolderCreateClick = {
+                            // 광고 보기
+                            onAdRequest {
+                                onFolderCreateClick()
+                            }
+                        }
                     )
                 }
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
@@ -48,8 +48,9 @@ import daily.dayo.domain.model.Profile
 import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_AD_START_COUNT
+import daily.dayo.presentation.common.constant.FolderConstants.MAX_FOLDER_COUNT
 import daily.dayo.presentation.common.extension.clickableSingle
-import daily.dayo.presentation.screen.write.MAX_FOLDER_COUNT
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -81,6 +82,8 @@ fun MyPageScreen(
 ) {
     val profileInfo = profileViewModel.profileInfo.observeAsState()
     val folderList = folderViewModel.folderList.observeAsState()
+    val folderCount = folderList.value?.data?.size ?: 0
+    val shouldShowAd = folderCount + 1 in FOLDER_AD_START_COUNT..MAX_FOLDER_COUNT
 
     LaunchedEffect(Unit) {
         profileViewModel.requestMyProfile()
@@ -112,7 +115,11 @@ fun MyPageScreen(
                         isCreateFolderEnabled = folderList.value?.data?.size?.let { it < MAX_FOLDER_COUNT } ?: false,
                         onFolderCreateClick = {
                             // 광고 보기
-                            onAdRequest {
+                            if (shouldShowAd) {
+                                onAdRequest {
+                                    onFolderCreateClick()
+                                }
+                            } else {
                                 onFolderCreateClick()
                             }
                         }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
@@ -13,7 +13,6 @@ import daily.dayo.presentation.screen.folder.FolderEditScreen
 import daily.dayo.presentation.screen.folder.FolderPostMoveScreen
 import daily.dayo.presentation.screen.folder.FolderScreen
 import daily.dayo.presentation.screen.settings.BlockedUsersScreen
-import kotlinx.coroutines.CoroutineScope
 
 fun NavController.navigateMyPage() {
     navigate(MyPageRoute.route) {
@@ -75,6 +74,7 @@ fun NavGraphBuilder.myPageNavGraph(
     onFolderEditClick: (Long) -> Unit,
     onPostClick: (Long) -> Unit,
     onPostMoveClick: (Long) -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     navigateBackToFolder: (Long) -> Unit
 ) {
     composable(MyPageRoute.route) {
@@ -84,7 +84,8 @@ fun NavGraphBuilder.myPageNavGraph(
             onProfileEditClick = onProfileEditClick,
             onBookmarkClick = onBookmarkClick,
             onFolderClick = onFolderClick,
-            onFolderCreateClick = onFolderCreateClick
+            onFolderCreateClick = onFolderCreateClick,
+            onAdRequest = onAdRequest
         )
     }
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
@@ -187,6 +187,7 @@ fun NavGraphBuilder.myPageNavGraph(
                 currentFolderId = folderId,
                 navigateToCreateNewFolder = onFolderCreateClick,
                 navigateBackToFolder = { navigateBackToFolder(folderId) },
+                onAdRequest = onAdRequest,
                 onBackClick = onBackClick,
                 folderViewModel = hiltViewModel(parentStackEntry)
             )

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
@@ -68,6 +68,7 @@ const val FOLDER_THUMBNAIL_RADIUS_SIZE = 12
 fun WriteFolderRoute(
     onBackClick: () -> Unit,
     onWriteFolderNewClick: () -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     writeViewModel: WriteViewModel = hiltViewModel(),
     accountViewModel: AccountViewModel = hiltViewModel(),
     profileViewModel: ProfileViewModel = hiltViewModel(),
@@ -93,7 +94,8 @@ fun WriteFolderRoute(
         },
         navigateToCreateNewFolder = { onWriteFolderNewClick() },
         folders = folders.data.orEmpty(),
-        currentFolderId = folderId
+        currentFolderId = folderId,
+        onAdRequest = onAdRequest
     )
 
 }
@@ -106,6 +108,7 @@ fun WriteFolderScreen(
     navigateToCreateNewFolder: () -> Unit,
     folders: List<Folder>,
     currentFolderId: Long?,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit
 ) {
     Surface(
         color = White_FFFFFF,
@@ -122,7 +125,8 @@ fun WriteFolderScreen(
                 onFolderClick = onFolderClick,
                 navigateToCreateNewFolder = navigateToCreateNewFolder,
                 folders = folders,
-                currentFolderId = currentFolderId
+                currentFolderId = currentFolderId,
+                onAdRequest = onAdRequest
             )
         }
     }
@@ -152,6 +156,7 @@ fun WriteFolderContent(
     navigateToCreateNewFolder: () -> Unit = {},
     folders: List<Folder> = emptyList(),
     currentFolderId: Long? = null,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -160,7 +165,8 @@ fun WriteFolderContent(
     ) {
         if (showCreateFolder) {
             WriteFolderNewLayout(
-                navigateToCreateNewFolder = navigateToCreateNewFolder
+                navigateToCreateNewFolder = navigateToCreateNewFolder,
+                onAdRequest = onAdRequest
             )
             Spacer(
                 modifier = Modifier
@@ -179,14 +185,20 @@ fun WriteFolderContent(
 @Preview
 @Composable
 fun WriteFolderNewLayout(
-    navigateToCreateNewFolder: () -> Unit = {}
+    navigateToCreateNewFolder: () -> Unit = {},
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(FOLDER_THUMBNAIL_SIZE.dp)
             .background(White_FFFFFF)
-            .clickableSingle { navigateToCreateNewFolder() },
+            .clickableSingle {
+                // 광고 보기
+                onAdRequest {
+                    navigateToCreateNewFolder()
+                }
+            }
     ) {
         Image(
             contentDescription = "new folderThumbnail",

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
@@ -44,6 +44,10 @@ import daily.dayo.domain.model.Folder
 import daily.dayo.domain.model.Privacy
 import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_AD_START_COUNT
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_THUMBNAIL_RADIUS_SIZE
+import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_THUMBNAIL_SIZE
+import daily.dayo.presentation.common.constant.FolderConstants.MAX_FOLDER_COUNT
 import daily.dayo.presentation.common.extension.clickableSingle
 import daily.dayo.presentation.common.extension.limitTo
 import daily.dayo.presentation.theme.Dark
@@ -59,10 +63,6 @@ import daily.dayo.presentation.view.TopNavigationAlign
 import daily.dayo.presentation.viewmodel.AccountViewModel
 import daily.dayo.presentation.viewmodel.ProfileViewModel
 import daily.dayo.presentation.viewmodel.WriteViewModel
-
-const val MAX_FOLDER_COUNT = 5
-const val FOLDER_THUMBNAIL_SIZE = 72
-const val FOLDER_THUMBNAIL_RADIUS_SIZE = 12
 
 @Composable
 fun WriteFolderRoute(
@@ -165,6 +165,7 @@ fun WriteFolderContent(
     ) {
         if (showCreateFolder) {
             WriteFolderNewLayout(
+                shouldShowAd = folders.size + 1 in FOLDER_AD_START_COUNT..MAX_FOLDER_COUNT,
                 navigateToCreateNewFolder = navigateToCreateNewFolder,
                 onAdRequest = onAdRequest
             )
@@ -182,10 +183,10 @@ fun WriteFolderContent(
     }
 }
 
-@Preview
 @Composable
 fun WriteFolderNewLayout(
-    navigateToCreateNewFolder: () -> Unit = {},
+    shouldShowAd: Boolean,
+    navigateToCreateNewFolder: () -> Unit,
     onAdRequest: (onRewardSuccess: () -> Unit) -> Unit
 ) {
     Row(
@@ -195,7 +196,11 @@ fun WriteFolderNewLayout(
             .background(White_FFFFFF)
             .clickableSingle {
                 // 광고 보기
-                onAdRequest {
+                if (shouldShowAd) {
+                    onAdRequest {
+                        navigateToCreateNewFolder()
+                    }
+                } else {
                     navigateToCreateNewFolder()
                 }
             }
@@ -343,4 +348,14 @@ fun WriteFolderItemLayout(
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun PreviewWriteFolderNewLayout() {
+    WriteFolderNewLayout(
+        shouldShowAd = false,
+        navigateToCreateNewFolder = {},
+        onAdRequest = {}
+    )
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteNavigation.kt
@@ -1,6 +1,5 @@
 package daily.dayo.presentation.screen.write
 
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -22,11 +21,11 @@ fun NavController.navigateWriteTag() {
 fun NavController.navigateWriteFolder() {
     navigate(WriteRoute.folder)
 }
+
 fun NavController.navigateWriteFolderNew() {
     navigate(WriteRoute.folderNew)
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 fun NavGraphBuilder.writeNavGraph(
     snackBarHostState: SnackbarHostState,
     navController: NavController,
@@ -34,6 +33,7 @@ fun NavGraphBuilder.writeNavGraph(
     onTagClick: () -> Unit,
     onWriteFolderClick: () -> Unit,
     onWriteFolderNewClick: () -> Unit,
+    onAdRequest: (onRewardSuccess: () -> Unit) -> Unit,
     bottomSheetState: ModalBottomSheetState,
     bottomSheetContent: (@Composable () -> Unit) -> Unit,
 ) {
@@ -73,6 +73,7 @@ fun NavGraphBuilder.writeNavGraph(
             WriteFolderRoute(
                 onBackClick = onBackClick,
                 onWriteFolderNewClick = onWriteFolderNewClick,
+                onAdRequest = onAdRequest,
                 writeViewModel = hiltViewModel(parentStackEntry),
                 profileViewModel = hiltViewModel(parentStackEntry),
                 accountViewModel = hiltViewModel(parentStackEntry),

--- a/presentation/src/main/java/daily/dayo/presentation/viewmodel/FolderViewModel.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/viewmodel/FolderViewModel.kt
@@ -269,6 +269,3 @@ val DEFAULT_FOLDER_INFO = FolderInfo(
     subheading = "",
     thumbnailImage = ""
 )
-
-const val FOLDER_NAME_MAX_LENGTH = 12
-const val FOLDER_DESCRIPTION_MAX_LENGTH = 20


### PR DESCRIPTION
## 작업 내용
- 폴더 관련 상수 파일 분리
- 3~5번째 폴더 생성 시 광고를 끝까지 봐야 폴더 생성 가능
- 테스트광고 아이디와 실제 광고 아이디를 빌드 타입에 따라 분리
  - 저장소에 `local.properties` 수정해두었습니다 

## 참고
- resolved : #675 