### PR TITLE
Blocked Users screen UI based on Design QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -97,19 +98,25 @@ fun BlockedUsersScreen(
         topBar = { BlockedUsersActionbarLayout(onBackClick = onBackClick) },
         snackbarHost = { SnackbarHost(snackBarHostState) },
         content = { innerPadding ->
-            Column(
+            Box(
                 modifier = Modifier
                     .background(DayoTheme.colorScheme.background)
                     .padding(innerPadding)
                     .fillMaxSize()
-                    .padding(top = 12.dp, start = 20.dp, end = 20.dp)
+                    .padding(top = 12.dp)
             ) {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    contentPadding = PaddingValues(vertical = 16.dp)
-                ) {
-                    if (blockedUsers.status != Status.ERROR) {
+                if (blockedUsers.status == Status.ERROR) {
+                    BlockedUsersErrorLayout(
+                        onRetry = { profileSettingViewModel.requestBlockList() },
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 20.dp, end = 20.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        contentPadding = PaddingValues(vertical = 16.dp)
+                    ) {
                         blockedUsers.data.orEmpty().let { blockedUsers ->
                             if (blockedUsers.isEmpty()) {
                                 item {
@@ -160,46 +167,55 @@ fun BlockedUsersScreen(
                                 }
                             }
                         }
-                    } else {
-                        item {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(top = 164.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.Center
-                            ) {
-                                Image(
-                                    painter = painterResource(id = R.drawable.ic_blocked_users_empty),
-                                    contentDescription = null,
-                                    modifier = Modifier
-                                        .width(136.dp)
-                                        .wrapContentHeight()
-                                        .padding(6.5.dp)
-                                )
-                                Spacer(modifier = Modifier.height(20.dp))
-                                Text(
-                                    text = stringResource(R.string.blocked_users_error_description),
-                                    color = Gray3_9FA5AE,
-                                    style = DayoTheme.typography.b3,
-                                    modifier = Modifier
-                                        .wrapContentSize()
-                                )
-                                Spacer(modifier = Modifier.height(20.dp))
-                                FilledRoundedCornerButton(
-                                    modifier = Modifier
-                                        .padding(horizontal = 20.dp)
-                                        .wrapContentSize(),
-                                    onClick = { profileSettingViewModel.requestBlockList() },
-                                    label = stringResource(R.string.re_try)
-                                )
-                            }
-                        }
                     }
                 }
             }
         }
     )
+}
+
+@Composable
+private fun BlockedUsersErrorLayout(
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.weight(176f))
+
+        Column(
+            modifier = Modifier.wrapContentHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_blocked_users_empty),
+                contentDescription = null,
+                modifier = Modifier
+                    .width(136.dp)
+                    .height(100.dp)
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = stringResource(R.string.blocked_users_error_description),
+                style = DayoTheme.typography.h3.copy(color = Gray3_9FA5AE),
+                modifier = Modifier.wrapContentSize()
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(336f))
+
+        FilledRoundedCornerButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+                .padding(bottom = 20.dp),
+            onClick = onRetry,
+            label = stringResource(R.string.re_try),
+        )
+    }
 }
 
 @Preview

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
@@ -49,6 +49,7 @@ import daily.dayo.presentation.view.FilledRoundedCornerButton
 import daily.dayo.presentation.view.NoRippleIconButton
 import daily.dayo.presentation.view.RoundImageView
 import daily.dayo.presentation.view.TopNavigation
+import daily.dayo.presentation.view.TopNavigationAlign
 import daily.dayo.presentation.viewmodel.ProfileSettingViewModel
 import daily.dayo.presentation.viewmodel.ProfileViewModel
 import kotlinx.coroutines.launch
@@ -261,5 +262,6 @@ fun BlockedUsersActionbarLayout(
             )
         },
         title = stringResource(R.string.blocked_users_title),
+        titleAlignment = TopNavigationAlign.CENTER,
     )
 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TopNavigation.kt
@@ -40,7 +40,7 @@ fun TopNavigation(
                 navigationIcon = leftIcon,
                 actions = { rightIcon() },
                 title = {
-                    Text(text = title, maxLines = 1, style = DayoTheme.typography.h3)
+                    Text(text = title, maxLines = 1, style = DayoTheme.typography.b3)
                 }
             )
         }
@@ -55,7 +55,7 @@ fun TopNavigation(
                 navigationIcon = leftIcon,
                 actions = { rightIcon() },
                 title = {
-                    Text(text = title, maxLines = 1, style = DayoTheme.typography.h3)
+                    Text(text = title, maxLines = 1, style = DayoTheme.typography.b3)
                 }
             )
         }

--- a/presentation/src/main/res/drawable/ic_blocked_users_empty.xml
+++ b/presentation/src/main/res/drawable/ic_blocked_users_empty.xml
@@ -1,42 +1,9 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="137dp"
-    android:height="100dp"
-    android:autoMirrored="true"
-    android:viewportWidth="137"
-    android:viewportHeight="100">
-
-    <group>
-
-        <clip-path android:pathData="M20.5,6h96.91v88.3h-96.91z" />
-
-        <path
-            android:fillColor="#F6F6F7"
-            android:pathData="M68.95,94.31C95.71,94.31 117.4,91.57 117.4,88.18C117.4,84.8 95.71,82.05 68.95,82.05C42.19,82.05 20.5,84.8 20.5,88.18C20.5,91.57 42.19,94.31 68.95,94.31Z" />
-
-        <path
-            android:fillColor="#ffffff"
-            android:pathData="M57.12,63.96C70.36,63.96 81.1,53.22 81.1,39.98C81.1,26.74 70.36,16 57.12,16C43.88,16 33.14,26.74 33.14,39.98C33.14,53.22 43.88,63.96 57.12,63.96Z" />
-
-        <path
-            android:fillColor="#E8EAEE"
-            android:pathData="M106.02,80.38L94.58,68.94C90.4,64.76 85.73,61.05 80.7,57.93L80.03,57.51L74.67,62.88L75.09,63.55C78.21,68.57 81.92,73.24 86.1,77.43L97.54,88.87C98.23,89.56 99.15,89.94 100.13,89.94C101.11,89.94 102.03,89.56 102.72,88.87L106.03,85.56C107.46,84.13 107.46,81.81 106.03,80.38H106.02Z" />
-
-        <path
-            android:fillColor="#F6F6F7"
-            android:pathData="M94.58,68.94C90.4,64.76 85.73,61.05 80.7,57.93L80.03,57.51L74.67,62.88L75.09,63.55C78.21,68.57 81.92,73.24 86.1,77.43L94.58,68.95V68.94Z" />
-
-        <path
-            android:fillColor="#F6F6F7"
-            android:pathData="M57.12,73.97C38.38,73.97 23.13,58.72 23.13,39.99C23.13,21.26 38.38,6 57.12,6C75.86,6 91.1,21.25 91.1,39.99C91.1,49.07 87.56,57.6 81.15,64.02C74.74,70.44 66.2,73.97 57.12,73.97ZM57.12,16C43.89,16 33.13,26.76 33.13,39.99C33.13,53.22 43.89,63.97 57.12,63.97C63.53,63.97 69.55,61.48 74.08,56.95C78.61,52.42 81.1,46.4 81.1,39.99C81.1,26.76 70.34,16 57.12,16Z" />
-
-        <path
-            android:fillColor="#E8EAEE"
-            android:pathData="M50.23,28.59L45.99,32.83L64.54,51.39L68.79,47.15L50.23,28.59Z" />
-
-        <path
-            android:fillColor="#E8EAEE"
-            android:pathData="M64.54,28.59L45.99,47.15L50.23,51.39L68.79,32.83L64.54,28.59Z" />
-
-    </group>
-
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="100dp" android:viewportHeight="100" android:viewportWidth="136" android:width="136dp">
+      
+    <path android:fillColor="#F6F6F7" android:pathData="M100.33,50.42C100.33,32.58 85.88,18.13 68.04,18.13C50.21,18.13 35.75,32.58 35.75,50.42C35.75,68.25 50.21,82.71 68.04,82.71C85.88,82.71 100.33,68.25 100.33,50.42ZM106.58,50.42C106.58,71.7 89.33,88.96 68.04,88.96C46.76,88.96 29.5,71.7 29.5,50.42C29.5,29.13 46.76,11.88 68.04,11.88C89.33,11.88 106.58,29.13 106.58,50.42Z" android:strokeColor="#F6F6F7" android:strokeWidth="3"/>
+      
+    <path android:fillColor="#E8EAEE" android:pathData="M68.12,72.25C70.61,72.25 72.62,70.23 72.62,67.75C72.62,65.26 70.61,63.25 68.12,63.25C65.64,63.25 63.63,65.26 63.63,67.75C63.63,70.23 65.64,72.25 68.12,72.25Z" android:strokeColor="#E8EAEE" android:strokeWidth="1"/>
+      
+    <path android:fillColor="#E8EAEE" android:pathData="M65,54V33C65,31.27 66.39,29.88 68.12,29.88C69.85,29.88 71.25,31.27 71.25,33V54L71.24,54.16C71.16,55.81 69.79,57.13 68.12,57.13C66.45,57.13 65.08,55.81 65,54.16L65,54Z" android:strokeColor="#E8EAEE" android:strokeLineCap="round" android:strokeWidth="2"/>
+    
 </vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="loading_default_message">잠시만 기다려 주세요</string>
     <string name="network_error_dialog_default_message">인터넷 연결 상태를 확인해주세요</string>
     <string name="close_sign">닫기</string>
-    <string name="re_try">재시도</string>
+    <string name="re_try">다시 시도</string>
 
     <!-- Time -->
     <string name="time_now">방금 전</string>


### PR DESCRIPTION
## 작업 내용
- 차단관리 화면 내 Top Navigation Bar Alignment Center 추가
- 로딩 실패시 재시도 레이아웃 수정
- 재시도 문구 "재시도" -> "다시 시도"로 변경
- 에러 아이콘 피그마 디자인에 맞게 변경 

## 참고 
- resolved: #1060 
- resolved: #1061 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# 차단된 사용자 화면 UI 개선 (Design QA 적용)

## 1. 기능 및 사용자 영향

### BlockedUsersScreen.kt - 레이아웃 및 상태 관리 개선
- **에러 상태 처리**: `blockedUsers.status == Status.ERROR` 시 새로운 `BlockedUsersErrorLayout` 컴포저블로 전환하여 에러 UI를 독립적으로 관리
- **네비게이션 바 타이틀 정렬**: `TopNavigationAlign.CENTER`를 적용하여 차단된 사용자 제목을 화면 중앙에 정렬
- **콘텐츠 패딩 조정**: LazyColumn에 좌우 20.dp 패딩 추가로 일관된 여백 확보
- **에러 레이아웃 구성**: Spacer의 weight를 활용(176f, 336f)하여 이미지/텍스트/재시도 버튼을 수직 중앙 배치

### ic_blocked_users_empty.xml - 에러 아이콘 교체
- 기존의 복잡한 clip-path 기반 벡터에서 단순화된 디자인으로 변경
- 새로운 아이콘: 원형 링(strokeColor #F6F6F7, strokeWidth 3) + 2개의 회색 filled 경로(#E8EAEE)로 구성
- 시각적으로 더 깔끔하고 Figma 디자인과 일치

### strings.xml - 재시도 텍스트 업데이트
- "재시도" → "다시 시도"로 변경하여 자연스러운 한글 표현 적용

### TopNavigation.kt - 타이포그래피 통일 (부수 변경)
- LEFT/CENTER 타이틀 모두 `b3` 스타일로 통일하여 일관성 강화

---

## 2. 리스크 포인트

### 에러 처리 및 상태 일관성
- **ERROR 상태 진입 조건**: `blockedUsers.status == Status.ERROR`로의 상태 전환 로직이 ViewModel에서 올바르게 트리거되어야 함
- **재시도 콜백**: `onRetry` 함수에서 `profileSettingViewModel.requestBlockList()` 호출 시 중복 요청 방지 필요 (로딩 중 상태 체크)
- **네트워크 에러 vs 데이터 비어있음**: ERROR 상태와 빈 리스트(empty data) 상태가 명확히 구분되어야 UI가 올바르게 렌더링됨

### 레이아웃 스페이싱
- **Spacer weight 값(176f, 336f)의 상대성**: 화면 높이가 변경되거나 다양한 디바이스에서 의도한 대로 배치되는지 검증 필요
- **이미지 크기 불일치 방지**: LazyColumn의 empty 상태에서는 `wrapContentHeight()` 사용, ErrorLayout에서는 명시적 `height(100.dp)` 사용 → 두 상태 간 이미지 크기 일관성 확인

### Composable 재구성
- `blockedUsers` 상태 변화 시 전체 화면이 ERROR 또는 LIST 상태로 전환되는데, 빈 리스트에서 에러로의 상태 전이가 부자연스러울 수 있음

---

## 3. 필수 검증 및 후속 테스트

### UI/UX 검증
- [ ] 모든 디바이스(스마트폰 정도, 태블릿)에서 Spacer weight 비율에 따른 이미지/텍스트/버튼 배치 확인
- [ ] 에러 상태 아이콘이 Figma 디자인과 정확히 일치하는지 비교
- [ ] 네비게이션 바 타이틀이 중앙 정렬되었는지, 양쪽 여백이 동일한지 확인
- [ ] 재시도 버튼 텍스트 "다시 시도"가 자연스럽게 표시되는지 확인

### 상태 관리 및 네트워크 테스트
- [ ] 네트워크 오류 발생 시 ERROR 상태로 정상 전환되는지 테스트
- [ ] 재시도 버튼 클릭 후 로딩 중 상태 표시 및 중복 요청 방지 검증
- [ ] 데이터가 비어있는 경우(정상 상태)와 에러 상태를 명확히 구분 가능한지 확인
- [ ] 차단 해제 성공 후 리스트가 정상 새로고침되고 에러 상태에서 빠져나오는지 테스트

### 다국어 및 호환성
- [ ] 재시도 텍스트 "다시 시도"가 다른 언어로도 제대로 표시되는지 확인
- [ ] 구형 안드로이드 버전(API 레벨 낮음)에서 레이아웃 깨짐 여부 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->