### PR TITLE
Fix FolderCreateScreen based on QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderCreateScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderCreateScreen.kt
@@ -107,7 +107,7 @@ private fun FolderCreateScreen(
                 .background(DayoTheme.colorScheme.background)
                 .fillMaxSize()
                 .padding(contentPadding)
-                .padding(horizontal = 18.dp, vertical = 16.dp),
+                .padding(horizontal = 20.dp, vertical = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             DayoTextField(
@@ -143,7 +143,10 @@ private fun FolderCreateScreen(
             ToggleButtonWithLabel(
                 label = stringResource(R.string.write_post_folder_new_folder_privacy_title),
                 isToggled = privacy.value == Privacy.ONLY_ME,
-                onToggleChanged = { privacy.value = if (it) Privacy.ONLY_ME else Privacy.ALL }
+                onToggleChanged = { privacy.value = if (it) Privacy.ONLY_ME else Privacy.ALL },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.End),
             )
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Switch.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Switch.kt
@@ -3,10 +3,7 @@ package daily.dayo.presentation.view
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Text
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -24,15 +21,13 @@ import daily.dayo.presentation.theme.White_FFFFFF
 fun ToggleButtonWithLabel(
     label: String,
     isToggled: Boolean,
-    onToggleChanged: (Boolean) -> Unit
+    onToggleChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.End,
-        modifier = Modifier
-            .padding(18.dp)
-            .fillMaxWidth()
-            .wrapContentHeight()
+        modifier = modifier
     ) {
         Text(
             text = label,

--- a/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/TextField.kt
@@ -53,6 +53,7 @@ import daily.dayo.presentation.common.TextLimitUtil
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
+import daily.dayo.presentation.theme.Gray3_9FA5AE
 import daily.dayo.presentation.theme.Gray4_C5CAD2
 import daily.dayo.presentation.theme.Gray5_E8EAEE
 import daily.dayo.presentation.theme.Gray6_F0F1F3
@@ -90,7 +91,7 @@ fun DayoTextField(
             Text(
                 text = label,
                 style = DayoTheme.typography.caption3.copy(
-                    color = Gray4_C5CAD2,
+                    color = Gray3_9FA5AE,
                     fontWeight = FontWeight.SemiBold
                 )
             )
@@ -143,7 +144,7 @@ fun DayoTextField(
                             errorContainerColor = Color.Transparent,
                             focusedContainerColor = Color.Transparent,
                             unfocusedLabelColor = Color.Transparent, // 라벨
-                            focusedLabelColor = Gray4_C5CAD2,
+                            focusedLabelColor = Gray3_9FA5AE,
                             errorLabelColor = Red_FF4545,
                             focusedPlaceholderColor = Gray5_E8EAEE, // 힌트
                             unfocusedPlaceholderColor = Gray5_E8EAEE,
@@ -224,7 +225,7 @@ fun DayoPasswordTextField(
             Text(
                 text = label,
                 style = DayoTheme.typography.caption3.copy(
-                    color = Gray4_C5CAD2,
+                    color = Gray3_9FA5AE,
                     fontWeight = FontWeight.SemiBold
                 )
             )
@@ -278,7 +279,7 @@ fun DayoPasswordTextField(
                             errorContainerColor = Color.Transparent,
                             focusedContainerColor = Color.Transparent,
                             unfocusedLabelColor = Color.Transparent, // 라벨
-                            focusedLabelColor = Gray4_C5CAD2,
+                            focusedLabelColor = Gray3_9FA5AE,
                             errorLabelColor = Red_FF4545,
                             focusedPlaceholderColor = Gray5_E8EAEE, // 힌트
                             unfocusedPlaceholderColor = Gray5_E8EAEE,
@@ -355,7 +356,7 @@ fun DayoTimerTextField(
     isError: Boolean = false,
     errorMessage: String = "",
     timeOutErrorMessage: String = stringResource(id = R.string.email_address_certificate_alert_message_time_fail),
-    labelColor: Color = Gray4_C5CAD2,
+    labelColor: Color = Gray3_9FA5AE,
     onTimeOut: (() -> Unit) = { },
     textAlign: TextAlign = TextAlign.Left,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -437,7 +438,7 @@ fun DayoTimerTextField(
                             errorContainerColor = Color.Transparent,
                             focusedContainerColor = Color.Transparent,
                             unfocusedLabelColor = Color.Transparent, // 라벨
-                            focusedLabelColor = Gray4_C5CAD2,
+                            focusedLabelColor = Gray3_9FA5AE,
                             errorLabelColor = Red_FF4545,
                             focusedPlaceholderColor = Gray5_E8EAEE, // 힌트
                             unfocusedPlaceholderColor = Gray5_E8EAEE,


### PR DESCRIPTION
## 작업 내용
- 해당 페이지의 여백 조정
- 토글 버튼 조정
- 텍스트필드 라벨 색상 변경 

## 참고
- resolved : #1052
- resolved: #1050 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 모듈별 요약 및 위험 평가

### 1. 기능적 영향 및 사용자 대면 동작 변경

#### **FolderCreateScreen (폴더 생성 화면)**
- **여백 조정**: Column의 수평 padding을 `18.dp`에서 `20.dp`로 증가시켜 QA 명세와 일치하도록 조정
- **토글 버튼 레이아웃**: ToggleButtonWithLabel에 `.fillMaxWidth().align(Alignment.End)` modifier를 추가하여 토글 버튼이 우측 정렬되고 전체 너비를 차지하도록 변경
  - 결과: 토글과 우측 여백 사이의 과도한 수평 간격이 감소

#### **텍스트필드 라벨 색상 변경**
- **DayoTextField, DayoPasswordTextField, DayoTimerTextField**: 라벨 텍스트 색상을 `Gray4_C5CAD2` (밝은 회색)에서 `Gray3_9FA5AE` (더 어두운 회색)로 변경
  - 영향 범위: 전체 앱의 텍스트필드 라벨이 더 진하고 가시성이 높아짐

#### **ToggleButtonWithLabel 컴포넌트 리팩토링**
- `Switch.kt`의 ToggleButtonWithLabel이 선택적 `modifier` 파라미터를 추가하여 호출자가 레이아웃을 제어 가능하도록 변경
- 기존 hardcoded modifier (`padding(18.dp)`, `fillMaxWidth()`, `wrapContentHeight()`)는 제거

---

### 2. 위험 지점

#### **하위호환성 위험 (중간 수준)**
- `FolderEditScreen.kt`에서 ToggleButtonWithLabel을 호출할 때 modifier 파라미터를 전달하지 않음
  - 현재: 기본값인 `Modifier = Modifier`를 사용하므로 컴파일은 통과하지만, 레이아웃이 예상과 다를 수 있음
  - FolderEditScreen의 토글 버튼이 FolderCreateScreen과 다르게 렌더링될 가능성 존재
  - **필수 확인**: FolderEditScreen도 FolderCreateScreen과 동일하게 modifier를 적용했는지 검증 필요

#### **색상 일관성 위험 (낮음)**
- TextField 라벨 색상 변경이 TextField를 사용하는 모든 화면에 영향
  - 영향받는 화면: SignInScreen, SignInEmailScreen, ResetPasswordScreen, WithdrawScreen, WriteScreen 등 (약 20개 화면)
  - 기존 명시적 라벨 색상 오버라이드가 없는 경우, 모두 동일하게 색상이 변경되므로 일관성은 유지됨
  - **주의**: 특정 화면에서 라벨 색상을 명시적으로 지정한 경우는 영향 없음

#### **WriteFolderNewScreen 불일치**
- WriteFolderNewScreen.kt에는 로컬 ToggleButtonWithLabel 함수가 정의되어 있음 (중복 구현)
  - 이 파일의 로컬 함수는 변경되지 않았으므로 WriteFolderNewScreen의 토글은 기존 동작 유지
  - 향후 일관성을 위해 Switch.kt의 공용 컴포넌트로 통일 필요

---

### 3. 필수 검증 및 후속 테스트

#### **UI 레이아웃 검증 (필수)**
1. **FolderCreateScreen**: 
   - 토글 버튼이 우측 정렬되고 Figma 디자인 명세와 일치하는지 확인
   - 토글과 우측 여백의 간격이 디자인 명세와 일치하는지 확인
   - 여백 변경(18.dp → 20.dp)이 화면 좌우 여백을 올바르게 조정하는지 확인

2. **FolderEditScreen**: 
   - 폴더 편집 화면의 토글 버튼이 폴더 생성 화면과 동일하게 렌더링되는지 확인 (현재 modifier 미적용으로 인한 불일치 가능성)
   - **권장**: FolderEditScreen의 ToggleButtonWithLabel 호출에도 동일한 modifier 적용 필요

#### **텍스트필드 색상 검증 (필수)**
1. 모든 입력 화면(로그인, 회원가입, 설정 등)에서 라벨 텍스트 가시성 확인
2. 라벨 색상 변경이 다크 모드에서도 충분한 대비를 제공하는지 확인
3. Gray3_9FA5AE와 배경색의 명도 대비 비율 검증 (WCAG 접근성 기준: 최소 4.5:1)

#### **통합 테스트**
- 폴더 생성 및 편집 플로우 전체 테스트
- WriteFolderNewScreen과 FolderCreateScreen의 토글 버튼 외형 비교
- 다양한 화면 크기(휴대폰, 태블릿)에서의 레이아웃 일관성 확인

#### **회귀 테스트**
- TextField를 사용하는 모든 화면에서 라벨 가시성 확인
- 기존 라벨 색상을 명시적으로 오버라이드한 부분이 있는지 검색 및 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->