### PR TITLE
Update Bottom sheet style

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -160,21 +160,22 @@ fun BottomSheetDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .wrapContentHeight()
+                            .height(56.dp)
                             .background(
                                 if (isPressed) Gray6_F0F1F3 else White_FFFFFF,
                                 RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp)
                             )
-                            .padding(16.dp)
                             .clickable(
                                 onClick = button.second,
                                 interactionSource = interactionSource,
                                 indication = null
                             ),
                         horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
                             text = button.first,
+                            textAlign = TextAlign.Center,
                             color = if ((isFirstButtonColored && index == 0) || (checkedButtonIndex == index)) checkedColor else normalColor,
                             fontSize = 16.sp,
                             style = DayoTheme.typography.b4

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -68,7 +68,7 @@ fun BottomSheetDialog(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight(),
-        shape = RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp),
+        shape = RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp),
         color = White_FFFFFF
     ) {
         Column(

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -164,7 +164,7 @@ fun BottomSheetDialog(
                             .heightIn(min = 56.dp)
                             .background(
                                 if (isPressed) Gray6_F0F1F3 else White_FFFFFF,
-                                RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp)
+                                RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp)
                             )
                             .clickable(
                                 onClick = button.second,

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -160,7 +161,7 @@ fun BottomSheetDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(56.dp)
+                            .heightIn(min = 56.dp)
                             .background(
                                 if (isPressed) Gray6_F0F1F3 else White_FFFFFF,
                                 RoundedCornerShape(12.dp, 12.dp, 0.dp, 0.dp)

--- a/presentation/src/main/res/drawable/dialog_bottom_sheet_default.xml
+++ b/presentation/src/main/res/drawable/dialog_bottom_sheet_default.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="#FFFFFFFF"/>
-    <corners
-        android:topLeftRadius="30dp"
-        android:topRightRadius="30dp"/>
-</shape>

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -12,8 +12,6 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">#FFFFFFFF</item>
         <item name="android:windowLightStatusBar" tools:targetApi="1">true</item>
-        <!-- Customize your theme here. -->
-        <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
     </style>
     <style name="Theme.DAYO.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">#FFFFFFFF</item>
@@ -21,12 +19,4 @@
         <item name="postSplashScreenTheme">@style/Theme.DAYO</item>
     </style>
 
-    <style name="AppBottomSheetDialogTheme"
-        parent="Theme.Design.Light.BottomSheetDialog">
-        <item name="bottomSheetStyle">@style/AppModalStyle</item>
-    </style>
-
-    <style name="AppModalStyle" parent="Widget.Design.BottomSheet.Modal">
-        <item name="android:background">@drawable/dialog_bottom_sheet_default</item>
-    </style>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -12,23 +12,11 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">#FFFFFFFF</item>
         <item name="android:windowLightStatusBar" tools:targetApi="1">true</item>
-        <!-- Customize your theme here. -->
-        <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
     </style>
     <style name="Theme.DAYO.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">#FFFFFFFF</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_dayo_logo_splash</item>
         <item name="postSplashScreenTheme">@style/Theme.DAYO</item>
-    </style>
-
-    <style name="AppBottomSheetDialogTheme"
-        parent="Theme.Design.Light.BottomSheetDialog">
-        <item name="bottomSheetStyle">@style/AppModalStyle</item>
-    </style>
-
-    <style name="AppModalStyle"
-        parent="Widget.Design.BottomSheet.Modal">
-        <item name="android:background">@drawable/dialog_bottom_sheet_default</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## 작업 내용
- 사용하지 않는 xml 기반 바텀시트 스타일 설정 파일 제거
- 공통 바텀시트 Composable의 모서리 재설정
- 바텀시트 높이 추가

## 참고 
- resolved : #1062 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Bottom Sheet 스타일 업데이트

## 1. 기능적 영향 및 사용자 대면 변경
- BottomSheetDialog Composable
  - 상단 모서리 반경을 12dp → 20dp로 변경.
  - 버튼 행의 비아이콘 버튼에 최소 높이 heightIn으로 56dp 적용(이전에는 wrap/content), 행 패딩 제거 및 수직 중앙 정렬 보장.
  - 버튼 라벨 텍스트에 TextAlign.Center 적용으로 중앙 정렬 보장.
  - (커밋) 높이 설정을 height에서 heightIn으로 전환.
- XML 기반 스타일/리소스 제거
  - presentation/src/main/res/drawable/dialog_bottom_sheet_default.xml 제거(30dp 상단 모서리 정의 삭제).
  - values/values-night/themes.xml 및 values/themes.xml에서 Theme.DAYO의 bottomSheetDialogTheme 참조와 AppBottomSheetDialogTheme, AppModalStyle 스타일 삭제.
- 코드베이스 영향 범위
  - BottomSheetDialog를 사용하는 호출부(ProfileImageBottomSheetDialog, CommentBottomSheetDialog, 카테고리/다른 BottomSheet 호출처 등)가 존재함(검색으로 다수 파일 확인). 직접적인 XML drawable/style 참조는 검색 결과에서 발견되지 않음.

## 2. 위험 포인트
- 스타일/디자인 불일치
  - CommentBottomSheetDialog 등 기존 다이얼로그에 아직 12dp 모서리(또는 다른 값)를 사용 중일 가능성 있어, 여러 BottomSheet 간 시각적 불일치 발생 위험.
- 리소스 참조로 인한 빌드/런타임 문제
  - 제거된 drawable/style을 참조하는 구문은 현재 검색에서 발견되지 않았으나(검색 결과에 직접 참조 없음) 전체 빌드에서 숨겨진 참조가 있을 수 있음 — 전체 빌드 확인 필요.
- 레이아웃/접근성 이슈
  - 버튼 최소 높이(56dp)가 다국어(한글/영문) 긴 라벨, 멀티라인 텍스트, 또는 아이콘 포함 버튼과의 시각적 정렬에 미치는 영향.
- 상태/스레딩/에러 리스크: 변경은 UI 스타일/레이아웃 위주로 네트워크·스레딩·에러 처리에는 영향 없음.

## 3. 필수 검증 및 추후 작업
- UI/UX 검증
  1. 모든 BottomSheet 화면에서 시각적 회귀 확인(샘플 화면들):
     - ProfileImageBottomSheetDialog
     - CommentBottomSheetDialog
     - Category/Withdraw 등 프로젝트 내 모든 BottomSheet 호출처
  2. 동일한 디자인 규격(모서리 반경 20dp) 적용 여부 확인; 필요 시 CommentBottomSheetDialog 등도 20dp로 통일.
  3. 버튼 높이(56dp) 검증:
     - 다양한 텍스트 길이(한글/영문/멀티라인)에서 텍스트 잘림·레이아웃 파괴 없음 확인.
     - 아이콘 포함 버튼과의 정렬/높이 일관성 확인.
  4. 접근성(버튼 터치 타깃 최소 크기 등) 점검.
- 빌드 및 코드 검증
  - 전체 Gradle 빌드 및 릴리스 빌드 확인.
  - 제거된 리소스(dialog_bottom_sheet_default, AppBottomSheetDialogTheme, AppModalStyle) 참조 여부 전역 검색(이미 일부 검색 수행됨) 및 CI 빌드 확인.
- 코드리뷰 체크포인트
  - 디자인 의도(모서리 반경과 버튼 높이 표준화)가 제품/디자인팀 합의된 것인지 확인.
  - height → heightIn 변경 의도와 부작용(스크롤/최소 높이 상호작용) 검토.
  - Preview/다크모드에서의 동작 확인(값이 values-night/values 양쪽에서 제거됨).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->