### PR TITLE
Home screen UI based on Design QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/home/HomeDayoPickScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/home/HomeDayoPickScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -25,6 +26,7 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -181,21 +183,41 @@ private fun HomeDayoPickEmptyView() {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun CategoryButton(
     selectedCategory: String,
     onCategoryClick: () -> Unit
 ) {
+
     Button(
         onClick = onCategoryClick,
         shape = RoundedCornerShape(8.dp),
-        contentPadding = PaddingValues(top = 6.dp, bottom = 6.dp, start = 12.dp, end = 4.dp),
-        colors = androidx.compose.material3.ButtonDefaults.buttonColors(containerColor = White_FFFFFF, contentColor = Gray2_767B83),
-        modifier = Modifier.border(1.dp, Gray6_F0F1F3, shape = RoundedCornerShape(8.dp))
+        contentPadding = PaddingValues(start = 12.dp, end = 4.dp),
+        modifier = Modifier
+            .border(1.dp, Gray6_F0F1F3, shape = RoundedCornerShape(8.dp))
+            .height(36.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = White_FFFFFF,
+            contentColor = Gray2_767B83
+        )
     ) {
-        Text(text = selectedCategory, style = DayoTheme.typography.caption3)
-        Spacer(modifier = Modifier.width(8.dp))
-        Icon(Icons.Filled.ArrowDropDown, "category menu")
+        Row(
+            modifier = Modifier.height(36.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = selectedCategory,
+                style = DayoTheme.typography.caption3
+            )
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+        }
     }
+
 }
 

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -115,42 +116,36 @@ fun BottomSheetDialog(
             buttons.forEachIndexed { index, button ->
                 val interactionSource = remember { MutableInteractionSource() }
                 val isPressed = interactionSource.collectIsPressedAsState().value
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .wrapContentHeight()
-                        .background(
-                            if (isPressed) Gray6_F0F1F3 else White_FFFFFF,
-                            RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp)
+                if (leftIconButtons != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp, horizontal = 8.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable(
+                                onClick = button.second,
+                                interactionSource = interactionSource
+                            )
+                            .background(White_FFFFFF)
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (leftIconCheckedButtons != null) {
+                            Icon(
+                                imageVector = if (checkedButtonIndex == index) leftIconCheckedButtons[index] else leftIconButtons[index],
+                                contentDescription = "",
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                                tint = Color.Unspecified
+                            )
+                        }
+                        Text(
+                            text = button.first,
+                            modifier = Modifier.offset(8.dp, 0.dp),
+                            color = if ((isFirstButtonColored && index == 0) || (checkedButtonIndex == index)) checkedColor else normalColor,
+                            fontSize = 16.sp,
+                            style = DayoTheme.typography.b4
                         )
-                        .padding(if (leftIconButtons == null) 16.dp else 12.dp)
-                        .clickable(
-                            onClick = button.second,
-                            interactionSource = interactionSource,
-                            indication = null
-                        ),
-                    horizontalArrangement = if (leftIconButtons == null) Arrangement.Center else Arrangement.SpaceBetween,
-                ) {
-                    if (leftIconButtons != null && leftIconCheckedButtons != null) {
-                        Icon(
-                            imageVector = if (checkedButtonIndex == index) leftIconCheckedButtons[index] else leftIconButtons[index],
-                            contentDescription = "",
-                            modifier = Modifier.align(Alignment.CenterVertically),
-                            tint = Color.Unspecified
-                        )
-                    }
-                    Text(
-                        text = button.first,
-                        modifier = Modifier.offset(
-                            if (leftIconButtons == null) 0.dp else 8.dp,
-                            0.dp
-                        ),
-                        color = if ((isFirstButtonColored && index == 0) || (checkedButtonIndex == index)) checkedColor else normalColor,
-                        fontSize = 16.sp,
-                        style = DayoTheme.typography.b4
-                    )
-                    if (leftIconButtons != null) {
                         Spacer(modifier = Modifier.weight(1f))
                         if (checkedButtonIndex == index) {
                             Icon(
@@ -161,7 +156,32 @@ fun BottomSheetDialog(
                             )
                         }
                     }
+                } else {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .background(
+                                if (isPressed) Gray6_F0F1F3 else White_FFFFFF,
+                                RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp)
+                            )
+                            .padding(16.dp)
+                            .clickable(
+                                onClick = button.second,
+                                interactionSource = interactionSource,
+                                indication = null
+                            ),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        Text(
+                            text = button.first,
+                            color = if ((isFirstButtonColored && index == 0) || (checkedButtonIndex == index)) checkedColor else normalColor,
+                            fontSize = 16.sp,
+                            style = DayoTheme.typography.b4
+                        )
+                    }
                 }
+
                 if (index < buttons.size - 1 && title.isEmpty()) {
                     Divider(
                         modifier = Modifier


### PR DESCRIPTION
## 작업 내용
- 홈화면의 ui를 디자인 문서에 맞게 일부 조정 
- 홈화면의 카테고리 버튼 크기 조정
- 바텀시트의 카테고리 선택 시 Ripple영역 조정

## 참고 
- resolved: #715 
- resolved: #1022 
- resolved: #1023 