### PR TITLE
My Folder Screen UI based on QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -410,7 +411,8 @@ private fun FolderDropdownMenu(
         onDismissRequest = { expanded.value = false },
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
-            .width(140.dp)
+            .width(140.dp),
+        shape = RoundedCornerShape(16.dp)
     ) {
         menuItems.forEach {
             DropdownMenuItem(
@@ -436,6 +438,9 @@ private fun FolderDropdownMenu(
                     it.onClickMenu()
                     expanded.value = false
                 },
+                modifier = Modifier
+                    .padding(horizontal = 4.dp)
+                    .clip(RoundedCornerShape(12.dp)),
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 11.5.dp)
             )
         }

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.material3.Divider
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +46,7 @@ fun ConfirmDialog(
     ) {
         Box(
             modifier = modifier
+                .widthIn(min = 252.dp, max = 320.dp)
                 .background(
                     DayoTheme.colorScheme.background,
                     RoundedCornerShape(16.dp)

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
@@ -46,9 +46,9 @@ fun ConfirmDialog(
             modifier = modifier
                 .background(
                     DayoTheme.colorScheme.background,
-                    RoundedCornerShape(10.dp)
+                    RoundedCornerShape(16.dp)
                 )
-                .clip(RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(16.dp))
         ) {
             Column {
                 DialogHeader(title, description)

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/ConfirmDialog.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -87,6 +89,7 @@ private fun DialogHeader(title: String, description: String) {
         }
 
         if (description.isNotBlank()) {
+            Spacer(Modifier.height(8.dp))
             Text(
                 text = description,
                 color = Gray2_767B83,


### PR DESCRIPTION
## 작업 내용
- 폴더 화면의 옵션 스타일 변경
- 폴더 화면 이슈 중 이미 지정되어 있는 이슈는 close 처리함
- 폴더 삭제 시 dialog 스타일 수정

## 참고
- resolved : #1055 
- resolved: #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 모듈별 변경 사항

### 1. FolderScreen.kt - FolderDropdownMenu 컴포넌트

**기능 영향 및 사용자 대면 변화:**
- 폴더 옵션 드롭다운 메뉴의 시각적 스타일이 변경됨:
  - 드롭다운 메뉴 전체에 16dp 라운드 코너 적용 (RoundedCornerShape)
  - 각 메뉴 아이템에 4dp 수평 패딩 및 12dp 라운드 클립 추가로 개별 아이템의 모서리 처리 개선
- 메뉴 아이템의 시각적 구분과 터치 영역이 더 명확하게 정의됨

**위험 포인트:**
- UI 렌더링 변화만 해당 - 상태 관리, 이벤트 핸들링, 비즈니스 로직에 영향 없음
- 기존 onClick 핸들러와 expanded 상태 관리는 유지됨
- 클립 처리로 인한 텍스트/아이콘 잘림 가능성: contentPadding(horizontal: 16dp, vertical: 11.5dp)이 이미 적용되어 있어 content overflow 위험 낮음

---

### 2. ConfirmDialog.kt - 대화상자 스타일 개선

**기능 영향 및 사용자 대면 변화:**
- 대화상자 크기 제약 추가: 최소 252dp, 최대 320dp 너비로 고정
- 라운드 코너를 10dp에서 16dp로 확대하여 더 둥근 모서리 제공
- 제목과 설명 텍스트 사이에 8dp 스페이서 추가로 텍스트 간격 개선
- Material3 Text 컴포넌트로 마이그레이션 (Material 2에서 업그레이드)

**위험 포인트:**
- **레이아웃 안정성**: widthIn 제약으로 인해 매우 긴 텍스트는 클리핑될 수 있음 - 리소스 문자열 길이 검증 필요
- **재사용성**: 여러 화면에서 ConfirmDialog를 사용할 경우 새로운 크기 제약이 모든 대화상자에 균일하게 적용됨
- **상태 관리**: onDismissRequest 콜백은 변경 없음 - 기존 취소/확인 로직은 정상 작동

---

## 필수 검증 항목

### UI/UX 테스트
1. 폴더 옵션 메뉴: 아이콘과 텍스트가 12dp 라운드 클립 내에서 올바르게 렌더링되는지 확인
   - 메뉴 항목 클릭 반응성 및 피드백 확인
   - 다양한 텍스트 길이(예: 긴 이름)에서 오버플로우 없는지 검증

2. 폴더 삭제 대화상자: 
   - 320dp 최대 너비 제약 내에서 제목과 설명 텍스트 표시 확인 (한국어 포함)
   - 제목/설명 간 8dp 스페이서 시각적 효과 검증
   - 16dp 라운드 코너의 시각적 일관성 확인

### 호환성 검증
- Material3 Text 컴포넌트로의 마이그레이션이 다른 Text 사용 부분과 일관성 있는지 확인
- 다양한 디바이스 화면 크기(휴대폰, 태블릿)에서 widthIn 제약이 적절한지 검증

### 스크린 시나리오
- 폴더 목록에서 옵션 메뉴 터치 → 메뉴 열림/닫힘 동작 확인
- 폴더 삭제 흐름: 옵션 메뉴 → 삭제 선택 → 확인 대화상자 표시 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->