### PR TITLE
Settings UI based on Design QA   

### DIFF
--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
@@ -617,11 +617,11 @@ fun WithdrawConfirmScreen(
                         fontWeight = FontWeight.SemiBold
                     ),
                 )
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(modifier = Modifier.height(32.dp))
                 withdrawCheckLists.forEachIndexed { index, text ->
                     WithdrawConfirmCheckItems(checkText = text)
                     if (index != withdrawCheckLists.lastIndex) {
-                        Spacer(modifier = Modifier.height(12.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
                     }
                 }
             }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
@@ -455,33 +455,28 @@ fun WithdrawHoldBottomSheet(
                 .fillMaxWidth()
                 .wrapContentHeight()
         ) {
-            Column(
-                modifier = Modifier
-                    .padding(bottom = 8.dp)
-            ) {
+            Text(
+                text = stringResource(id = content.titleResId),
+                style = DayoTheme.typography.b1,
+                color = Dark,
+            )
 
-                Text(
-                    text = stringResource(id = content.titleResId),
-                    style = DayoTheme.typography.b1,
-                    color = Dark,
+            val descriptionText = stringResource(id = content.descriptionResId)
+            if (descriptionText.isNotBlank()) {
+                Spacer(
+                    modifier = Modifier.height(
+                        if (isOtherReason) 2.dp else 4.dp
+                    )
                 )
-
-                val descriptionText = stringResource(id = content.descriptionResId)
-                if (descriptionText.isNotBlank()) {
-                    Spacer(
-                        modifier = Modifier.height(
-                            if (isOtherReason) 2.dp else 4.dp
-                        )
+                Text(
+                    text = descriptionText,
+                    style = DayoTheme.typography.caption2.copy(
+                        color = Gray2_767B83,
+                        fontWeight = FontWeight.Medium
                     )
-                    Text(
-                        text = descriptionText,
-                        style = DayoTheme.typography.caption2.copy(
-                            color = Gray2_767B83,
-                            fontWeight = FontWeight.Medium
-                        )
-                    )
-                }
+                )
             }
+
             Spacer(
                 modifier = Modifier.height(
                     if (isOtherReason || hasWithdrawReasonGuide) 8.dp
@@ -832,9 +827,11 @@ private fun WithdrawGuideContentUI(
                     style = DayoTheme.typography.caption4,
                 )
                 if (index != guideStrings.lastIndex) {
-                    Spacer(modifier = Modifier
-                        .width(6.dp)
-                        .align(Alignment.CenterVertically))
+                    Spacer(
+                        modifier = Modifier
+                            .width(6.dp)
+                            .align(Alignment.CenterVertically)
+                    )
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_right),
                         contentDescription = null,
@@ -843,9 +840,11 @@ private fun WithdrawGuideContentUI(
                             .align(Alignment.CenterVertically),
                         tint = Gray3_9FA5AE,
                     )
-                    Spacer(modifier = Modifier
-                        .width(6.dp)
-                        .align(Alignment.CenterVertically))
+                    Spacer(
+                        modifier = Modifier
+                            .width(6.dp)
+                            .align(Alignment.CenterVertically)
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/account/WithdrawScreen.kt
@@ -687,11 +687,13 @@ fun WithdrawConfirmCheckItems(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
+            .wrapContentHeight(),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_check),
             contentDescription = null,
+            modifier = Modifier.size(20.dp),
             tint = Primary_23C882,
         )
         Spacer(modifier = Modifier.width(4.dp))

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
@@ -42,8 +42,10 @@ import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import daily.dayo.domain.model.Profile
@@ -273,14 +275,16 @@ private fun SettingProfile(
         Text(
             text = profile?.nickname ?: "",
             color = Dark,
-            style = DayoTheme.typography.b2
+            textAlign = TextAlign.Center,
+            style = DayoTheme.typography.b1
         )
 
         // email
         Text(
             text = profile?.email ?: "",
             color = Gray3_9FA5AE,
-            style = DayoTheme.typography.b6
+            textAlign = TextAlign.Center,
+            style = DayoTheme.typography.b6.copy(lineHeight = 21.sp)
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Button.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -31,8 +32,10 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -116,7 +119,14 @@ fun FilledRoundedCornerButton(
                     text = label,
                     textAlign = TextAlign.Center,
                     style = textStyle,
-                    modifier = contentModifier ?: Modifier.fillMaxWidth()
+                    modifier = contentModifier ?: Modifier.fillMaxWidth(),
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Clip,
+                    autoSize = TextAutoSize.StepBased(
+                        minFontSize = 12.sp,
+                        maxFontSize = textStyle.fontSize
+                    )
                 )
             }
         },

--- a/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/dialog/BottomSheetDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
@@ -152,7 +153,9 @@ fun BottomSheetDialog(
                             Icon(
                                 imageVector = rightIcon,
                                 contentDescription = "",
-                                modifier = Modifier.align(Alignment.CenterVertically),
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .align(Alignment.CenterVertically),
                                 tint = Color.Unspecified
                             )
                         }

--- a/presentation/src/main/res/drawable/ic_check.xml
+++ b/presentation/src/main/res/drawable/ic_check.xml
@@ -1,10 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="18dp"
-    android:height="13dp"
-    android:viewportWidth="18"
-    android:viewportHeight="13">
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
     <path
+        android:pathData="M4.58 9.61l3.83 4.64 7-8.5"
+        android:strokeWidth="1.5"
         android:strokeColor="#FF23C882"
-        android:strokeWidth="2"
-        android:pathData="M1 6l5.33 5L17 1"/>
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>


### PR DESCRIPTION
## 작업 내용 
- 환경설정 화면의 닉네임, 이메일 텍스트 스타일 변경
- 계정 삭제 이유 클릭 시 바텀 시트
  - 기존의 중첩된 Column 코드 정리 
  - 버튼의 텍스트가 한 줄로 표시되도록 AutoSize 적용
- 계정 삭제 확인 화면의 간격 조정
- 체크 아이콘 변경, 해당 아이콘을 사용 중인 곳 확인해 사이즈 변경

## 참고 
- resolved : #1042 
- resolved: #1057 
- resolved: #1058 
- resolved: #1059 
- resolved : #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 모듈별 변경 사항 및 기능적 영향

### 1. **WithdrawScreen.kt** (계정 삭제 화면)
**기능적 영향:**
- 계정 삭제 사유 선택 화면: 중첩된 Column 제거로 레이아웃 코드 간결화
- 계정 삭제 확인 화면: 
  - 체크리스트 상단 여백 증가 (20dp → 32dp)
  - 각 항목 간 구분선 여백 증가 (12dp → 16dp)
  - 체크 아이콘 크기 고정 (20dp)
  - 항목 텍스트와 아이콘 간 정렬 개선 (수직 중앙 정렬)

**사용자 대면 변경:**
- 디자인 QA 기준에 맞춘 일관된 간격으로 가독성 및 시각적 계층 개선
- 체크 아이콘의 균형잡힌 크기로 UI 일관성 강화

**위험도:** 낮음 (순수 UI 레이아웃 변경)

### 2. **SettingsScreen.kt** (설정 화면)
**기능적 영향:**
- 프로필 닉네임: 텍스트 정렬을 중앙 정렬로 변경, 타이포그래피 업그레이드 (b2 → b1)
- 프로필 이메일: 중앙 정렬 설정, 라인 높이 조정 (21.sp)

**사용자 대면 변경:**
- 프로필 섹션의 시각적 계층을 강화하여 가독성 개선
- 일관된 텍스트 정렬로 UI 정렬성 향상

**위험도:** 낮음 (순수 스타일 변경, 상태 관리 영향 없음)

### 3. **Button.kt** (FilledRoundedCornerButton)
**기능적 영향:**
- 버튼 텍스트를 단일 라인으로 제한
- 텍스트 오버플로우 시 자동 크기 조정 (TextAutoSize.StepBased, 최소 12sp, 최대 지정 크기)

**사용자 대면 변경:**
- 계정 삭제 사유 선택 화면의 버튼 텍스트가 항상 한 줄로 렌더링되어 일관된 UI 제공

**위험도:** 낮음 (텍스트 렌더링 제약만 추가)

### 4. **BottomSheetDialog.kt** (바텀시트 다이얼로그)
**기능적 영향:**
- 체크 아이콘 크기 고정 (24.dp)

**사용자 대면 변경:**
- 선택 항목의 체크 아이콘 일관된 크기 표시

**위험도:** 낮음 (단순 크기 조정)

### 5. **ic_check.xml** (체크 아이콘 리소스)
**기능적 영향:**
- 아이콘 뷰포트 크기 조정 (18×13 → 20×20)
- 체크마크 경로 데이터 변경
- 스트로크 너비 조정 (2 → 1.5)
- 라운드 스트로크 끝단 및 연결부 적용

**사용자 대면 변경:**
- 디자인 가이드에 맞춰 개선된 체크 아이콘 표시

**위험도:** 낮음 (리소스 업데이트)

---

## 위험 포인트 분석

**네트워크/오류 처리:** 없음 (UI 관련 변경만)

**스레딩 문제:** 없음 (모든 변경이 주 스레드의 Compose UI 레이아웃/스타일)

**상태 일관성:** 없음 (상태 관리 로직 변경 없음, 기존 조건부 렌더링 유지)

---

## 필요한 테스트 및 검증

### 필수 검증 항목:
1. **설정 화면 계정 삭제 플로우:**
   - 계정 삭제 사유 선택 화면에서 바텀시트가 정상 표시되는지 확인
   - 텍스트 오버플로우 시 버튼 텍스트 자동 크기 조정 동작 확인
   - 각 화면의 간격이 디자인 QA 기준(itemSpacing: 4)을 만족하는지 확인

2. **프로필 닉네임/이메일 표시:**
   - SettingsScreen에서 프로필 정보가 중앙 정렬되어 올바르게 표시되는지 확인
   - 텍스트 길이별 렌더링 확인 (짧은 텍스트, 긴 텍스트)

3. **체크 아이콘 일관성:**
   - 계정 삭제 확인 화면에서 체크 아이콘 크기(20dp)가 일관되게 표시되는지 확인
   - 바텀시트 다이얼로그의 체크 아이콘 크기(24.dp)가 정상 표시되는지 확인

4. **레이아웃 호환성:**
   - 다양한 화면 크기(휴대폰, 태블릿) 및 방향(세로, 가로)에서 정상 렌더링 확인
   - 다국어 텍스트(긴 언어) 환경에서 오버플로우 처리 확인

### 권장 테스트:
- 자동 UI 테스트: Compose Preview 또는 Paparazzi를 통한 스냅샷 테스트
- 수동 테스트: 실제 기기에서 계정 삭제 플로우 엔드-투-엔드 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->