### PR TITLE
Fix entire thumbnail card clickable

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
@@ -50,6 +50,7 @@ import java.text.DecimalFormat
 
 @Composable
 fun BookmarkScreen(
+    onPostClick: (Long) -> Unit,
     onBackClick: () -> Unit,
     bookmarkViewModel: BookmarkViewModel = hiltViewModel()
 ) {
@@ -105,7 +106,8 @@ fun BookmarkScreen(
                             post = post,
                             isEditMode = bookmarkUiState.isEditMode,
                             isSelected = bookmarkUiState.selectedBookmarks.contains(post.postId),
-                            onBookmarkClick = { bookmarkViewModel.toggleSelection(post.postId) }
+                            onBookmarkPostClick = { onPostClick(post.postId) },
+                            onBookmarkEditClick = { bookmarkViewModel.toggleSelection(post.postId) }
                         )
                     }
                 }
@@ -222,11 +224,10 @@ private fun BookmarkPostItem(
     post: BookmarkPost,
     isEditMode: Boolean,
     isSelected: Boolean,
-    onBookmarkClick: () -> Unit
+    onBookmarkPostClick: (BookmarkPost) -> Unit,
+    onBookmarkEditClick: () -> Unit
 ) {
-    Box(
-        modifier = Modifier.clickableSingle(onClick = { onBookmarkClick() })
-    ) {
+    Box {
         RoundImageView(
             context = LocalContext.current,
             imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",
@@ -234,12 +235,19 @@ private fun BookmarkPostItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)
+                .clickableSingle(onClick = {
+                    if (isEditMode) {
+                        onBookmarkEditClick()
+                    } else {
+                        onBookmarkPostClick(post)
+                    }
+                })
         )
 
         if (isEditMode) {
             DayoCheckbox(
                 checked = isSelected,
-                onCheckedChange = { onBookmarkClick() },
+                onCheckedChange = { onBookmarkEditClick() },
                 modifier = Modifier.align(Alignment.TopEnd)
             )
         }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
@@ -224,7 +224,9 @@ private fun BookmarkPostItem(
     isSelected: Boolean,
     onBookmarkClick: () -> Unit
 ) {
-    Box {
+    Box(
+        modifier = Modifier.clickableSingle(onClick = { onBookmarkClick() })
+    ) {
         RoundImageView(
             context = LocalContext.current,
             imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt
@@ -125,6 +125,7 @@ fun NavGraphBuilder.myPageNavGraph(
 
     composable(MyPageRoute.bookmark()) {
         BookmarkScreen(
+            onPostClick = onPostClick,
             onBackClick = onBackClick
         )
     }


### PR DESCRIPTION
## 작업 내용
- 북마크 게시글 편집 시 썸네일 카드 전체를 클릭 영역으로 지정 
- 편집 상태가 아닐 때 북마크 게시글 클릭 시 해당 게시글로 이동하는 기능 추가 

## 참고
- resolved : #1049 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 기능적 영향 및 사용자 경험 변화

- Bookmark 화면(presentation/src/.../bookmark/BookmarkScreen.kt)
  - 썸네일 카드 전체(이미지 포함)를 클릭 가능한 영역으로 변경하여 카드 전체 탭으로 게시글 열람 또는 편집 선택이 가능해짐.
  - 일반 모드: 카드 클릭 시 onPostClick(postId)를 호출해 해당 게시글로 네비게이트(편집 모드가 아닐 때의 동작).
  - 편집 모드: 카드 클릭(및 체크박스 조작)은 onBookmarkEditClick() → ViewModel의 toggleSelection(postId)를 호출해 선택/해제 처리.
  - 중복 클릭 방지용 clickableSingle(약 300ms) 적용으로 우발적 다중 클릭 방지.

- 내 정보 네비게이션(presentation/src/.../mypage/MypageNavigation.kt)
  - MyPageRoute.bookmark()에서 BookmarkScreen에 onPostClick 콜백을 전달하도록 변경 — 네비게이션/라우팅 쪽에서 게시글 클릭 핸들러를 수용.

## 위험 포인트

- 상태 일관성
  - 편집 모드에서 카드(Box)와 체크박스가 각기 onBookmarkEditClick()을 호출하므로 동일 액션으로 수렴하지만 클릭 이벤트가 중복 전달되거나 toggleSelection이 중복 호출될 수 있는 경로(체크박스 클릭 시 부모 Box로 이벤트 전파) 존재.
  - selectedBookmarks 집합 및 UI(체크박스 표시)가 비동기적으로 업데이트될 때 일시적 불일치(리컴포지션 시점) 가능성.

- 이벤트 소비/전파 충돌
  - 체크박스가 클릭 이벤트를 완전히 소비하지 않으면 부모 클릭 핸들러도 트리거되어 의도치 않은 이중 토글 발생 가능.

- 스레딩/네트워크 영향
  - 본 변경은 UI 이벤트/네비게이션 연결에 국한되어 네트워크 호출이나 백그라운드 스레드 변경은 없음. 다만 삭제(하단 버튼)나 선택 변경 시 ViewModel에서 비동기 작업(예: 서버 동기화)이 있다면 상태 반영 순서 관련 경합 가능성 존재.

- 에러 처리
  - 네비게이션(onPostClick) 경로가 null/잘못된 id를 전달하는 케이스나 선택 삭제 실패 시 사용자 피드백 처리(에러 토스트/롤백)가 충분히 보장되어야 함.

## 필수 후속 검증 및 테스트

1. 편집 모드 동작 검증
   - 카드(썸네일 포함) 클릭 시 toggleSelection(postId)가 정확히 한 번 호출되는지 확인.
   - 체크박스 클릭 시 부모 Box의 클릭이 중복 호출되지 않고 선택 상태가 한 번만 토글되는지 확인(이벤트 소비 여부 확인).
   - 빠른 연속 클릭(중복 클릭) 시 clickableSingle로 중복 토글 방지되는지 확인.

2. 일반 모드 동작 검증
   - 편집 모드가 아닐 때 카드 클릭이 onPostClick(postId)를 호출하여 정상적으로 상세 화면으로 네비게이트되는지 확인.
   - onPostClick에 전달되는 postId 값이 올바른지 검사(경계값/널 검사).

3. 상태 일관성 및 UI 동기화
   - selectedBookmarks 컬렉션과 체크박스 UI가 항상 동기화되는지(리컴포지션/페이징 항목 교체 시 포함) 확인.
   - 다수 아이템 선택/삭제 후 화면 상태(카운트, 버튼 활성화 등)가 정확히 반영되는지 확인.

4. 오류 및 네비게이션 예외
   - 삭제 실패 또는 서버 동기화 실패 시 롤백/에러 노출이 적절히 동작하는지 확인.
   - onPostClick으로 네비게이션 실패(잘못된 id) 시 앱 비정상 종료 방지 및 적절한 핸들링 확인.

5. 접근성 및 UX
   - 전체 카드가 클릭 대상이 된 만큼 터치 타깃이 적절한지, 보이스오버 등 접근성 도구에서의 포커스/설명(체크박스와 카드의 역할)이 명확한지 점검.

(변경된 주요 파일: presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt, presentation/src/main/java/daily/dayo/presentation/screen/mypage/MypageNavigation.kt)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->