### PR TITLE
SearchPw screen UI based on Design QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -592,6 +592,14 @@ fun EmailInputLayout(
     requestEmailCertification: (String) -> Unit = {},
 ) {
     val lastErrorMessage = remember { mutableStateOf("") }
+    val isEmailError = when {
+        email.isBlank() -> null
+        emailCertification == EmailCertificationState.INVALID_FORMAT ||
+                emailCertification == EmailCertificationState.NOT_EXIST_EMAIL ||
+                emailCertification == EmailCertificationState.OAUTH_EMAIL -> true
+
+        else -> false
+    }
 
     LaunchedEffect(emailCertification) {
         lastErrorMessage.value = when (emailCertification) {
@@ -612,9 +620,13 @@ fun EmailInputLayout(
             val formatValid = android.util.Patterns.EMAIL_ADDRESS.matcher(it).matches()
             setNextButtonEnabled(formatValid)
             setIsNextButtonClickable(formatValid)
-            if (!formatValid) {
+            if (it.isBlank()) {
+                setEmailCertification(EmailCertificationState.BEFORE_CERTIFICATION)
+                lastErrorMessage.value = ""
+            } else if (!formatValid) {
                 setEmailCertification(EmailCertificationState.INVALID_FORMAT)
             } else {
+                setEmailCertification(EmailCertificationState.BEFORE_CERTIFICATION)
                 lastErrorMessage.value = ""
                 // INVALID FORMAT 에러 메시지가 다음 에러 메시지가 표시될 떄 남아 있지 않도록 value Clear
             }
@@ -624,7 +636,7 @@ fun EmailInputLayout(
         trailingIconId = if (email.isNotBlank()) R.drawable.ic_trailing_check else null,
         errorTrailingIconId = R.drawable.ic_trailing_error,
         errorMessage = lastErrorMessage.value,
-        isError = if (email.isBlank()) null else !isNextButtonEnabled,
+        isError = isEmailError,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
     )
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -631,7 +631,11 @@ fun EmailInputLayout(
                 // INVALID FORMAT 에러 메시지가 다음 에러 메시지가 표시될 떄 남아 있지 않도록 value Clear
             }
         },
-        label = stringResource(R.string.email),
+        label = if (email.isNotEmpty()) {
+            stringResource(R.string.email)
+        } else {
+            " "
+        },
         placeholder = stringResource(R.string.reset_password_email_placeholder),
         trailingIconId = if (email.isNotBlank()) R.drawable.ic_trailing_check else null,
         errorTrailingIconId = R.drawable.ic_trailing_error,


### PR DESCRIPTION
## 작업 내용
- 로그인전 비밀번호 찾기 화면에서 TextField가 비어있음에도 label이 보이는 현상 수정
- 로그인전 비밀번호 찾기 화면에서, 이메일 인증간 유효 이메일 입력후 인증번호 받기 화면으로 넘어가기 직전 순간적으로 에러상태가 보이는 문제 수정


## 참고 
- resolved: #1018 