### PR TITLE
Update Image Upload Flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,9 +73,6 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
-        <activity
-            android:name="com.canhub.cropper.CropImageActivity"
-            android:theme="@style/Base.Theme.AppCompat"/>
     </application>
 
 </manifest>

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -255,6 +255,4 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2"
 
 //    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.12'
-    // Image Cropper
-    implementation("com.vanniktech:android-image-cropper:4.6.0")
 }

--- a/presentation/src/main/java/daily/dayo/presentation/common/image/ImageOrientationUtil.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/image/ImageOrientationUtil.kt
@@ -1,0 +1,42 @@
+package daily.dayo.presentation.common.image
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+
+data class ExifInfo(
+    val orientation: Int,
+    val rotationDegrees: Int,
+    val flipX: Boolean,
+    val flipY: Boolean
+)
+
+fun ContentResolver.readExifInfo(uri: Uri): ExifInfo {
+    openFileDescriptor(uri, "r")?.use { pfd ->
+        val exif = ExifInterface(pfd.fileDescriptor)
+        val o = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        return when (o) {
+            ExifInterface.ORIENTATION_ROTATE_90   -> ExifInfo(o, 90,  false, false)
+            ExifInterface.ORIENTATION_ROTATE_180  -> ExifInfo(o, 180, false, false)
+            ExifInterface.ORIENTATION_ROTATE_270  -> ExifInfo(o, 270, false, false)
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> ExifInfo(o, 0, true,  false)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL   -> ExifInfo(o, 0, false, true)
+            ExifInterface.ORIENTATION_TRANSPOSE   -> ExifInfo(o, 90,  true,  false)  // flipH + rot90
+            ExifInterface.ORIENTATION_TRANSVERSE  -> ExifInfo(o, 270, true,  false)  // flipH + rot270
+            else -> ExifInfo(ExifInterface.ORIENTATION_NORMAL, 0, false, false)
+        }
+    }
+    return ExifInfo(ExifInterface.ORIENTATION_UNDEFINED, 0, false, false)
+}
+
+fun Bitmap.applyExif(exif: ExifInfo): Bitmap {
+    if (exif.rotationDegrees == 0 && !exif.flipX && !exif.flipY) return this
+    val m = Matrix()
+    // flip 먼저
+    if (exif.flipX || exif.flipY) m.preScale(if (exif.flipX) -1f else 1f, if (exif.flipY) -1f else 1f)
+    // 회전
+    if (exif.rotationDegrees != 0) m.postRotate(exif.rotationDegrees.toFloat())
+    return Bitmap.createBitmap(this, 0, 0, width, height, m, true)
+}

--- a/presentation/src/main/java/daily/dayo/presentation/common/image/ImageSamplingUtils.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/image/ImageSamplingUtils.kt
@@ -1,0 +1,51 @@
+package daily.dayo.presentation.common.image
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+
+/**
+ *  OOM 방지를 위해 URI와 목표 사이즈를 받아 최적화된 비트맵을 로드하는 함수
+ **/
+fun decodeSampledBitmapFromUri(
+    contentResolver: ContentResolver,
+    uri: Uri,
+    reqWidth: Int,
+    reqHeight: Int
+): Bitmap? {
+    // inJustDecodeBounds = true 로 설정해 이미지의 실제 크기만 확인 (메모리 할당 X)
+    val options = BitmapFactory.Options().apply {
+        inJustDecodeBounds = true
+    }
+    contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
+    // 최적의 inSampleSize 계산
+    options.inSampleSize = calculateInSampleSize(options, reqWidth, reqHeight)
+
+    // 계산된 inSampleSize로 실제 비트맵 디코딩 (메모리 할당 O)
+    options.inJustDecodeBounds = false
+    return contentResolver.openInputStream(uri)
+        ?.use { BitmapFactory.decodeStream(it, null, options) }
+}
+
+/**
+ *  최적의 inSampleSize 값을 계산하는 헬퍼 함수
+ */
+private fun calculateInSampleSize(
+    options: BitmapFactory.Options,
+    reqWidth: Int,
+    reqHeight: Int
+): Int {
+    val (height: Int, width: Int) = options.run { outHeight to outWidth }
+    var inSampleSize = 1
+
+    if (height > reqHeight || width > reqWidth) {
+        val halfHeight: Int = height / 2
+        val halfWidth: Int = width / 2
+        // requested size보다 크기가 작아지지 않는 가장 큰 inSampleSize 값을 찾는다. (2의 거듭제곱)
+        while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+    return inSampleSize
+}

--- a/presentation/src/main/java/daily/dayo/presentation/common/image/ImageSamplingUtils.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/image/ImageSamplingUtils.kt
@@ -24,8 +24,14 @@ fun decodeSampledBitmapFromUri(
 
     // 계산된 inSampleSize로 실제 비트맵 디코딩 (메모리 할당 O)
     options.inJustDecodeBounds = false
-    return contentResolver.openInputStream(uri)
+    val bitmap = contentResolver.openInputStream(uri)
         ?.use { BitmapFactory.decodeStream(it, null, options) }
+    
+    // EXIF 정보를 읽어서 이미지를 올바르게 회전
+    return bitmap?.let { bmp ->
+        val exifInfo = contentResolver.readExifInfo(uri)
+        bmp.applyExif(exifInfo)
+    }
 }
 
 /**

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropScreen.kt
@@ -335,8 +335,6 @@ private fun ImageCropActionbarLayout(
             DayoTextButton(
                 onClick = {
                     if (isCropEnabled) onCropClick()
-                    else {
-                    }
                 },
                 text = stringResource(R.string.complete),
                 textStyle = DayoTheme.typography.b3.copy(

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropScreen.kt
@@ -1,0 +1,340 @@
+package daily.dayo.presentation.screen.write
+
+import android.graphics.Bitmap
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import daily.dayo.presentation.R
+import daily.dayo.presentation.common.image.decodeSampledBitmapFromUri
+import daily.dayo.presentation.theme.Dark
+import daily.dayo.presentation.theme.DayoTheme
+import daily.dayo.presentation.view.DayoTextButton
+import daily.dayo.presentation.view.NoRippleIconButton
+import daily.dayo.presentation.view.TopNavigation
+import daily.dayo.presentation.view.TopNavigationAlign
+import daily.dayo.presentation.viewmodel.WriteViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+@Composable
+fun ImageCropScreen(
+    navController: NavController,
+    viewModel: WriteViewModel,
+    imageIndex: Int,
+    onBackClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val imageAssets by viewModel.writeImagesUri.collectAsState()
+    val imageAsset = imageAssets.getOrNull(imageIndex)
+
+    var containerSize by remember { mutableStateOf<IntSize?>(null) }
+    var stateHolder by remember { mutableStateOf<ImageCropStateHolder?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.errorEvent.collect { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    // Uri로부터 비동기적으로 비트맵 로드 (로딩 상태 처리)
+    val bitmapState =
+        produceState<Bitmap?>(initialValue = null, key1 = imageAsset, key2 = containerSize) {
+            // containerSize가 정해진 후에야 이 블록이 실행됨
+            if (imageAsset != null && containerSize != null) {
+                value = withContext(Dispatchers.IO) {
+                    // 이미지를 직접 가져오지 않고, 기기에 맞게 디코딩해서 가져옴
+                    decodeSampledBitmapFromUri(
+                        context.contentResolver,
+                        Uri.parse(imageAsset.uriString),
+                        containerSize!!.width,
+                        containerSize!!.height
+                    )
+                }
+            } else {
+                null
+            }
+        }
+    val sampledBitmap = bitmapState.value
+
+    // 이미지 로드 실패 또는 Uri가 없는 경우 처리
+    if (imageAsset == null) {
+        LaunchedEffect(Unit) { onBackClick() }
+        return
+    }
+
+    // 비트맵과 컨테이너 사이즈가 준비되면 stateHolder를 생성
+    LaunchedEffect(sampledBitmap, containerSize) {
+        if (sampledBitmap != null && containerSize != null) {
+            stateHolder = ImageCropStateHolder(
+                originalBitmap = sampledBitmap,
+                containerSize = containerSize!!
+            )
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            ImageCropActionbarLayout(
+                onBackClick = onBackClick,
+                isCropEnabled = stateHolder != null,
+                onCropClick = {
+                    stateHolder?.let { holder ->
+                        scope.launch {
+                            viewModel.cropImageAndUpdate(imageIndex, holder)
+                            navController.popBackStack()
+                        }
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Surface(modifier = Modifier.padding(innerPadding)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(DayoTheme.colorScheme.background)
+                    .onSizeChanged { containerSize = it },
+                contentAlignment = Alignment.Center
+            ) {
+                // stateHolder의 존재 여부에 따라 로딩 UI 또는 Crop UI를 표시
+                stateHolder?.let { holder ->
+                    Image(
+                        bitmap = sampledBitmap!!.asImageBitmap(),
+                        contentDescription = stringResource(id = R.string.write_post_image_edit),
+                        contentScale = ContentScale.FillWidth,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height((holder.imageHeight / LocalDensity.current.density).dp)
+                    )
+                    ImageCropCanvas(stateHolder = holder)
+                } ?: run {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageCropCanvas(stateHolder: ImageCropStateHolder) {
+    val cropProperties by stateHolder.cropProperties
+
+    // 두 손가락 제스처와 4개의 모서리를 드래그 하는 제스처의 동시 발생을 방지를 위한 리사이징 진행중 FLag
+    var isResizing by remember { mutableStateOf(false) }
+
+    val dimPath = remember(cropProperties) {
+        Path().apply {
+            val cropRect = Rect(
+                offset = cropProperties.cropOffset,
+                size = Size(cropProperties.cropSize, cropProperties.cropSize)
+            )
+            addRect(
+                Rect(
+                    left = 0f,
+                    top = stateHolder.imageTop,
+                    right = stateHolder.imageWidth,
+                    bottom = stateHolder.imageTop + stateHolder.imageHeight
+                )
+            )
+            addRect(cropRect)
+            fillType = PathFillType.EvenOdd
+        }
+    }
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    if (!isResizing) {
+                        stateHolder.handleTransform(pan, zoom)
+                    }
+                }
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val cropRect = Rect(
+                offset = cropProperties.cropOffset,
+                size = Size(cropProperties.cropSize, cropProperties.cropSize)
+            )
+
+            // Dimmed Background
+            drawPath(path = dimPath, color = Color.Black.copy(alpha = 0.4f))
+
+            // Grid lines
+            val guideLineColor = Color.White.copy(alpha = 0.5f)
+            val strokeWidth = 1.dp.toPx()
+            val third = cropProperties.cropSize / 3
+            drawLine(
+                guideLineColor,
+                Offset(cropRect.left + third, cropRect.top),
+                Offset(cropRect.left + third, cropRect.bottom),
+                strokeWidth
+            )
+            drawLine(
+                guideLineColor,
+                Offset(cropRect.left + 2 * third, cropRect.top),
+                Offset(cropRect.left + 2 * third, cropRect.bottom),
+                strokeWidth
+            )
+            drawLine(
+                guideLineColor,
+                Offset(cropRect.left, cropRect.top + third),
+                Offset(cropRect.right, cropRect.top + third),
+                strokeWidth
+            )
+            drawLine(
+                guideLineColor,
+                Offset(cropRect.left, cropRect.top + 2 * third),
+                Offset(cropRect.right, cropRect.top + 2 * third),
+                strokeWidth
+            )
+
+            drawRect(
+                guideLineColor,
+                topLeft = cropRect.topLeft,
+                size = cropRect.size,
+                style = Stroke(width = 2.dp.toPx())
+            )
+        }
+
+        CropHandles(
+            cropProperties = cropProperties,
+            onResizeStart = { isResizing = true },
+            onResizeEnd = { isResizing = false },
+            onDrag = { corner, dragAmount -> stateHolder.handleCornerDrag(corner, dragAmount) }
+        )
+    }
+}
+
+@Composable
+private fun CropHandles(
+    cropProperties: CropProperties,
+    onResizeStart: () -> Unit,
+    onResizeEnd: () -> Unit,
+    onDrag: (Corner, Offset) -> Unit
+) {
+    val density = LocalDensity.current
+    val handleSizeDp = 32.dp
+    val handleRadiusPx = with(density) { (handleSizeDp / 2).toPx() }
+
+    Corner.values().forEach { corner ->
+        val position = Offset(
+            x = cropProperties.cropOffset.x + if (corner.isLeft()) 0f else cropProperties.cropSize,
+            y = cropProperties.cropOffset.y + if (corner.isTop()) 0f else cropProperties.cropSize
+        )
+
+        Box(
+            modifier = Modifier
+                .offset {
+                    IntOffset(
+                        (position.x - handleRadiusPx).roundToInt(),
+                        (position.y - handleRadiusPx).roundToInt()
+                    )
+                }
+                .size(handleSizeDp)
+                .pointerInput(corner) {
+                    detectDragGestures(
+                        onDragStart = { onResizeStart() },
+                        onDragEnd = { onResizeEnd() },
+                        onDragCancel = { onResizeEnd() }
+                    ) { change, dragAmount ->
+                        change.consume()
+                        onDrag(corner, dragAmount)
+                    }
+                }
+        ) {
+            Canvas(Modifier.fillMaxSize()) {
+                val center = size.toRect().center
+                val stroke = 3.dp.toPx()
+                val length = min(cropProperties.cropSize * 0.1f, 20.dp.toPx())
+
+                val hSign = if (corner.isLeft()) 1f else -1f
+                val vSign = if (corner.isTop()) 1f else -1f
+
+                drawLine(
+                    Color.White,
+                    start = center,
+                    end = Offset(center.x + (length * hSign), center.y),
+                    strokeWidth = stroke
+                )
+                drawLine(
+                    Color.White,
+                    start = center,
+                    end = Offset(center.x, center.y + (length * vSign)),
+                    strokeWidth = stroke
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageCropActionbarLayout(
+    onBackClick: () -> Unit,
+    isCropEnabled: Boolean,
+    onCropClick: () -> Unit,
+) {
+    TopNavigation(
+        leftIcon = {
+            NoRippleIconButton(
+                onClick = onBackClick,
+                iconContentDescription = stringResource(R.string.back_sign),
+                iconPainter = painterResource(id = R.drawable.ic_arrow_left),
+            )
+        },
+        title = stringResource(R.string.write_post_image_crop_title),
+        rightIcon = {
+            DayoTextButton(
+                onClick = {
+                    if (isCropEnabled) onCropClick()
+                    else {
+                    }
+                },
+                text = stringResource(R.string.complete),
+                textStyle = DayoTheme.typography.b3.copy(
+                    textAlign = TextAlign.Center,
+                    color = Dark
+                ),
+                modifier = Modifier.padding(10.dp),
+            )
+        },
+        titleAlignment = TopNavigationAlign.CENTER,
+    )
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropStateHolder.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropStateHolder.kt
@@ -5,11 +5,13 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
+import daily.dayo.presentation.common.image.ExifInfo
 import kotlin.math.min
 
 data class ImageAsset(
     val uriString: String,
-    val lastModified: Long = System.currentTimeMillis()
+    val lastModified: Long = System.currentTimeMillis(),
+    val exifInfo: ExifInfo? = null
 )
 
 data class CropProperties(
@@ -20,7 +22,8 @@ data class CropProperties(
 class ImageCropStateHolder(
     private val originalBitmap: Bitmap,
     private val containerSize: IntSize,
-    private val minCropSize: Float = 100f
+    private val minCropSize: Float = 100f,
+    val exifInfo: ExifInfo? = null
 ) {
     private val _cropProperties = mutableStateOf(CropProperties())
     val cropProperties: State<CropProperties> = _cropProperties

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropStateHolder.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/ImageCropStateHolder.kt
@@ -1,0 +1,102 @@
+package daily.dayo.presentation.screen.write
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.min
+
+data class ImageAsset(
+    val uriString: String,
+    val lastModified: Long = System.currentTimeMillis()
+)
+
+data class CropProperties(
+    val cropSize: Float = 0f,
+    val cropOffset: Offset = Offset.Zero
+)
+
+class ImageCropStateHolder(
+    private val originalBitmap: Bitmap,
+    private val containerSize: IntSize,
+    private val minCropSize: Float = 100f
+) {
+    private val _cropProperties = mutableStateOf(CropProperties())
+    val cropProperties: State<CropProperties> = _cropProperties
+
+    private val imageAspectRatio = originalBitmap.height.toFloat() / originalBitmap.width
+    val imageWidth = containerSize.width.toFloat()
+    val imageHeight = imageWidth * imageAspectRatio
+    val imageTop = (containerSize.height - imageHeight) / 2f
+    private val maxCropSize = min(imageWidth, imageHeight)
+
+    init {
+        val initialSize = min(imageWidth, imageHeight) * 0.8f
+        _cropProperties.value = CropProperties(
+            cropSize = initialSize,
+            cropOffset = Offset(
+                x = (imageWidth - initialSize) / 2f,
+                y = imageTop + (imageHeight - initialSize) / 2f
+            )
+        )
+    }
+
+    // 두 손가락으로 그리드를 확대/축소하고 이동하는 제스처 처리
+    fun handleTransform(pan: Offset, zoom: Float) {
+        val currentSize = _cropProperties.value.cropSize
+        val currentOffset = _cropProperties.value.cropOffset
+
+        val newSize = (currentSize * zoom).coerceIn(minCropSize, maxCropSize)
+        val sizeDelta = (newSize - currentSize) / 2f
+
+        val newOffsetX = (currentOffset.x - sizeDelta + pan.x)
+            .coerceIn(0f, imageWidth - newSize)
+        val newOffsetY = (currentOffset.y - sizeDelta + pan.y)
+            .coerceIn(imageTop, imageTop + imageHeight - newSize)
+
+        _cropProperties.value =
+            CropProperties(cropSize = newSize, cropOffset = Offset(newOffsetX, newOffsetY))
+    }
+
+    // 각 그리드 모서리 드래그 제스처 처리
+    fun handleCornerDrag(corner: Corner, dragAmount: Offset) {
+        val currentSize = _cropProperties.value.cropSize
+        val currentOffset = _cropProperties.value.cropOffset
+
+        val newSize = when (corner) {
+            Corner.TOP_LEFT, Corner.TOP_RIGHT, Corner.BOTTOM_LEFT, Corner.BOTTOM_RIGHT -> {
+                val potentialSizeX =
+                    if (corner.isLeft()) currentSize - dragAmount.x else currentSize + dragAmount.x
+                val potentialSizeY =
+                    if (corner.isTop()) currentSize - dragAmount.y else currentSize + dragAmount.y
+                min(potentialSizeX, potentialSizeY).coerceIn(minCropSize, maxCropSize)
+            }
+        }
+
+        val newOffset = when (corner) {
+            Corner.TOP_LEFT -> Offset(
+                currentOffset.x + (currentSize - newSize),
+                currentOffset.y + (currentSize - newSize)
+            )
+
+            Corner.TOP_RIGHT -> Offset(currentOffset.x, currentOffset.y + (currentSize - newSize))
+            Corner.BOTTOM_LEFT -> Offset(currentOffset.x + (currentSize - newSize), currentOffset.y)
+            Corner.BOTTOM_RIGHT -> currentOffset
+        }
+
+        val finalSize = newSize.coerceIn(minCropSize, maxCropSize)
+        val finalOffset = Offset(
+            x = newOffset.x.coerceIn(0f, imageWidth - finalSize),
+            y = newOffset.y.coerceIn(imageTop, imageTop + imageHeight - finalSize)
+        )
+        _cropProperties.value = CropProperties(cropSize = finalSize, cropOffset = finalOffset)
+    }
+}
+
+enum class Corner {
+    TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT;
+
+    fun isLeft(): Boolean = this == TOP_LEFT || this == BOTTOM_LEFT
+    fun isTop(): Boolean = this == TOP_LEFT || this == TOP_RIGHT
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteScreen.kt
@@ -383,11 +383,12 @@ fun WriteUploadImages(
         ) { index, imageAsset ->
             val context = LocalContext.current
 
-            // 캐시 키를 uri및 마지막 수정시간으로 지정해 이미지 편집하는 경우 갱신될수 있도록 수정
+            // 캐시 키를 uri, 수정시간, EXIF 정보로 지정해 이미지 편집하는 경우 갱신될수 있도록 수정
+            val cacheKey = "${imageAsset.uriString}-${imageAsset.lastModified}-${imageAsset.exifInfo?.orientation ?: "none"}"
             val imageRequest = ImageRequest.Builder(context)
                 .data(imageAsset.uriString)
-                .memoryCacheKey("${imageAsset.uriString}-${imageAsset.lastModified}")
-                .diskCacheKey("${imageAsset.uriString}-${imageAsset.lastModified}")
+                .memoryCacheKey(cacheKey)
+                .diskCacheKey(cacheKey)
                 .crossfade(true)
                 .build()
 

--- a/presentation/src/main/java/daily/dayo/presentation/viewmodel/WriteViewModel.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/viewmodel/WriteViewModel.kt
@@ -5,7 +5,10 @@ import android.content.ContentResolver
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.BitmapRegionDecoder
+import android.graphics.Rect
 import android.net.Uri
+import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -27,19 +30,28 @@ import daily.dayo.presentation.common.Event
 import daily.dayo.presentation.common.ListLiveData
 import daily.dayo.presentation.common.Resource
 import daily.dayo.presentation.common.Status
+import daily.dayo.presentation.common.image.ImageResizeUtil.POST_IMAGE_RESIZE_SIZE
 import daily.dayo.presentation.common.image.ImageResizeUtil.cropCenterBitmap
 import daily.dayo.presentation.common.image.ImageResizeUtil.resizeBitmap
 import daily.dayo.presentation.common.toFile
+import daily.dayo.presentation.screen.write.ImageAsset
+import daily.dayo.presentation.screen.write.ImageCropStateHolder
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @SuppressLint("StaticFieldLeak")
 @HiltViewModel
@@ -56,6 +68,9 @@ class WriteViewModel @Inject constructor(
 
     // Show Dialog
     val showWriteOptionDialog = MutableLiveData<Event<Boolean>>()
+
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent = _errorEvent.asSharedFlow()
 
     // WriteInfo
     private val _postId = MutableLiveData(0L)
@@ -76,12 +91,8 @@ class WriteViewModel @Inject constructor(
     val writeFolderId get() = _writeFolderId
     private val _writeFolderName = MutableStateFlow(null as String?)
     val writeFolderName get() = _writeFolderName
-    private val _postImageUriList = ListLiveData<String>() // 갤러리에서 불러온 이미지 리스트
-    val postImageUriList get() = _postImageUriList
-    val writeImagesUri get() = _writeImagesUri.asStateFlow()
-    private val _writeImagesUri = MutableStateFlow(emptyList<String>())
-    val writeImages get() = _writeImages.asStateFlow()
-    private val _writeImages = MutableStateFlow(emptyList<Bitmap>())
+    private val _writeImagesUri = MutableStateFlow<List<ImageAsset>>(emptyList())
+    val writeImagesUri = _writeImagesUri.asStateFlow()
     private val _postTagList = ListLiveData<String>()
     val postTagList: ListLiveData<String> get() = _postTagList
     private val _writeTags = MutableStateFlow(emptyList<String>())
@@ -125,30 +136,53 @@ class WriteViewModel @Inject constructor(
             return "${applicationContext.cacheDir}/$fileName"
         }
 
+    /**
+     * 새 게시글 업로드
+     * 업로드 시점에만 Uri로부터 Bitmap을 로드하여 사용 (OOM 방지)
+     */
     private fun requestUploadNewPost() = viewModelScope.launch(Dispatchers.IO) {
         _uploadSuccess.emit(Status.LOADING)
-        val resizedImages =
-            writeImages.value.map { item -> item.cropCenterBitmap().toFile(uploadImagePath) }
-        resizedImages.let {
-            requestUploadPostUseCase(
-                category = writeCategory.value.first!!,
-                contents = writeText.value,
-                files = it.toTypedArray(),
-                folderId = writeFolderId.value ?: 0L,
-                tags = if (writeTags.value.isNotEmpty()) writeTags.value.toTypedArray() else emptyArray()
-            ).let { ApiResponse ->
-                when (ApiResponse) {
-                    is NetworkResponse.Success -> {
-                        _uploadSuccess.emit(Status.SUCCESS)
-                    }
+        val imageFiles = _writeImagesUri.value.mapNotNull { imageAsset ->
+            // 각 Uri로부터 비트맵을 열고, 리사이즈하고, 파일로 변환
+            applicationContext.contentResolver.openInputStream(Uri.parse(imageAsset.uriString))
+                ?.use { inputStream ->
+                    val bitmap = BitmapFactory.decodeStream(inputStream)
+                    val resizedBitmap = resizeBitmap(
+                        bitmap.cropCenterBitmap(),
+                        POST_IMAGE_RESIZE_SIZE,
+                        POST_IMAGE_RESIZE_SIZE
+                    )
+                    val file = resizedBitmap.toFile(uploadImagePath)
+                    bitmap.recycle()
+                    resizedBitmap.recycle()
+                    file
+                }
+        }
 
-                    else -> {
-                        _uploadSuccess.emit(Status.ERROR)
-                    }
+        if (imageFiles.isEmpty() && _writeImagesUri.value.isNotEmpty()) {
+            _errorEvent.emit("이미지를 파일로 변환하는 데 실패했습니다.")
+            _uploadSuccess.emit(Status.ERROR)
+            return@launch
+        }
+
+        requestUploadPostUseCase(
+            category = writeCategory.value.first!!,
+            contents = writeText.value,
+            files = imageFiles.toTypedArray(),
+            folderId = writeFolderId.value ?: 0L,
+            tags = if (writeTags.value.isNotEmpty()) writeTags.value.toTypedArray() else emptyArray()
+        ).let { apiResponse ->
+            when (apiResponse) {
+                is NetworkResponse.Success -> {
+                    _uploadSuccess.emit(Status.SUCCESS)
                 }
-                if (ApiResponse is NetworkResponse.Success) {
-                    _writePostId.postValue(ApiResponse.body?.let { Event(it.id) })
+
+                else -> {
+                    _uploadSuccess.emit(Status.ERROR)
                 }
+            }
+            if (apiResponse is NetworkResponse.Success) {
+                _writePostId.postValue(apiResponse.body?.let { Event(it.id) })
             }
         }
     }
@@ -166,41 +200,6 @@ class WriteViewModel @Inject constructor(
                 _writePostId.postValue(ApiResponse.body?.let { Event(it.postId) })
             }
         }
-    }
-
-    fun requestPostDetail(postId: Long) = viewModelScope.launch(Dispatchers.IO) {
-        withContext(Dispatchers.Main) {
-            resetWriteInfoValue()
-            requestPostDetailUseCase(postId = postId)
-        }.let { ApiResponse ->
-            if (ApiResponse is NetworkResponse.Success) {
-                ApiResponse.body.let { postDetail ->
-                    postDetail?.let {
-                        withContext(Dispatchers.Main) {
-                            setOriginalPostDetail(postDetail)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun setOriginalPostDetail(postDetail: PostDetail) = viewModelScope.launch {
-        _writeCurrentPostDetail.postValue(postDetail)
-        postDetail.images.map { element ->
-            addUploadImage(
-                Uri.parse("${BuildConfig.BASE_URL}/images/$element")
-                    .toString(),
-                true
-            )
-        }
-
-        postDetail.hashtags.let { _postTagList.addAll(it, false) }
-        postDetail.hashtags.let { _writeTags.emit(it) }
-        _postFolderId.postValue(postDetail.folderId)
-        _postFolderName.postValue(postDetail.folderName)
-        _writeFolderId.emit(postDetail.folderId)
-        _writeFolderName.emit(postDetail.folderName)
     }
 
     fun requestAllMyFolderList() = viewModelScope.launch(Dispatchers.IO) {
@@ -244,6 +243,9 @@ class WriteViewModel @Inject constructor(
             }
         }
 
+    /**
+     * 상태 초기화
+     */
     fun resetWriteInfoValue() = viewModelScope.launch {
         _postId.postValue(0)
         _postContents.postValue("")
@@ -251,12 +253,9 @@ class WriteViewModel @Inject constructor(
         _postFolderName.postValue("")
         _writeFolderId.emit(0)
         _writeFolderName.emit("")
-        _postImageUriList.postValue(arrayListOf())
         _postTagList.clear(notify = false)
         _writeTags.emit(emptyList())
-        viewModelScope.launch {
-            _writeImagesUri.emit(emptyList())
-        }
+        _writeImagesUri.emit(emptyList())
     }
 
     fun setPostId(id: Long) {
@@ -286,103 +285,98 @@ class WriteViewModel @Inject constructor(
         _writeFolderName.emit(name)
     }
 
-    fun addUploadImage(uriPath: String, notify: Boolean = false) {
-        _postImageUriList.add(uriPath, notify)
-        _writeImagesUri.getAndUpdate { it + uriPath }
+    /**
+     * 갤러리에서 가져온 이미지들을 ViewModel에 추가
+     * Bitmap을 로드하지 않고 Uri만 ImageAsset 형태로 저장
+     */
+    fun addOriginalImages(uris: List<Uri>) {
+        viewModelScope.launch {
+            val newImageAssets = uris.map { ImageAsset(uriString = it.toString()) }
+            _writeImagesUri.emit(newImageAssets)
+        }
     }
 
-    fun updateAndResizeUploadImages(
-        uri: Uri,
-        currentIndex: Int,
-        contentResolver: ContentResolver,
-        option: BitmapFactory.Options,
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val inputStream = contentResolver.openInputStream(uri)
-            inputStream?.use {
-                val bitmap = BitmapFactory.decodeStream(it, null, option)
-                val resizedBitmap = bitmap?.let { resizeBitmap(it, 220, 500) }
-                resizedBitmap?.let { newBitmap ->
-                    _writeImages.getAndUpdate { currentList ->
-                        currentList.toMutableList().apply {
-                            if (currentIndex in indices) {
-                                this[currentIndex] = newBitmap
-                            } else {
-                                add(newBitmap)
-                            }
-                        }
+    /**
+     * 이미지를 편집하고, 완료되면 리스트의 해당 ImageAsset을 새 정보로 교체
+     */
+    fun cropImageAndUpdate(imageIndex: Int, stateHolder: ImageCropStateHolder) {
+        val imageAsset = _writeImagesUri.value.getOrNull(imageIndex) ?: return
+
+        viewModelScope.launch {
+            try {
+                val newUri = withContext(Dispatchers.IO) {
+                    val originalUri = Uri.parse(imageAsset.uriString)
+                    val inputStream =
+                        applicationContext.contentResolver.openInputStream(originalUri)
+                            ?: throw IOException("원본 이미지 스트림 열기 실패")
+
+                    // BitmapRegionDecoder 생성 (전체 이미지를 로드하지 않음)
+                    val decoder = BitmapRegionDecoder.newInstance(inputStream, false)
+                        ?: throw IOException("BitmapRegionDecoder 생성 실패")
+
+                    // 화면의 '미리보기용' 비트맵과 '원본' 비트맵의 크기 비율 계산
+                    // ImageCropStateHolder가 가진 비트맵은 이제 sampledBitmap이므로,
+                    // 최종 크롭은 원본 파일의 너비를 기준으로 해야 함
+                    val scale = decoder.width.toFloat() / stateHolder.imageWidth
+                    val cropProps = stateHolder.cropProperties.value
+
+                    // 미리보기 기준 좌표 -> 원본 기준 좌표로 변환
+                    val left = (cropProps.cropOffset.x * scale).roundToInt()
+                    val top = ((cropProps.cropOffset.y - stateHolder.imageTop) * scale).roundToInt()
+                    val size = (cropProps.cropSize * scale).roundToInt()
+                    val cropRect = Rect(left, top, left + size, top + size)
+
+                    // 크롭 영역이 원본 이미지 범위를 벗어나지 않도록 보정
+                    cropRect.intersect(0, 0, decoder.width, decoder.height)
+
+                    // 4. 필요한 영역만 정확히 디코딩
+                    val croppedBitmap = decoder.decodeRegion(cropRect, null)
+                    decoder.recycle()
+                    inputStream.close()
+
+                    // 크롭된 이미지를 새 캐시 파일로 저장
+                    val cacheFile = File(
+                        applicationContext.cacheDir,
+                        "cropped_${System.currentTimeMillis()}.jpg"
+                    )
+                    FileOutputStream(cacheFile).use { out ->
+                        croppedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
                     }
-                    _writeImagesUri.getAndUpdate { currentList ->
-                        currentList.toMutableList().apply {
-                            if (currentIndex in indices) {
-                                this[currentIndex] = uri.toString()
-                            } else {
-                                add(uri.toString())
-                            }
-                        }
+                    croppedBitmap.recycle()
+                    cacheFile.toUri()
+                }
+
+                _writeImagesUri.getAndUpdate { currentList ->
+                    currentList.toMutableList().apply {
+                        this[imageIndex] = ImageAsset(uriString = newUri.toString())
                     }
                 }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _errorEvent.emit("이미지 처리에 실패했습니다. 다시 시도해 주세요.")
             }
         }
     }
 
-    fun addAndResizeUploadImages(
-        uris: List<Uri>,
-        contentResolver: ContentResolver,
-        option: BitmapFactory.Options
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            uris.forEach { uri ->
-                val inputStream = contentResolver.openInputStream(uri)
-                inputStream?.use {
-                    val bitmap = BitmapFactory.decodeStream(it, null, option)
-                    val resizedBitmap = bitmap?.let { resizeBitmap(it, 220, 500) }
-                    resizedBitmap?.let {
-                        val currentList = _writeImages.value.toMutableList()
-                        currentList.add(it)
-                        _writeImages.emit(currentList)
-                    }
-                }
+    /**
+     * 지정된 인덱스의 이미지 제거
+     */
+    fun removeUploadImage(pos: Int) {
+        viewModelScope.launch {
+            _writeImagesUri.getAndUpdate { currentList ->
+                currentList.filterIndexed { index, _ -> index != pos }
             }
         }
-    }
-
-    fun removeUploadImage(pos: Int, notify: Boolean = false) {
-        viewModelScope.launch(Dispatchers.IO) {
-            _writeImages.getAndUpdate { it.filterIndexed { index, _ -> index != pos } }
-        }
-    }
-
-    fun deleteUploadImage(pos: Int, notify: Boolean = false) {
-        _postImageUriList.removeAt(pos, notify)
-        _writeImagesUri.getAndUpdate { it.filterIndexed { index, _ -> index != pos } }
     }
 
     fun clearUploadImage() {
-        _postImageUriList.clear(notify = true)
-        viewModelScope.launch { _writeImagesUri.emit(emptyList()) }
-    }
-
-    fun addPostTag(tagText: String, notify: Boolean = false) = viewModelScope.launch {
-        _postTagList.add(tagText, notify)
-        _writeTags.emit(
-            writeTags.value.toMutableList().apply {
-                add(tagText)
-            }
-        )
+        viewModelScope.launch {
+            _writeImagesUri.emit(emptyList())
+        }
     }
 
     fun updatePostTags(tagTextList: List<String>, notify: Boolean = false) = viewModelScope.launch {
         _postTagList.replaceAll(tagTextList, notify)
         _writeTags.emit(tagTextList)
-    }
-
-    fun removePostTag(tagText: String, notify: Boolean = false) = viewModelScope.launch {
-        _postTagList.remove(tagText, notify)
-        _writeTags.emit(
-            writeTags.value.toMutableList().apply {
-                remove(tagText)
-            }
-        )
     }
 }

--- a/presentation/src/main/res/drawable/ic_crop.xml
+++ b/presentation/src/main/res/drawable/ic_crop.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:autoMirrored="true"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M5,2V14C5,14.552 5.448,15 6,15H18"
+        android:strokeWidth="1.25"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="round" />
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M15,18L15,6C15,5.448 14.552,5 14,5L2,5"
+        android:strokeWidth="1.25"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="round" />
+
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="feed_empty_button">팔로우하러 가기</string>
 
     <!-- Write -->
+    <string name="write_post_image_edit">이미지 편집</string>
     <string name="write_post_image_crop_title">이미지 편집</string>
     <string name="write_post_title">게시글 작성</string>
     <string name="write_post_upload">올리기</string>


### PR DESCRIPTION
# 작업 사항
- 업로드 이미지 편집기능 내재화
- 대용량 이미지 로드 대응
- 의도치 않은 이미지 방향 오류 발생 해결

# 구현 내용
- Third-party cropper library 제거 및 Compose 기반의 인앱 이미지 편집 기능 구현
- 대용량 이미지 로드간 OOM 방지 처리
- EXIF 정보를 활용해 이미지 로드시, 유저의 의도와 달리 회전되어있는 경우 유저 입장에서 정상적으로 보이도록 이미지 처리
- Write 관련 state에 대해 lifecycle에 맞게 유지되도록 변경

# 구현 세부사항
## Custom Image Cropper
- 크롭 이미지 영역 지정시 정사각형 형태의 그리드 형태로 구현
- 크롭 이미지 영역 지정시 두 손가락으로 조작하는 Pinch-Zoom 제스처와 한 손가락으로 사각형의 각 4개의 모서리로 영역을 조작하는 제스처를 통한 영역 지정 제스처 구현
   - 최소 이미지 처리 추가
   - 크롭 진행간 제스처 겹침 및 이미지뷰 외부 영역으로 영역 벗어남 등에 대한 예외 처리 적용
- 관련 ImageAsset 등의 데이터 클래스 등을 활용해 크롭 상태 관리 처리
- 이외 지정 영역에 대한 그리드 및 shadow 등 UI 개선

## 대용량 이미지 로드
- 업로드 이미지 로드에 대해 이미지 로드이전 이미지 정보를 미리 읽고 inSampleSize를 개선해 기기에 최적화된 디코딩을 통한 OOM 방지 처리
   - `inJustDecodeBounds = true/false`
- 글 작성화면 및 이미지 편집화면 진입시 이미지 로드간 비동기적 로드를 통해 OOM 방지처리
- 업로드 시점에만 서버와 미리 지정한 사이즈로 리사이징 및 파일포맷 변환, 업로드 처리 이후 관련 메모리 해제 처리로직 추가
- 편집 완료 경우에 대한 이미지 파일 캐싱처리 및 캐시키를 활용해 갱신 처리

# 참고
- #663 