### PR TITLE
Search Result Screen UI based on Design QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -339,7 +339,6 @@ fun SearchResultEmpty() {
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = stringResource(id = R.string.search_result_empty_description),
-            modifier = Modifier.padding(vertical = 2.dp),
             color = Gray4_C5CAD2,
             fontWeight = FontWeight(500),
             style = DayoTheme.typography.caption2,
@@ -366,7 +365,6 @@ fun SearchResultsCount(resultCount: Int = 0) {
         ) {
             Text(
                 text = "$resultCount",
-                modifier = Modifier.padding(end = 2.dp),
                 style = TextStyle(
                     fontSize = 13.sp,
                     lineHeight = 19.5.sp,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -335,6 +335,7 @@ fun SearchResultEmpty() {
                     textAlign = TextAlign.Center
                 ),
         )
+        Spacer(modifier = Modifier.height(2.dp))
         Text(
             modifier = Modifier.padding(vertical = 2.dp),
             text = stringResource(id = R.string.search_result_empty_description),

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -351,33 +351,37 @@ fun SearchResultEmpty() {
 @Preview
 fun SearchResultsCount(resultCount: Int = 0) {
     Surface(
-        color = White_FFFFFF,
         modifier = Modifier
             .fillMaxWidth()
-            .height(44.dp),
+            .height(44.dp)
+            .background(White_FFFFFF)
+            .padding(horizontal = 18.dp, vertical = 12.dp)
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(0.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 18.dp, vertical = 12.dp)
+            modifier = Modifier.height(20.dp)
         ) {
             Text(
+                text = "$resultCount",
+                modifier = Modifier.padding(end = 2.dp),
                 style = TextStyle(
                     fontSize = 13.sp,
+                    lineHeight = 19.5.sp,
                     fontFamily = FontFamily(Font(R.font.pretendard_medium)),
                     fontWeight = FontWeight(500),
                     color = Primary_23C882
-                ),
-                text = "$resultCount",
-                modifier = Modifier.padding(end = 2.dp)
+                )
             )
             Text(
+                text = stringResource(R.string.search_result_count_description),
                 style = TextStyle(
                     fontSize = 13.sp,
+                    lineHeight = 19.5.sp,
                     fontFamily = FontFamily(Font(R.font.pretendard_medium)),
-                    fontWeight = FontWeight(500)
-                ),
-                text = "개의 검색결과"
+                    fontWeight = FontWeight(500),
+                    color = Gray2_767B83,
+                )
             )
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -87,6 +86,7 @@ import daily.dayo.presentation.theme.Gray1_50545B
 import daily.dayo.presentation.theme.Gray2_767B83
 import daily.dayo.presentation.theme.Gray3_9FA5AE
 import daily.dayo.presentation.theme.Gray5_E8EAEE
+import daily.dayo.presentation.theme.Gray6_F0F1F3
 import daily.dayo.presentation.theme.PrimaryL3_F2FBF7
 import daily.dayo.presentation.theme.Primary_23C882
 import daily.dayo.presentation.theme.White_FFFFFF
@@ -231,7 +231,7 @@ fun SearchResultScreen(
                         color = Primary_23C882,
                     )
                 },
-                divider = { Divider(color = Color.Transparent, thickness = 0.dp) },
+                divider = { Divider(color = Gray6_F0F1F3, thickness = 1.dp) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(18.dp, 0.dp, 18.dp, 0.dp),

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -360,7 +360,9 @@ fun SearchResultsCount(resultCount: Int = 0) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.height(20.dp)
+            modifier = Modifier
+                .height(20.dp)
+                .background(White_FFFFFF)
         ) {
             Text(
                 text = "$resultCount",

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -85,6 +85,7 @@ import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
 import daily.dayo.presentation.theme.Gray2_767B83
 import daily.dayo.presentation.theme.Gray3_9FA5AE
+import daily.dayo.presentation.theme.Gray4_C5CAD2
 import daily.dayo.presentation.theme.Gray5_E8EAEE
 import daily.dayo.presentation.theme.Gray6_F0F1F3
 import daily.dayo.presentation.theme.PrimaryL3_F2FBF7
@@ -337,13 +338,11 @@ fun SearchResultEmpty() {
         )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
-            modifier = Modifier.padding(vertical = 2.dp),
             text = stringResource(id = R.string.search_result_empty_description),
-            style = DayoTheme.typography.caption1
-                .copy(
-                    color = Gray3_9FA5AE,
-                    textAlign = TextAlign.Center
-                ),
+            modifier = Modifier.padding(vertical = 2.dp),
+            color = Gray4_C5CAD2,
+            fontWeight = FontWeight(500),
+            style = DayoTheme.typography.caption2,
         )
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -259,6 +259,7 @@
     <string name="search_recommend">추천 검색어</string>
     <string name="search_result_empty_title">앗! 찾으시는 검색 결과가 없어요.</string>
     <string name="search_result_empty_description">다른 검색어를 입력해보세요</string>
+    <string name="search_result_count_description">개의 검색 결과</string>
     <string name="search_history_clear">검색 기록 지우기</string>
     <string name="search_history_empty_title">최근 검색 결과가 없어요.</string>
     <string name="search_history_empty_description">관심있는 키워드 또는 사용자를 찾아보세요</string>


### PR DESCRIPTION
## 작업 내용
- 검색 결과 화면의 헤더 텍스트, 간격 수정
- 검색 결과 탭에 구분선 추가
- 검색 결과가 없을 때 보여지는 화면의 텍스트와 간격 조정

## 참고
- resolved: #1024 
- resolved: #1025 
- resolved: #1026 
- resolved: #1027 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 모듈별 요약: SearchResultScreen UI 개선

### 1. 기능 및 사용자 대면 변경사항

- TabRow 하단 Divider 추가
  - 기존 투명 Divider 대신 Gray6_F0F1F3 색상(RGB 약 240,241,243), 두께 1.dp 사용으로 탭 행 하단 구분선이 표시됨.
- 검색 결과 개수 표시 개선(SearchResultsCount)
  - 결과 개수를 숫자(Primary_23C882, 초록)와 설명("개의 검색 결과")으로 분리하여 노출.
  - Surface에 White 배경과 내부 패딩 적용(컨테이너 높이 44.dp 유지, 내부 Row 높이/레이아웃 조정).
  - 텍스트 간격을 2.dp로 설정하고 typography에 lineHeight(19.5.sp 등) 및 폰트/색상 조정 적용.
  - strings.xml에 search_result_count_description("개의 검색 결과") 리소스 추가.
- 검색 결과 없음(Empty) 화면 개선
  - 제목 아래 Spacer(2.dp) 추가로 수직 간격 조정.
  - 설명 텍스트 스타일 변경: 색상 Gray4_C5CAD2(약 RGB 197,202,210), fontWeight 500, caption2 typography 적용(기존 패딩 제거).
- 기타
  - SearchResultScreen 파일에 Gray4_C5CAD2 및 Gray6_F0F1F3 색상 import 추가 및 여러 레이아웃/정렬·간격 소소 조정으로 디자인 QA 반영.

### 2. 위험 요소 분석

- 전반적 위험도: 낮음 — 변경사항은 UI 스타일과 레이아웃에 국한되어 비즈니스 로직·네트워크·스레딩에는 영향 없음.
- 주의 포인트:
  - 테마·컬러 일관성: Gray4/Gray6 색상 상수 추가로 앱 전역 테마와 시각적 일관성 확인 필요(다크모드 영향 포함).
  - 고정 높이/레이아웃: SearchResultsCount의 고정 컨테이너 높이(44.dp)와 내부 Row 고정값으로 인해 긴 텍스트/언어별 확장에서 오버플로우나 클리핑 발생 가능.
  - 접근성(명도 대비): 변경된 설명 색상(Gray4_C5CAD2)과 배경 대비가 WCAG 기준을 만족하는지 검증 필요.
  - 문자열 리소스(i18n): "개의 검색 결과" 분리로 다국어 번역/문장 구조가 올바른지 확인 필요.

### 3. 필요 검증 및 후속 테스트

- 필수 검증
  1. Figma와의 픽셀/타입검증: 색상(RGB), 간격(Spacer/Divider 두께 및 여백), 폰트 가중치가 디자인 QA와 일치하는지 확인(여러 해상도에서).
  2. 텍스트 오버플로우/줄바꿈: 결과 개수(숫자 길이 포함)와 설명 텍스트가 고정 높이 영역에서 잘림 없이 표시되는지 확인(특히 큰 숫자, 로케일별 긴 번역).
  3. 라이트/다크 테마 검증: 새 색상과 배경 조합이 두 테마에서 의도대로 보이는지 확인.
  4. 접근성 검증: 색상 대비 기준 충족 여부 확인.
  5. 탭 전환/상태 전환 검증: TabRow 및 Empty/Result 상태 전환 시 레이아웃이 일관되게 동작하는지 확인(애니메이션/리렌더링 이상 유무).
- 권장 테스트
  - 다양한 기기 크기(폰·태블릿), 화면 밀도에서 레이아웃 점검.
  - 다국어(특히 한국어→영어→장문 언어)에서 문자열 배치·레이아웃 확인.
  - 엣지 케이스: 결과가 0, 1, 수백/수천 개일 때 UI 반응 확인.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->