### PR TITLE
Email Sign Up screen UI based on Design QA

### DIFF
--- a/presentation/src/androidTest/AndroidManifest.xml
+++ b/presentation/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+    </application>
+
+</manifest>

--- a/presentation/src/androidTest/java/daily/dayo/presentation/screen/account/AuthPasswordFieldUsageTest.kt
+++ b/presentation/src/androidTest/java/daily/dayo/presentation/screen/account/AuthPasswordFieldUsageTest.kt
@@ -1,0 +1,91 @@
+package daily.dayo.presentation.screen.account
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import daily.dayo.presentation.theme.DayoTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AuthPasswordFieldUsageTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun assertContentDescriptionCount(contentDescription: String, expectedCount: Int) {
+        composeRule.onAllNodesWithContentDescription(contentDescription)
+            .assertCountEquals(expectedCount)
+    }
+
+    @Test
+    fun signInEmailInputLayout_showsClearAndVisibilityOnEditablePasswordField() {
+        var email by mutableStateOf("")
+        var password by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                SignInEmailInputLayout(
+                    emailValue = email,
+                    onEmailChange = { email = it },
+                    passwordValue = password,
+                    onPasswordChange = { password = it }
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 1)
+        assertContentDescriptionCount("Show password", 1)
+    }
+
+    @Test
+    fun signUpPasswordConfirmLayout_hidesClearOnDisabledReferenceField() {
+        var password by mutableStateOf("password")
+        var passwordConfirmation by mutableStateOf("confirm")
+
+        composeRule.setContent {
+            DayoTheme {
+                SetPasswordView(
+                    passwordInputViewCondition = false,
+                    passwordConfirmationViewCondition = true,
+                    password = password,
+                    setPassword = { password = it },
+                    isPasswordFormatValid = true,
+                    passwordConfirmation = passwordConfirmation,
+                    setPasswordConfirmation = { passwordConfirmation = it }
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 1)
+        assertContentDescriptionCount("Show password", 2)
+    }
+
+    @Test
+    fun resetPasswordConfirmLayout_hidesClearOnDisabledReferenceField() {
+        var password by mutableStateOf("password")
+        var passwordConfirmation by mutableStateOf("confirm")
+
+        composeRule.setContent {
+            DayoTheme {
+                NewPasswordLayout(
+                    resetPasswordStep = ResetPasswordStep.NEW_PASSWORD_CONFIRM,
+                    password = password,
+                    setPassword = { password = it },
+                    isPasswordFormatValid = true,
+                    passwordConfirmation = passwordConfirmation,
+                    setPasswordConfirmation = { passwordConfirmation = it }
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 1)
+        assertContentDescriptionCount("Show password", 2)
+    }
+}

--- a/presentation/src/androidTest/java/daily/dayo/presentation/view/DayoPasswordTextFieldTest.kt
+++ b/presentation/src/androidTest/java/daily/dayo/presentation/view/DayoPasswordTextFieldTest.kt
@@ -1,0 +1,163 @@
+package daily.dayo.presentation.view
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import daily.dayo.presentation.theme.DayoTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DayoPasswordTextFieldTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun assertContentDescriptionCount(contentDescription: String, expectedCount: Int) {
+        composeRule.onAllNodesWithContentDescription(contentDescription)
+            .assertCountEquals(expectedCount)
+    }
+
+    @Test
+    fun givenTextAndDefaultFlags_whenRendered_thenClearAndEyeIconsAreBothShown() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it }
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 1)
+        assertContentDescriptionCount("Show password", 1)
+    }
+
+    @Test
+    fun givenText_whenClearIconTapped_thenFieldIsEmptied() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it }
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Clear password").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals("", passwordValue)
+        }
+        assertContentDescriptionCount("Clear password", 0)
+        assertContentDescriptionCount("Show password", 1)
+    }
+
+    @Test
+    fun givenDefaultVisibilityIcon_whenTapped_thenContentDescriptionChangesToHidePassword() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it }
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Show password").performClick()
+
+        assertContentDescriptionCount("Hide password", 1)
+    }
+
+    @Test
+    fun givenErrorState_whenRendered_thenOnlyErrorIconIsShown() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it },
+                    isError = true,
+                    errorMessage = "error"
+                )
+            }
+        }
+
+        assertContentDescriptionCount("error icon", 1)
+        assertContentDescriptionCount("Clear password", 0)
+        assertContentDescriptionCount("Show password", 0)
+    }
+
+    @Test
+    fun givenVisibilityIconHiddenAndTextExists_whenRendered_thenOnlyClearIconIsShown() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it },
+                    showVisibilityIcon = false
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 1)
+        assertContentDescriptionCount("Show password", 0)
+        assertContentDescriptionCount("Hide password", 0)
+    }
+
+    @Test
+    fun givenVisibilityIconHiddenAndTextBlank_whenRendered_thenNoTrailingIconsAreShown() {
+        var passwordValue by mutableStateOf("")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it },
+                    showVisibilityIcon = false
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 0)
+        assertContentDescriptionCount("Show password", 0)
+        assertContentDescriptionCount("Hide password", 0)
+        assertContentDescriptionCount("error icon", 0)
+    }
+
+    @Test
+    fun givenDisabledFieldWithText_whenRendered_thenClearIsHiddenAndEyeRemains() {
+        var passwordValue by mutableStateOf("password")
+
+        composeRule.setContent {
+            DayoTheme {
+                DayoPasswordTextField(
+                    value = passwordValue,
+                    onValueChange = { passwordValue = it },
+                    isEnabled = false
+                )
+            }
+        }
+
+        assertContentDescriptionCount("Clear password", 0)
+        assertContentDescriptionCount("Show password", 1)
+    }
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -738,7 +738,7 @@ private fun EmailCertificationLayout(
 
 @Composable
 @Preview
-private fun NewPasswordLayout(
+internal fun NewPasswordLayout(
     resetPasswordStep: ResetPasswordStep = ResetPasswordStep.NEW_PASSWORD_INPUT,
     isNextButtonEnabled: Boolean = false,
     setNextButtonEnabled: (Boolean) -> Unit = {},

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -712,6 +712,10 @@ private fun EmailCertificationLayout(
                 text = stringResource(R.string.reset_password_email_certification_resend_button),
                 onClick = {
                     tryCount++
+                    setCertificationInputCode("")
+                    timerErrorMessageRedId.value =
+                        R.string.reset_password_email_certification_fail_wrong
+                    setIsEmailCertificateError(false)
                     requestEmailCertification(email)
                 },
                 underline = true,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -354,19 +354,21 @@ fun ResetPasswordScreen(
                 AnimatedVisibility(
                     visible = (resetPasswordStep.stepNum in 1..2),
                 ) {
-                    Spacer(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(4.dp)
-                    )
-                    Text(
-                        text = if (resetPasswordStep == ResetPasswordStep.EMAIL_INPUT)
-                            stringResource(R.string.reset_password_email_sub_title)
-                        else if (resetPasswordStep == ResetPasswordStep.EMAIL_VERIFICATION)
-                            stringResource(R.string.reset_password_new_password_sub_title)
-                        else "",
-                        style = DayoTheme.typography.b6.copy(color = Gray2_767B83),
-                    )
+                    Column {
+                        Spacer(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(4.dp)
+                        )
+                        Text(
+                            text = if (resetPasswordStep == ResetPasswordStep.EMAIL_INPUT)
+                                stringResource(R.string.reset_password_email_sub_title)
+                            else if (resetPasswordStep == ResetPasswordStep.EMAIL_VERIFICATION)
+                                stringResource(R.string.reset_password_new_password_sub_title)
+                            else "",
+                            style = DayoTheme.typography.b6.copy(color = Gray2_767B83),
+                        )
+                    }
                 }
 
                 // Contents 영역

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -53,6 +53,7 @@ import daily.dayo.presentation.screen.account.model.EmailExistenceStatus
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
+import daily.dayo.presentation.theme.Gray3_9FA5AE
 import daily.dayo.presentation.theme.White_FFFFFF
 import daily.dayo.presentation.view.DayoPasswordTextField
 import daily.dayo.presentation.view.DayoTextButton
@@ -685,6 +686,7 @@ private fun EmailCertificationLayout(
             isError = isEmailCertificateError ?: false,
             errorMessage = stringResource(timerErrorMessageRedId.value),
             timeOutErrorMessage = stringResource(R.string.reset_password_email_certification_fail_time_out),
+            labelColor = Gray3_9FA5AE,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
         )
     }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/ResetPasswordScreen.kt
@@ -647,6 +647,9 @@ private fun EmailCertificationLayout(
     requestEmailCertification: (String) -> Unit = {},
 ) {
     val certificateEmailAuthCodeFormat = Regex("^\\d{6}$")
+    val isServerCertificationCodeReady =
+        certificationCode != EMAIL_CERTIFICATE_AUTH_CODE_INITIAL.toString() &&
+                certificationCode != RESET_PASSWORD_EMAIL_CERTIFICATE_AUTH_CODE_FAIL.toString()
 
     var tryCount by remember { mutableStateOf(1) }
     val isPaused = remember { mutableStateOf(false) }
@@ -657,10 +660,12 @@ private fun EmailCertificationLayout(
         remember { mutableStateOf((R.string.reset_password_email_certification_fail_wrong)) }
 
     setNextButtonEnabled(
-        certificateEmailAuthCodeFormat.matches(certificationInputCode)
+        certificateEmailAuthCodeFormat.matches(certificationInputCode) &&
+                isServerCertificationCodeReady
     )
     setIsNextButtonClickable(
-        certificateEmailAuthCodeFormat.matches(certificationInputCode)
+        certificateEmailAuthCodeFormat.matches(certificationInputCode) &&
+                isServerCertificationCodeReady
     )
 
     key(tryCount) {

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
@@ -117,7 +117,11 @@ fun SetEmailCertificationView(
                 text = stringResource(R.string.sign_up_email_set_address_resend_button),
                 onClick = {
                     tryCount++
+                    setCertificationInputCode("")
                     isTimeOut.value = false
+                    timerErrorMessageRedId.value =
+                        R.string.sign_up_email_set_address_certification_fail_wrong
+                    setIsEmailCertificateError(false)
                     requestEmailCertification(email)
                 },
                 underline = true,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
@@ -25,6 +25,7 @@ import daily.dayo.presentation.screen.account.model.EmailCertificationState
 import daily.dayo.presentation.screen.account.model.SignUpStep
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
+import daily.dayo.presentation.theme.Gray3_9FA5AE
 import daily.dayo.presentation.view.DayoTextButton
 import daily.dayo.presentation.view.DayoTimerTextField
 import daily.dayo.presentation.viewmodel.AccountViewModel
@@ -85,6 +86,7 @@ fun SetEmailCertificationView(
             isError = isEmailCertificateError ?: false,
             errorMessage = stringResource(timerErrorMessageRedId.value),
             timeOutErrorMessage = stringResource(R.string.sign_up_email_set_address_certification_fail_time_out),
+            labelColor = Gray3_9FA5AE,
             onTimeOut = {
                 isTimeOut.value = true
                 setNextButtonEnabled(false)

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailCertificationView.kt
@@ -48,6 +48,9 @@ fun SetEmailCertificationView(
     requestEmailCertification: (String) -> Unit = {},
 ) {
     val certificateEmailAuthCodeFormat = Regex("^\\d{6}$")
+    val isServerCertificationCodeReady =
+        certificationCode != AccountViewModel.EMAIL_CERTIFICATE_AUTH_CODE_INITIAL.toString() &&
+                certificationCode != AccountViewModel.SIGN_UP_EMAIL_CERTIFICATE_AUTH_CODE_FAIL.toString()
 
     var tryCount by remember { mutableStateOf(1) }
     val isPaused = remember { mutableStateOf(false) }
@@ -57,10 +60,14 @@ fun SetEmailCertificationView(
     val isTimeOut = remember { mutableStateOf(false) }
 
     setNextButtonEnabled(
-        certificateEmailAuthCodeFormat.matches(certificationInputCode) && !isTimeOut.value
+        certificateEmailAuthCodeFormat.matches(certificationInputCode) &&
+                isServerCertificationCodeReady &&
+                !isTimeOut.value
     )
     setIsNextButtonClickable(
-        certificateEmailAuthCodeFormat.matches(certificationInputCode) && !isTimeOut.value
+        certificateEmailAuthCodeFormat.matches(certificationInputCode) &&
+                isServerCertificationCodeReady &&
+                !isTimeOut.value
     )
 
     key(tryCount) {

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SetEmailView.kt
@@ -54,7 +54,11 @@ fun SetEmailView(
                 requestEmailCertification(it)
             }
         },
-        label = stringResource(R.string.email),
+        label = if (email.isNotEmpty()) {
+            stringResource(R.string.email)
+        } else {
+            " "
+        },
         placeholder = stringResource(R.string.sign_up_email_set_address_placeholder),
         trailingIconId = if (email.isNotBlank()) R.drawable.ic_trailing_check else null,
         errorTrailingIconId = R.drawable.ic_trailing_error,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SignUpEmailScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SignUpEmailScreen.kt
@@ -263,15 +263,17 @@ fun SignUpEmailTitleLayout(
 
     // SubTitle 영역
     AnimatedVisibility(visible = subTitle.isNotBlank()) {
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp)
-        )
-        Text(
-            text = subTitle,
-            style = DayoTheme.typography.b6.copy(color = Gray2_767B83),
-        )
+        Column {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+            )
+            Text(
+                text = subTitle,
+                style = DayoTheme.typography.b6.copy(color = Gray2_767B83),
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/SignUpEmailScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/SignUpEmailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -592,6 +593,7 @@ fun SignUpEmailScaffold(
                         )
                     }
                 },
+                windowInsets = WindowInsets(0, 0, 0, 0),
             )
         }
     ) { innerPadding ->

--- a/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -198,6 +199,8 @@ fun DayoPasswordTextField(
     textAlign: TextAlign = TextAlign.Left,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onErrorIconClick: (() -> Unit) = { },
+    showClearIcon: Boolean = true,
+    showVisibilityIcon: Boolean = true,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     isEnabled: Boolean = true,
@@ -207,6 +210,15 @@ fun DayoPasswordTextField(
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         var passwordHidden by remember { mutableStateOf(true) }
+        val showError = isError == true
+        val shouldShowClear = showClearIcon && isEnabled && value.isNotBlank() && !showError
+        val shouldShowVisibility = showVisibilityIcon && !showError
+        val trailingContentWidth = when {
+            showError -> 20.dp
+            shouldShowClear && shouldShowVisibility -> 48.dp
+            shouldShowClear || shouldShowVisibility -> 20.dp
+            else -> 0.dp
+        }
 
         if (label.isNotEmpty()) {
             Text(
@@ -254,7 +266,7 @@ fun DayoPasswordTextField(
                         contentPadding = PaddingValues(
                             start = contentPadding.calculateStartPadding(LayoutDirection.Ltr),
                             top = contentPadding.calculateTopPadding(),
-                            end = contentPadding.calculateEndPadding(LayoutDirection.Ltr) + 20.dp,
+                            end = contentPadding.calculateEndPadding(LayoutDirection.Ltr) + trailingContentWidth,
                             bottom = contentPadding.calculateBottomPadding()
                         ),
                         colors = TextFieldDefaults.colors(
@@ -279,22 +291,42 @@ fun DayoPasswordTextField(
             Box(
                 modifier = Modifier.align(alignment = Alignment.CenterEnd)
             ) {
-                if (isError != null && isError == true) {
+                if (showError) {
                     NoRippleIconButton(
                         onClick = onErrorIconClick,
                         iconContentDescription = "error icon",
                         iconPainter = painterResource(id = errorTrailingIconId),
                         iconButtonModifier = Modifier.size(20.dp)
                     )
-                } else {
-                    val trailingIconId = if (passwordHidden) R.drawable.ic_trailing_invisible else R.drawable.ic_trailing_visible
-                    val description = if (passwordHidden) "Show password" else "Hide password"
-                    NoRippleIconButton(
-                        onClick = { passwordHidden = passwordHidden.not() },
-                        iconContentDescription = description,
-                        iconPainter = painterResource(id = trailingIconId),
-                        iconButtonModifier = Modifier.size(20.dp)
-                    )
+                } else if (shouldShowClear || shouldShowVisibility) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (shouldShowClear) {
+                            NoRippleIconButton(
+                                onClick = { onValueChange("") },
+                                iconContentDescription = "Clear password",
+                                iconPainter = painterResource(id = R.drawable.ic_trailing_delete),
+                                iconButtonModifier = Modifier.size(20.dp)
+                            )
+                        }
+
+                        if (shouldShowVisibility) {
+                            val trailingIconId = if (passwordHidden) {
+                                R.drawable.ic_trailing_invisible
+                            } else {
+                                R.drawable.ic_trailing_visible
+                            }
+                            val description = if (passwordHidden) "Show password" else "Hide password"
+                            NoRippleIconButton(
+                                onClick = { passwordHidden = passwordHidden.not() },
+                                iconContentDescription = description,
+                                iconPainter = painterResource(id = trailingIconId),
+                                iconButtonModifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
@@ -323,6 +323,7 @@ fun DayoTimerTextField(
     isError: Boolean = false,
     errorMessage: String = "",
     timeOutErrorMessage: String = stringResource(id = R.string.email_address_certificate_alert_message_time_fail),
+    labelColor: Color = Gray4_C5CAD2,
     onTimeOut: (() -> Unit) = { },
     textAlign: TextAlign = TextAlign.Left,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -351,7 +352,7 @@ fun DayoTimerTextField(
             Text(
                 text = label,
                 style = DayoTheme.typography.caption3.copy(
-                    color = Gray4_C5CAD2,
+                    color = labelColor,
                     fontWeight = FontWeight.SemiBold
                 )
             )

--- a/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
@@ -1,6 +1,7 @@
 package daily.dayo.presentation.view
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -25,7 +26,8 @@ fun TopNavigation(
     title: String = "",
     leftIcon: @Composable () -> Unit = {},
     rightIcon: @Composable () -> Unit = {},
-    titleAlignment: TopNavigationAlign = TopNavigationAlign.LEFT
+    titleAlignment: TopNavigationAlign = TopNavigationAlign.LEFT,
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets
 ) {
     when (titleAlignment) {
         TopNavigationAlign.LEFT -> {
@@ -34,6 +36,7 @@ fun TopNavigation(
                     containerColor = White_FFFFFF,
                     titleContentColor = Dark,
                 ),
+                windowInsets = windowInsets,
                 navigationIcon = leftIcon,
                 actions = { rightIcon() },
                 title = {
@@ -48,6 +51,7 @@ fun TopNavigation(
                     containerColor = White_FFFFFF,
                     titleContentColor = Dark,
                 ),
+                windowInsets = windowInsets,
                 navigationIcon = leftIcon,
                 actions = { rightIcon() },
                 title = {


### PR DESCRIPTION
## 작업 내용
- 인증번호를 받는데 사용되는 `DayoTimerTextField`의 label color parameter 추가 및 color 변경 적용(Gray3)
- 일부 기기에서 발생하는 헤더 상단의 여백 문제 해결
- [인증번호 재발송] 클릭 시, 에러 상태및 인증번호 입력값 초기화
- 인증하기 버튼의 활성상태 타이밍 수정
- 이메일 회원가입 페이지의 title과 subtitle 간격 미적용 문제 수정
- `DayoPasswordTextField`의 clear 및 visibility trailing icon이 동시에 표시될 수 있도록 수정 및 관련 테스트 추가

## 참고 
- resolved: #1015 
- resolved: #1016 
- resolved: #1017 
- resolved: #1020 
- resolved: #1021 