### PR TITLE
Feed UI based on Design QA

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/feed/FeedScreen.kt
@@ -203,6 +203,12 @@ private fun FeedEmptyView(onEmptyViewClick: () -> Unit) {
         Text(text = stringResource(id = R.string.feed_empty_description), style = DayoTheme.typography.caption1.copy(Gray4_C5CAD2))
 
         Spacer(modifier = Modifier.height(36.dp))
-        FilledButton(onClick = onEmptyViewClick, label = stringResource(id = R.string.feed_empty_button))
+        FilledButton(
+            onClick = onEmptyViewClick,
+            label = stringResource(id = R.string.feed_empty_button),
+            modifier = Modifier.height(44.dp),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 11.5.dp),
+            textStyle = DayoTheme.typography.b5
+        )
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/main/MainScreen.kt
@@ -292,6 +292,7 @@ internal fun MainScreen(
                             onDismissRequest = { bottomSheetController.hide() },
                             modifier = Modifier.navigationBarsPadding(),
                             sheetState = bottomSheetState,
+                            sheetGesturesEnabled = false,
                             dragHandle = null
                         ) {
                             Box {

--- a/presentation/src/main/java/daily/dayo/presentation/screen/post/PostScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/post/PostScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateListOf
@@ -106,12 +105,10 @@ fun PostScreen(
         postViewModel.requestDeletePostComment(commentId)
     }
     val postCommentDeleteSuccess by postViewModel.postCommentDeleteSuccess.observeAsState(Event(false))
-    if (postCommentDeleteSuccess.getContentIfNotHandled() == true) {
-        postViewModel.requestPostComment(postId)
-        SideEffect {
-            coroutineScope.launch {
-                snackBarHostState.showSnackbar(context.getString(R.string.comment_delete_message))
-            }
+    LaunchedEffect(postCommentDeleteSuccess) {
+        if (postCommentDeleteSuccess.getContentIfNotHandled() == true) {
+            postViewModel.requestPostComment(postId)
+            snackBarHostState.showSnackbar(context.getString(R.string.comment_delete_message))
         }
     }
     var showReportDialog by remember { mutableStateOf(false) }
@@ -493,4 +490,3 @@ private fun PreviewPostScreen() {
         )
     }
 }
-

--- a/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
@@ -50,7 +50,9 @@ fun FilledButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     isTonal: Boolean = false,
-    icon: @Composable (() -> Unit)? = null
+    icon: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    textStyle: TextStyle = DayoTheme.typography.b6
 ) {
     val buttonColors = if (isTonal)
         ButtonDefaults.buttonColors(
@@ -73,10 +75,10 @@ fun FilledButton(
         modifier = modifier,
         enabled = enabled,
         colors = buttonColors,
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        contentPadding = contentPadding,
         content = {
             if (icon != null) icon()
-            Text(text = label, style = DayoTheme.typography.b6)
+            Text(text = label, style = textStyle)
         }
     )
 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
@@ -12,25 +12,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
-import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.TextFieldDefaults.TextFieldDecorationBox
-import androidx.compose.material.TextFieldDefaults.textFieldColors
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -56,7 +49,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -396,7 +388,6 @@ fun CommentReplyDescriptionView(replyCommentState: MutableState<Pair<Long, Comme
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun CommentTextField(
     enabled: Boolean,
@@ -417,10 +408,10 @@ fun CommentTextField(
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
             .fillMaxWidth()
-            .wrapContentHeight()
-            .padding(horizontal = 18.dp)
+            .height(64.dp)
+            .padding(horizontal = 16.dp)
             .padding(top = 12.dp, bottom = 16.dp),
-        verticalAlignment = Alignment.Bottom
+        verticalAlignment = Alignment.CenterVertically
     ) {
         val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
         BasicTextField(
@@ -463,32 +454,36 @@ fun CommentTextField(
                 }
             },
             modifier = Modifier
-                .padding(end = 8.dp)
-                .heightIn(min = 36.dp)
                 .weight(1f)
+                .height(36.dp)
                 .focusRequester(focusRequester),
             textStyle = DayoTheme.typography.b6,
             interactionSource = interactionSource,
             cursorBrush = SolidColor(Primary_23C882),
             decorationBox = @Composable { innerTextField ->
-                TextFieldDecorationBox(
-                    value = commentText.value.text,
-                    innerTextField = innerTextField,
-                    enabled = true,
-                    singleLine = false,
-                    visualTransformation = VisualTransformation.None,
-                    interactionSource = interactionSource,
-                    placeholder = { Text(text = "댓글을 남겨주세요", style = DayoTheme.typography.b6.copy(Gray4_C5CAD2)) },
-                    shape = DayoTheme.shapes.small.copy(all = CornerSize(12.dp)),
-                    colors = textFieldColors(backgroundColor = Gray7_F6F6F7),
-                    contentPadding = TextFieldDefaults.textFieldWithLabelPadding(top = 8.dp, bottom = 8.dp, start = 12.dp)
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Gray7_F6F6F7, RoundedCornerShape(12.dp))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (commentText.value.text.isEmpty()) {
+                        Text(
+                            text = "댓글을 남겨주세요",
+                            style = DayoTheme.typography.b6.copy(Gray4_C5CAD2)
+                        )
+                    }
+                    innerTextField()
+                }
             }
         )
 
+        Spacer(modifier = Modifier.width(8.dp))
+
         Box(
             modifier = Modifier
-                .defaultMinSize(minWidth = 64.dp, minHeight = 36.dp)
+                .height(36.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(color = if (enabled) Primary_23C882 else PrimaryL1_8FD9B9)
                 .clickableSingle(enabled = enabled) { onClickPostComment() }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
@@ -91,31 +91,35 @@ fun CommentListView(
             if (postComments.isEmpty()) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
                     modifier = Modifier
                         .background(DayoTheme.colorScheme.background)
                         .fillMaxSize()
-                        .padding(top = 12.dp, bottom = 30.dp)
                         .then(modifier)
                 ) {
-                    if (showEmptyIcon) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_comment_empty),
-                            contentDescription = "empty",
-                            tint = Color.Unspecified
+                    Spacer(modifier = Modifier.weight(64f))
+
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        if (showEmptyIcon) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_comment_empty),
+                                contentDescription = "empty",
+                                tint = Color.Unspecified
+                            )
+                        }
+
+                        Text(
+                            text = stringResource(id = R.string.post_comment_empty),
+                            style = DayoTheme.typography.b5.copy(Gray2_767B83),
+                            modifier = Modifier.padding(top = 12.dp, bottom = 2.dp)
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            text = stringResource(id = R.string.post_comment_empty_description),
+                            style = DayoTheme.typography.caption4.copy(Gray3_9FA5AE)
                         )
                     }
 
-                    Text(
-                        text = stringResource(id = R.string.post_comment_empty),
-                        style = DayoTheme.typography.b5.copy(Gray2_767B83),
-                        modifier = Modifier.padding(top = 12.dp, bottom = 2.dp)
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        text = stringResource(id = R.string.post_comment_empty_description),
-                        style = DayoTheme.typography.caption4.copy(Gray3_9FA5AE)
-                    )
+                    Spacer(modifier = Modifier.weight(135f))
                 }
             } else {
                 Column(

--- a/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -329,20 +330,24 @@ fun CommentMentionSearchView(userResults: LazyPagingItems<SearchUser>, onClickFo
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
             .fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 18.dp)
+        contentPadding = PaddingValues(start = 18.dp, end = 18.dp, top = 16.dp, bottom = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         items(userResults.itemCount) { index ->
             userResults[index]?.let { user ->
+                val interactionSource = remember { MutableInteractionSource() }
+                val isPressed = interactionSource.collectIsPressedAsState().value
                 Row(
                     modifier = Modifier
-                        .background(DayoTheme.colorScheme.background)
                         .fillMaxWidth()
-                        .padding(vertical = 4.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(if (isPressed) Gray7_F6F6F7 else DayoTheme.colorScheme.background)
                         .clickableSingle(
-                            indication = ripple(bounded = false, radius = 8.dp, color = Gray7_F6F6F7),
-                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            interactionSource = interactionSource,
                             onClick = { onClickFollowUser(user) }
-                        ),
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RoundImageView(
@@ -350,12 +355,7 @@ fun CommentMentionSearchView(userResults: LazyPagingItems<SearchUser>, onClickFo
                         context = LocalContext.current,
                         modifier = Modifier
                             .clip(CircleShape)
-                            .size(24.dp)
-                            .clickableSingle(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null,
-                                onClick = { }
-                            ),
+                            .size(24.dp),
                         imageDescription = "search users profile image",
                     )
                     Spacer(modifier = Modifier.width(12.dp))

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -285,19 +285,19 @@ fun FeedPostView(
             // like count
             val dec = DecimalFormat("#,###")
             Row(modifier = Modifier.weight(1f)) {
-                Text(text = stringResource(id = R.string.post_like_count_message_1), style = DayoTheme.typography.caption1.copy(Gray2_767B83))
+                Text(text = stringResource(id = R.string.post_like_count_message_1), style = DayoTheme.typography.caption2.copy(Gray2_767B83))
                 Text(
                     text = " ${dec.format(post.heartCount)} ",
-                    style = DayoTheme.typography.caption1,
+                    style = DayoTheme.typography.caption2,
                     modifier = if (post.heartCount != 0) Modifier.clickableSingle { post.postId?.let { onPostLikeUsersClick(it) } } else Modifier,
                     color = if (post.heartCount != 0) Primary_23C882 else Gray4_C5CAD2)
-                Text(text = stringResource(id = R.string.post_like_count_message_2), style = DayoTheme.typography.caption1.copy(Gray2_767B83))
+                Text(text = stringResource(id = R.string.post_like_count_message_2), style = DayoTheme.typography.caption2.copy(Gray2_767B83))
             }
 
             // comment count
             Row {
-                Text(text = " ${dec.format(post.commentCount)} ", style = DayoTheme.typography.caption1, color = if (post.commentCount != 0) Primary_23C882 else Gray4_C5CAD2)
-                Text(text = stringResource(id = R.string.post_comment_count_message), style = DayoTheme.typography.caption1.copy(Gray2_767B83))
+                Text(text = " ${dec.format(post.commentCount)} ", style = DayoTheme.typography.caption2, color = if (post.commentCount != 0) Primary_23C882 else Gray4_C5CAD2)
+                Text(text = stringResource(id = R.string.post_comment_count_message), style = DayoTheme.typography.caption2.copy(Gray2_767B83))
             }
         }
 

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateListOf
@@ -94,12 +93,10 @@ fun CommentBottomSheetDialog(
         postViewModel.requestDeletePostComment(commentId)
     }
     val postCommentDeleteSuccess by postViewModel.postCommentDeleteSuccess.observeAsState(Event(false))
-    if (postCommentDeleteSuccess.getContentIfNotHandled() == true) {
-        postViewModel.requestPostComment(postId)
-        SideEffect {
-            coroutineScope.launch {
-                snackBarHostState.showSnackbar("댓글이 삭제되었어요.")
-            }
+    LaunchedEffect(postCommentDeleteSuccess) {
+        if (postCommentDeleteSuccess.getContentIfNotHandled() == true) {
+            postViewModel.requestPostComment(postId)
+            snackBarHostState.showSnackbar(context.getString(R.string.comment_delete_message))
         }
     }
     var showReportDialog by remember { mutableStateOf(false) }

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -92,7 +94,11 @@ fun CommentBottomSheetDialog(
     val onClickDelete: (Long) -> Unit = { commentId ->
         postViewModel.requestDeletePostComment(commentId)
     }
-    val postCommentDeleteSuccess by postViewModel.postCommentDeleteSuccess.observeAsState(Event(false))
+    val postCommentDeleteSuccess by postViewModel.postCommentDeleteSuccess.observeAsState(
+        Event(
+            false
+        )
+    )
     LaunchedEffect(postCommentDeleteSuccess) {
         if (postCommentDeleteSuccess.getContentIfNotHandled() == true) {
             postViewModel.requestPostComment(postId)
@@ -130,14 +136,24 @@ fun CommentBottomSheetDialog(
     }
 
     // create comment
-    val replyCommentState = remember { mutableStateOf<Pair<Long, Comment>?>(null) } // parent comment Id, reply comment
+    val replyCommentState =
+        remember { mutableStateOf<Pair<Long, Comment>?>(null) } // parent comment Id, reply comment
     val onClickPostComment: () -> Unit = {
         if (replyCommentState.value == null) {
             if (commentText.value.text.isNotBlank()) {
-                postViewModel.requestCreatePostComment(commentText.value.text, postId, mentionedMemberIds)
+                postViewModel.requestCreatePostComment(
+                    commentText.value.text,
+                    postId,
+                    mentionedMemberIds
+                )
             }
         } else {
-            postViewModel.requestCreatePostCommentReply(replyCommentState.value!!, commentText.value.text, postId, mentionedMemberIds)
+            postViewModel.requestCreatePostCommentReply(
+                replyCommentState.value!!,
+                commentText.value.text,
+                postId,
+                mentionedMemberIds
+            )
         }
     }
     val onClickReply: (Pair<Long, Comment>?) -> Unit = { reply ->
@@ -146,7 +162,8 @@ fun CommentBottomSheetDialog(
 
         // show mention user name
         val replyUsername = "@${replyCommentState.value?.second?.nickname} "
-        commentText.value = TextFieldValue(text = replyUsername, selection = TextRange(replyUsername.length))
+        commentText.value =
+            TextFieldValue(text = replyUsername, selection = TextRange(replyUsername.length))
         commentFocusRequester.requestFocus()
     }
     val commentEnabled = if (replyCommentState.value == null) {
@@ -204,7 +221,7 @@ fun CommentBottomSheetDialog(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 12.dp, bottom = 65.dp)
+                    .padding(bottom = 65.dp)
                     .wrapContentHeight(),
             ) {
                 CommentBottomSheetDialogTitle(clearComment, onClickClose)
@@ -222,8 +239,14 @@ fun CommentBottomSheetDialog(
             }
 
             Column(modifier = Modifier.align(Alignment.BottomCenter)) {
-                if (showMentionSearchView.value) CommentMentionSearchView(userResults, onClickFollowUser)
-                if (replyCommentState.value != null) CommentReplyDescriptionView(replyCommentState, onClickCancelReply)
+                if (showMentionSearchView.value) CommentMentionSearchView(
+                    userResults,
+                    onClickFollowUser
+                )
+                if (replyCommentState.value != null) CommentReplyDescriptionView(
+                    replyCommentState,
+                    onClickCancelReply
+                )
                 CommentTextField(
                     enabled = commentEnabled,
                     commentText = commentText,
@@ -258,12 +281,15 @@ private fun CommentBottomSheetDialogTitle(clearComment: () -> Unit, onClickClose
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
+            .height(48.dp)
             .background(DayoTheme.colorScheme.background)
     ) {
         Text(
             text = stringResource(id = R.string.comment),
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(top = 15.dp, bottom = 6.dp)
+                .height(27.dp),
             textAlign = TextAlign.Center,
             style = DayoTheme.typography.b1.copy(color = Dark, fontWeight = FontWeight.SemiBold)
         )
@@ -275,7 +301,10 @@ private fun CommentBottomSheetDialogTitle(clearComment: () -> Unit, onClickClose
             },
             iconContentDescription = "close",
             iconPainter = painterResource(id = R.drawable.ic_x),
-            iconButtonModifier = Modifier.align(Alignment.CenterEnd)
+            iconButtonModifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 8.dp)
+                .size(32.dp)
         )
     }
 }

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/CommentBottomSheetDialog.kt
@@ -325,16 +325,35 @@ private fun CommentBottomSheetDialogContent(
             .fillMaxHeight(0.8f)
     ) {
         item {
-            CommentListView(
-                currentMemberId = currentMemberId,
-                postComments = postComments,
-                onClickProfile = onClickCommentProfile,
-                onClickReply = onClickReply,
-                onClickDelete = onClickDelete,
-                onClickReport = onClickReport,
-                modifier = Modifier.padding(horizontal = 18.dp),
-                showEmptyIcon = true
-            )
+            if (postComments.data.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillParentMaxHeight()
+                        .fillMaxWidth()
+                ) {
+                    CommentListView(
+                        currentMemberId = currentMemberId,
+                        postComments = postComments,
+                        onClickProfile = onClickCommentProfile,
+                        onClickReply = onClickReply,
+                        onClickDelete = onClickDelete,
+                        onClickReport = onClickReport,
+                        modifier = Modifier.padding(horizontal = 18.dp),
+                        showEmptyIcon = true
+                    )
+                }
+            } else {
+                CommentListView(
+                    currentMemberId = currentMemberId,
+                    postComments = postComments,
+                    onClickProfile = onClickCommentProfile,
+                    onClickReply = onClickReply,
+                    onClickDelete = onClickDelete,
+                    onClickReport = onClickReport,
+                    modifier = Modifier.padding(horizontal = 18.dp),
+                    showEmptyIcon = true
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/res/drawable/ic_feed_empty.xml
+++ b/presentation/src/main/res/drawable/ic_feed_empty.xml
@@ -1,47 +1,68 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="136dp"
     android:height="100dp"
+    android:autoMirrored="true"
     android:viewportWidth="136"
     android:viewportHeight="100">
-    <path
-        android:fillColor="#FFEDEDED"
-        android:pathData="M86.16 14.29H35.22c-6.25 0-11.32 5.04-11.32 11.27v50.7c0 6.23 5.07 11.27 11.32 11.27h50.94c6.25 0 11.32-5.04 11.32-11.27v-50.7c0-6.23-5.07-11.27-11.32-11.27Z"/>
-    <path
-        android:fillColor="#FFD3D2D2"
-        android:pathData="M99.06 25.8H48.12c-6.25 0-11.32 5.05-11.32 11.27v50.7c0 6.23 5.07 11.27 11.32 11.27h50.94c6.25 0 11.32-5.04 11.32-11.26V37.07c0-6.22-5.07-11.27-11.32-11.27Z"/>
-    <path
-        android:fillColor="#FFEDEDED"
-        android:pathData="M67.96 36H52.04C49.26 36 47 38.26 47 41.04v15.92c0 2.78 2.26 5.04 5.04 5.04h15.92c2.78 0 5.04-2.26 5.04-5.04V41.04c0-2.78-2.26-5.04-5.04-5.04Z"/>
-    <path
-        android:strokeColor="#FFEDEDED"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:strokeMiterLimit="10"
-        android:pathData="M47.43 77.53h52.31"/>
-    <path
-        android:strokeColor="#FFEDEDED"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:strokeMiterLimit="10"
-        android:pathData="M47.43 85.47h52.31"/>
-    <path
-        android:fillColor="#FFC8C8C8"
-        android:pathData="M28.54 41.16l-12.56-3.1-2.02 8.17 12.56 3.1 2.02-8.16Z"/>
-    <path
-        android:fillColor="#FFC8C8C8"
-        android:pathData="M117.2 80.06L107 86.44l4.5 7.12 10.2-6.39-4.5-7.11Z"/>
-    <path
-        android:fillColor="#FFD3D2D2"
-        android:fillAlpha="0.5"
-        android:pathData="M127.6 27.85l-6.7 5.12 7.6 9.86 6.7-5.12-7.6-9.86Z"/>
-    <path
-        android:fillColor="#FFD3D2D2"
-        android:fillAlpha="0.5"
-        android:pathData="M9.62 1L1.7 11.19l6.68 5.14L16.3 6.14 9.62 1Z"/>
-    <path
-        android:fillColor="#FFC8C8C8"
-        android:pathData="M86.56 6.1l-4.54 12.87 7.97 2.78 4.54-12.87-7.97-2.78Z"/>
-    <path
-        android:fillColor="#FFF6F6F6"
-        android:pathData="M1.64 79.3L0 87.54l10.97 2.16 1.63-8.25L1.64 79.3Z"/>
+
+    <group>
+
+        <clip-path android:pathData="M0,0h136v100h-136z" />
+
+        <path
+            android:fillColor="#F6F6F7"
+            android:pathData="M86.16,14.29H35.22C28.97,14.29 23.9,19.33 23.9,25.56V76.26C23.9,82.49 28.97,87.53 35.22,87.53H86.16C92.41,87.53 97.48,82.49 97.48,76.26V25.56C97.48,19.33 92.41,14.29 86.16,14.29Z" />
+
+        <path
+            android:fillColor="#E8EAEE"
+            android:pathData="M99.06,25.8H48.12C41.87,25.8 36.8,30.85 36.8,37.07V87.78C36.8,94 41.87,99.04 48.12,99.04H99.06C105.31,99.04 110.38,94 110.38,87.78V37.07C110.38,30.85 105.31,25.8 99.06,25.8Z" />
+
+        <path
+            android:fillColor="#F6F6F7"
+            android:pathData="M67.96,36H52.04C49.26,36 47,38.26 47,41.04V56.96C47,59.74 49.26,62 52.04,62H67.96C70.74,62 73,59.74 73,56.96V41.04C73,38.26 70.74,36 67.96,36Z" />
+
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M47.43,77.53H99.74"
+            android:strokeWidth="3"
+            android:strokeColor="#F6F6F7"
+            android:strokeLineCap="round" />
+
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M47.43,85.47H99.74"
+            android:strokeWidth="3"
+            android:strokeColor="#F6F6F7"
+            android:strokeLineCap="round" />
+
+        <path
+            android:fillColor="#E8EAEE"
+            android:pathData="M28.54,41.17L15.98,38.06L13.96,46.23L26.52,49.33L28.54,41.17Z" />
+
+        <path
+            android:fillColor="#E8EAEE"
+            android:pathData="M117.2,80.06L107,86.44L111.5,93.56L121.7,87.17L117.2,80.06Z" />
+
+        <path
+            android:fillAlpha="0.5"
+            android:fillColor="#E8EAEE"
+            android:pathData="M127.61,27.85L120.9,32.97L128.5,42.83L135.2,37.71L127.61,27.85Z"
+            android:strokeAlpha="0.5" />
+
+        <path
+            android:fillAlpha="0.5"
+            android:fillColor="#E8EAEE"
+            android:pathData="M9.62,1L1.71,11.19L8.39,16.33L16.3,6.14L9.62,1Z"
+            android:strokeAlpha="0.5" />
+
+        <path
+            android:fillColor="#E8EAEE"
+            android:pathData="M86.56,6.1L82.02,18.97L89.99,21.75L94.53,8.88L86.56,6.1Z" />
+
+        <path
+            android:fillColor="#F6F6F7"
+            android:pathData="M1.64,79.3L0,87.54L10.97,89.7L12.6,81.45L1.64,79.3Z" />
+
+    </group>
+
 </vector>


### PR DESCRIPTION
### 작업 내용
- 피드 Empty 화면 이미지 색상 및 버튼 높이/패딩 디자인 QA 반영
- 피드 게시글 좋아요/댓글 수 텍스트 웨이트 및 컬러 스타일 조정
- 댓글 바텀시트 헤더 높이, 닫기 버튼 여백, 스크롤 중 닫힘 제스처 동작 수정
- 댓글 Empty 영역 중앙 정렬 및 입력창/등록 버튼 높이 조정
- 댓글 멘션 리스트 간격 및 항목 터치 상태 스타일 반영
- 댓글 삭제 완료 스낵바 노출 처리 개선

### 참고
- resolved: #1028
- resolved: #1029
- resolved: #1030
- resolved: #1031
- resolved: #1032
- resolved: #1033
- resolved: #1034
- resolved: #1035
- resolved: #1065
- resolved: #1066
- resolved: #1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 모듈별 기능 영향 및 사용자 대면 변경사항

### 피드 화면 (FeedScreen)
- **빈 상태 UI 개선**: 빈 피드 상태의 "친구를 팔로우하세요" 버튼을 높이 44dp, 패딩(좌우 20dp, 상하 11.5dp), b5 텍스트 스타일로 표준화
- **버튼 재사용성 강화**: `FilledButton` 컴포저블에 `contentPadding`과 `textStyle` 파라미터를 추가하여 향후 버튼 스타일 커스터마이징 가능하게 개선

### 댓글 화면 (Comment & CommentBottomSheetDialog)
- **입력 필드 높이 통일**: 댓글 입력 필드 및 제출 버튼 높이를 36dp로 표준화하여 디자인 일관성 확보
- **멘션 리스트 상호작용 개선**: 
  - 멘션 아이템 제시 시 터치 상태에서 배경색 채우기(MutableInteractionSource 활용)
  - 아이템 간 수직 간격 증가
- **빈 댓글 상태 중앙 정렬**: Spacer 기반 가중치 레이아웃으로 empty view 콘텐츠를 화면 중앙에 배치
- **삭제 완료 피드백**: 댓글 삭제 성공 시 "댓글이 삭제되었어요" 토스트 메시지 표시

### 메인 화면 (MainScreen)
- **댓글 bottom sheet 스크롤 중 닫기 방지**: `sheetGesturesEnabled = false` 설정으로 사용자가 리스트를 스크롤하는 중에 실수로 sheet를 닫는 것 방지

### 피드 아이템 (FeedPostView)
- **메타데이터 텍스트 가중치 조정**: 좋아요/댓글 카운트를 caption1에서 caption2로 변경하여 시각적 계층 명확화

### 피드 빈 상태 이미지 (ic_feed_empty.xml)
- **색상 팔레트 업데이트**: 라이트 핑크/그레이에서 F6F6F7/E8EAEE 그레이로 변경하여 디자인 QA 준수
- **RTL 지원 추가**: `autoMirrored="true"` 속성으로 우-좌 언어 지원

---

## 위험 포인트 및 상태 관리

### 중위험: 비동기 효과(Effect) 패턴 변경
- **변경 사항**: 댓글 삭제 성공 처리를 `SideEffect + coroutineScope.launch`에서 `LaunchedEffect(postCommentDeleteSuccess)` 이벤트 기반으로 마이그레이션
- **위험 요소**:
  - `Event` 래퍼의 `getContentIfNotHandled()` 동작이 정확히 한 번만 실행되어야 함
  - Compose 리컴포지션 시 중복 실행 방지 필요
  - 네트워크 요청(`requestPostComment`) 중에 사용자가 sheet를 닫을 경우 Race condition 가능성
- **검증 필요**: 댓글 삭제 후 목록 새로고침이 정확히 한 번만 발생하는지 확인

### 저위험: UI 상태 일관성
- **변경 사항**: `MutableInteractionSource`를 멘션 리스트 행에 추가하여 pressed 상태 시각화
- **위험 요소**: 빠른 탭/제스처 시 상태 전환이 즉시 반영되지 않을 수 있음
- **영향 범위**: 제한적(멘션 리스트만 영향)

### 저위험: bottom sheet 제스처 비활성화
- **변경 사항**: `sheetGesturesEnabled = false`로 드래그/스와이프 상호작용 완전 차단
- **부작용**: 사용자가 bottom sheet를 드래그로 닫을 수 없음(명시적 close 버튼에만 의존)
- **검증 필요**: close 버튼 가시성 및 접근성 확인

---

## 필수 테스트 및 검증 항목

### 기능 테스트
1. **댓글 삭제 플로우**:
   - 댓글 삭제 후 "댓글이 삭제되었어요" 토스트가 정확히 한 번만 표시되는지 확인
   - 토스트 표시 중 댓글 목록이 자동으로 새로고침되는지 확인
   - 삭제 후 빈 댓글 상태 화면이 중앙에 올바르게 표시되는지 확인

2. **멘션 목록 상호작용**:
   - 멘션 아이템 탭 시 배경색 채우기(터치 상태)가 명확히 시각화되는지 확인
   - 아이템 간 스펙(4dp 간격)이 시각적으로 일관성 있는지 확인

3. **댓글 입력 필드**:
   - 입력 필드와 제출 버튼이 36dp 높이로 정렬되어 있는지 확인
   - 플레이스홀더 텍스트 표시 여부 확인
   - 비활성화 상태 스타일 확인

4. **Bottom sheet 제스처**:
   - 드래그/스와이프로 sheet를 닫을 수 없음을 확인
   - close 버튼으로만 닫히는지 확인
   - 스크롤 중 의도치 않은 닫기가 발생하지 않는지 확인

5. **피드 UI 개선**:
   - 빈 피드 버튼 높이(44dp), 패딩, 텍스트 스타일이 디자인 스펙과 일치하는지 확인
   - 좋아요/댓글 카운트 텍스트 크기 변경이 시각적으로 적절한지 확인
   - 피드 빈 상태 이미지 색상이 디자인 QA와 일치하는지 확인

### 회귀(Regression) 테스트
1. **다른 bottom sheet UI**: CommentBottomSheetDialog 외 다른 modal sheet가 있을 경우 정상 작동 확인
2. **FilledButton 호출처**: Button.kt 파라미터 확장으로 기존 호출처에서 호환성 확인 필요
3. **댓글 네트워크 요청**: 느린 네트워크에서 삭제 후 목록 새로고침 중 sheet 닫기 테스트

### 엣지 케이스 및 상태 검증
1. **공시 패턴 (`Event<T>`) 정확성**: 댓글 삭제 성공 이벤트가 재처리되지 않는지 확인
2. **Compose 리컴포지션 안정성**: 화면 회전, 배경/포그라운드 전환 시 토스트 중복 표시 여부 확인
3. **빈 댓글 목록 조건**: postComments.data가 비어있을 때 empty icon/text/중앙정렬 모두 올바르게 표시되는지 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->