### PR TITLE
Support dynamic API base URL via Firebase Remote Config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,14 +99,12 @@ android {
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_dev\"")
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_dev_signature\"")
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_prod\"")
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_prod_signature\"")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
 def ADS_APPLICATION_ID = properties.getProperty('ADS_APPLICATION_ID')
-def REMOTE_CONFIG_BASE_URL_PUBLIC_KEY = properties.getProperty('REMOTE_CONFIG_BASE_URL_PUBLIC_KEY', '')
+def REMOTE_CONFIG_BASE_URL_PUBLIC_KEY = properties.getProperty('REMOTE_CONFIG_BASE_URL_PUBLIC_KEY', '').trim()
 def keystorePropertiesFile = rootProject.file("app/keystore-release.properties")
 def buildConfigString = { String value ->
     def escaped = (value ?: '')
@@ -112,6 +112,24 @@ android {
         }
     }
     namespace 'com.daily.dayo'
+}
+
+def validateRemoteConfigBaseUrlPublicKeyForRelease = tasks.register(
+        'validateRemoteConfigBaseUrlPublicKeyForRelease'
+) {
+    doLast {
+        if (!REMOTE_CONFIG_BASE_URL_PUBLIC_KEY) {
+            throw new GradleException(
+                    'Missing REMOTE_CONFIG_BASE_URL_PUBLIC_KEY in local.properties for release build'
+            )
+        }
+    }
+}
+
+tasks.configureEach { task ->
+    if (task.name ==~ /^pre.*ReleaseBuild$/) {
+        task.dependsOn(validateRemoteConfigBaseUrlPublicKeyForRelease)
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,26 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
 def ADS_APPLICATION_ID = properties.getProperty('ADS_APPLICATION_ID')
+def REMOTE_CONFIG_BASE_URL_PUBLIC_KEY = properties.getProperty('REMOTE_CONFIG_BASE_URL_PUBLIC_KEY', '')
 def keystorePropertiesFile = rootProject.file("app/keystore-release.properties")
+def buildConfigString = { String value ->
+    def escaped = (value ?: '')
+            .replace('\\', '\\\\')
+            .replace('"', '\\"')
+            .replace('\n', '\\n')
+    return "\"${escaped}\""
+}
+def fallbackBaseUrlProperty = { String fallbackKey, String legacyKey ->
+    def value = properties.getProperty(fallbackKey) ?: properties.getProperty(legacyKey)
+    if (!value) {
+        throw new GradleException("Missing ${fallbackKey} in local.properties")
+    }
+    return value
+}
+def FALLBACK_BASE_URL_DEV = fallbackBaseUrlProperty('FALLBACK_BASE_URL_DEV', 'BASE_URL_DEV')
+def FALLBACK_BASE_URL_PROD = fallbackBaseUrlProperty('FALLBACK_BASE_URL_PROD', 'BASE_URL_PROD')
+def USES_RELEASE_CLEARTEXT_TRAFFIC = [FALLBACK_BASE_URL_DEV, FALLBACK_BASE_URL_PROD]
+        .any { it?.contains('http://') == true }
 
 kotlin {
     jvmToolchain(17)
@@ -35,9 +54,11 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField ("String", "NATIVE_APP_KEY", properties['NATIVE_APP_KEY_STR'])
+        buildConfigField("String", "REMOTE_CONFIG_BASE_URL_PUBLIC_KEY", buildConfigString(REMOTE_CONFIG_BASE_URL_PUBLIC_KEY))
         manifestPlaceholders = [
-                NATIVE_APP_KEY    : NATIVE_APP_KEY,
-                ADS_APPLICATION_ID: ADS_APPLICATION_ID
+                NATIVE_APP_KEY        : NATIVE_APP_KEY,
+                ADS_APPLICATION_ID    : ADS_APPLICATION_ID,
+                USES_CLEARTEXT_TRAFFIC: USES_RELEASE_CLEARTEXT_TRAFFIC
         ]
     }
 
@@ -64,23 +85,31 @@ android {
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
             resValue "string", "app_name", "DAYO (Debug)"
+            manifestPlaceholders.USES_CLEARTEXT_TRAFFIC = true
         }
         release {
             resValue "string", "app_name", "DAYO"
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+            manifestPlaceholders.USES_CLEARTEXT_TRAFFIC = USES_RELEASE_CLEARTEXT_TRAFFIC
         }
     }
     flavorDimensions = ["environment"]
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_DEV'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
+            buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_dev\"")
+            buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_dev_signature\"")
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_PROD'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
+            buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_prod\"")
+            buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_prod_signature\"")
         }
     }
     namespace 'com.daily.dayo'
@@ -107,6 +136,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:34.6.0')
     implementation "com.google.firebase:firebase-crashlytics"
     implementation "com.google.firebase:firebase-analytics"
+    implementation "com.google.firebase:firebase-config"
 
     // Google Ads
     implementation 'com.google.android.gms:play-services-ads:24.7.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ def fallbackBaseUrlProperty = { String fallbackKey, String legacyKey ->
 }
 def FALLBACK_BASE_URL_DEV = fallbackBaseUrlProperty('FALLBACK_BASE_URL_DEV', 'BASE_URL_DEV')
 def FALLBACK_BASE_URL_PROD = fallbackBaseUrlProperty('FALLBACK_BASE_URL_PROD', 'BASE_URL_PROD')
-def USES_RELEASE_CLEARTEXT_TRAFFIC = [FALLBACK_BASE_URL_DEV, FALLBACK_BASE_URL_PROD]
-        .any { it?.contains('http://') == true }
+def USES_DEV_CLEARTEXT_TRAFFIC = FALLBACK_BASE_URL_DEV?.contains('http://') == true
+def USES_PROD_CLEARTEXT_TRAFFIC = FALLBACK_BASE_URL_PROD?.contains('http://') == true
 
 kotlin {
     jvmToolchain(17)
@@ -58,7 +58,7 @@ android {
         manifestPlaceholders = [
                 NATIVE_APP_KEY        : NATIVE_APP_KEY,
                 ADS_APPLICATION_ID    : ADS_APPLICATION_ID,
-                USES_CLEARTEXT_TRAFFIC: USES_RELEASE_CLEARTEXT_TRAFFIC
+                USES_CLEARTEXT_TRAFFIC: false
         ]
     }
 
@@ -92,19 +92,20 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
-            manifestPlaceholders.USES_CLEARTEXT_TRAFFIC = USES_RELEASE_CLEARTEXT_TRAFFIC
         }
     }
     flavorDimensions = ["environment"]
     productFlavors {
         dev {
             dimension "environment"
+            manifestPlaceholders.USES_CLEARTEXT_TRAFFIC = USES_DEV_CLEARTEXT_TRAFFIC
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_dev\"")
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_dev_signature\"")
         }
         prod {
             dimension "environment"
+            manifestPlaceholders.USES_CLEARTEXT_TRAFFIC = USES_PROD_CLEARTEXT_TRAFFIC
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_KEY", "\"api_base_url_prod\"")
             buildConfigField("String", "REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY", "\"api_base_url_prod_signature\"")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application
         android:name=".DayoApplication"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="${USES_CLEARTEXT_TRAFFIC}"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
+++ b/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
@@ -68,10 +68,11 @@ class RemoteConfigBaseUrlProvider(
             }
 
             val remoteBaseUrl = remoteBaseUrlValue.asString()
+            val remoteBaseUrlSignature = remoteConfig.getString(BuildConfig.REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY)
             val normalizedBaseUrl = normalizeBaseUrl(remoteBaseUrl) ?: run {
                 return false
             }
-            if (!isTrustedRemoteBaseUrl(normalizedBaseUrl)) {
+            if (!isTrustedRemoteBaseUrl(normalizedBaseUrl, remoteBaseUrlSignature)) {
                 return false
             }
 
@@ -81,6 +82,7 @@ class RemoteConfigBaseUrlProvider(
             )
             sharedPreferences.edit()
                 .putString(KEY_LAST_SUCCESSFUL_BASE_URL, normalizedBaseUrl)
+                .putString(KEY_LAST_SUCCESSFUL_BASE_URL_SIGNATURE, remoteBaseUrlSignature)
                 .apply()
             true
         } catch (exception: CancellationException) {
@@ -92,11 +94,20 @@ class RemoteConfigBaseUrlProvider(
 
     private fun getInitialBaseUrlState(): BaseUrlState {
         val cachedBaseUrl = sharedPreferences.getString(KEY_LAST_SUCCESSFUL_BASE_URL, null)
-        normalizeBaseUrl(cachedBaseUrl)?.let { baseUrl ->
-            return BaseUrlState(
-                baseUrl = baseUrl,
-                source = BaseUrlSource.CACHED_LAST_SUCCESS
-            )
+        val cachedBaseUrlSignature = sharedPreferences.getString(KEY_LAST_SUCCESSFUL_BASE_URL_SIGNATURE, null)
+        normalizeBaseUrl(cachedBaseUrl)
+            ?.takeIf { baseUrl -> isTrustedCachedBaseUrl(baseUrl, cachedBaseUrlSignature) }
+            ?.let { baseUrl ->
+                return BaseUrlState(
+                    baseUrl = baseUrl,
+                    source = BaseUrlSource.CACHED_LAST_SUCCESS
+                )
+            }
+        if (cachedBaseUrl != null) {
+            sharedPreferences.edit()
+                .remove(KEY_LAST_SUCCESSFUL_BASE_URL)
+                .remove(KEY_LAST_SUCCESSFUL_BASE_URL_SIGNATURE)
+                .apply()
         }
 
         return BaseUrlState(
@@ -147,13 +158,23 @@ class RemoteConfigBaseUrlProvider(
         }
     }
 
-    private fun isTrustedRemoteBaseUrl(normalizedBaseUrl: String): Boolean {
+    private fun isTrustedRemoteBaseUrl(normalizedBaseUrl: String, signature: String): Boolean {
         if (normalizedBaseUrl == normalizeBaseUrl(BuildConfig.FALLBACK_BASE_URL)) return true
         if (BuildConfig.DEBUG) return true
 
         return verifyBaseUrlSignature(
             baseUrl = normalizedBaseUrl,
-            signature = remoteConfig.getString(BuildConfig.REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY)
+            signature = signature
+        )
+    }
+
+    private fun isTrustedCachedBaseUrl(normalizedBaseUrl: String, signature: String?): Boolean {
+        if (normalizedBaseUrl == normalizeBaseUrl(BuildConfig.FALLBACK_BASE_URL)) return true
+        if (BuildConfig.DEBUG) return true
+
+        return verifyBaseUrlSignature(
+            baseUrl = normalizedBaseUrl,
+            signature = signature.orEmpty()
         )
     }
 
@@ -216,6 +237,7 @@ class RemoteConfigBaseUrlProvider(
     companion object {
         private const val PREFERENCES_NAME = "remote_config_base_url"
         private const val KEY_LAST_SUCCESSFUL_BASE_URL = "last_successful_base_url"
+        private const val KEY_LAST_SUCCESSFUL_BASE_URL_SIGNATURE = "last_successful_base_url_signature"
         private const val FETCH_TIMEOUT_SECONDS = 5L
         private const val TASK_TIMEOUT_MILLIS = 6_000L
         private val MINIMUM_FETCH_INTERVAL_SECONDS = if (BuildConfig.DEBUG) 0L else 3_600L

--- a/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
+++ b/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
@@ -142,7 +142,7 @@ class RemoteConfigBaseUrlProvider(
             if (uri.rawQuery != null || uri.rawFragment != null) return null
 
             val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
-            val host = uri.host?.takeIf { it.isNotBlank() } ?: return null
+            val host = uri.host?.takeIf { it.isNotBlank() }?.lowercase(Locale.US) ?: return null
             if (scheme != SCHEME_HTTP && scheme != SCHEME_HTTPS) return null
             if (!BuildConfig.DEBUG && scheme == SCHEME_HTTP && !isReleaseHttpAllowed()) return null
             if (uri.userInfo != null) return null
@@ -151,7 +151,13 @@ class RemoteConfigBaseUrlProvider(
             val path = uri.path.orEmpty()
             if (path.isNotBlank() && path != "/") return null
 
-            val normalizedUri = URI(scheme, null, host, uri.port, "/", null, null)
+            val canonicalPort = when {
+                scheme == SCHEME_HTTP && uri.port == DEFAULT_HTTP_PORT -> -1
+                scheme == SCHEME_HTTPS && uri.port == DEFAULT_HTTPS_PORT -> -1
+                else -> uri.port
+            }
+
+            val normalizedUri = URI(scheme, null, host, canonicalPort, "/", null, null)
             normalizedUri.toString().ensureTrailingSlash()
         } catch (exception: Exception) {
             null
@@ -243,6 +249,8 @@ class RemoteConfigBaseUrlProvider(
         private val MINIMUM_FETCH_INTERVAL_SECONDS = if (BuildConfig.DEBUG) 0L else 3_600L
         private const val SCHEME_HTTP = "http"
         private const val SCHEME_HTTPS = "https"
+        private const val DEFAULT_HTTP_PORT = 80
+        private const val DEFAULT_HTTPS_PORT = 443
         private const val KEY_ALGORITHM_RSA = "RSA"
         private const val SIGNATURE_ALGORITHM = "SHA256withRSA"
         private const val PEM_PUBLIC_KEY_BEGIN = "-----BEGIN PUBLIC KEY-----"

--- a/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
+++ b/app/src/main/java/com/daily/dayo/config/RemoteConfigBaseUrlProvider.kt
@@ -1,0 +1,232 @@
+package com.daily.dayo.config
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.daily.dayo.BuildConfig
+import com.google.android.gms.tasks.Task
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import daily.dayo.domain.provider.BaseUrlSource
+import daily.dayo.domain.provider.BaseUrlProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.InetAddress
+import java.net.URI
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class RemoteConfigBaseUrlProvider(
+    context: Context,
+    private val remoteConfig: FirebaseRemoteConfig
+) : BaseUrlProvider {
+
+    private val sharedPreferences: SharedPreferences = context.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    @Volatile
+    private var currentBaseUrlState: BaseUrlState = getInitialBaseUrlState()
+
+    init {
+        remoteConfig.setConfigSettingsAsync(
+            FirebaseRemoteConfigSettings.Builder()
+                .setFetchTimeoutInSeconds(FETCH_TIMEOUT_SECONDS)
+                .setMinimumFetchIntervalInSeconds(MINIMUM_FETCH_INTERVAL_SECONDS)
+                .build()
+        )
+        remoteConfig.setDefaultsAsync(
+            mapOf(
+                BuildConfig.REMOTE_CONFIG_BASE_URL_KEY to BuildConfig.FALLBACK_BASE_URL,
+                BuildConfig.REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY to ""
+            )
+        )
+    }
+
+    override fun getBaseUrl(): String = currentBaseUrlState.baseUrl
+
+    override fun getBaseUrlSource(): BaseUrlSource = currentBaseUrlState.source
+
+    override fun isTrustedBaseUrl(baseUrl: String): Boolean {
+        val normalizedBaseUrl = normalizeBaseUrl(baseUrl) ?: return false
+        return normalizedBaseUrl == currentBaseUrlState.baseUrl ||
+            normalizedBaseUrl == normalizeBaseUrl(BuildConfig.FALLBACK_BASE_URL)
+    }
+
+    override suspend fun refreshBaseUrl(): Boolean {
+        return try {
+            remoteConfig.fetchAndActivate().awaitWithTimeout() ?: return false
+            val remoteBaseUrlValue = remoteConfig.getValue(BuildConfig.REMOTE_CONFIG_BASE_URL_KEY)
+            if (remoteBaseUrlValue.source != FirebaseRemoteConfig.VALUE_SOURCE_REMOTE) {
+                return false
+            }
+
+            val remoteBaseUrl = remoteBaseUrlValue.asString()
+            val normalizedBaseUrl = normalizeBaseUrl(remoteBaseUrl) ?: run {
+                return false
+            }
+            if (!isTrustedRemoteBaseUrl(normalizedBaseUrl)) {
+                return false
+            }
+
+            currentBaseUrlState = BaseUrlState(
+                baseUrl = normalizedBaseUrl,
+                source = BaseUrlSource.REMOTE_CONFIG
+            )
+            sharedPreferences.edit()
+                .putString(KEY_LAST_SUCCESSFUL_BASE_URL, normalizedBaseUrl)
+                .apply()
+            true
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            false
+        }
+    }
+
+    private fun getInitialBaseUrlState(): BaseUrlState {
+        val cachedBaseUrl = sharedPreferences.getString(KEY_LAST_SUCCESSFUL_BASE_URL, null)
+        normalizeBaseUrl(cachedBaseUrl)?.let { baseUrl ->
+            return BaseUrlState(
+                baseUrl = baseUrl,
+                source = BaseUrlSource.CACHED_LAST_SUCCESS
+            )
+        }
+
+        return BaseUrlState(
+            baseUrl = normalizeBaseUrl(BuildConfig.FALLBACK_BASE_URL) ?: BuildConfig.FALLBACK_BASE_URL,
+            source = BaseUrlSource.FALLBACK
+        )
+    }
+
+    private suspend fun Task<Boolean>.awaitWithTimeout(): Boolean? {
+        return withTimeoutOrNull(TASK_TIMEOUT_MILLIS) {
+            suspendCancellableCoroutine { continuation ->
+                addOnCompleteListener { task ->
+                    if (!continuation.isActive) return@addOnCompleteListener
+
+                    val exception = task.exception
+                    if (exception != null) {
+                        continuation.resumeWithException(exception)
+                    } else {
+                        continuation.resume(task.result == true)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun normalizeBaseUrl(baseUrl: String?): String? {
+        val trimmedBaseUrl = baseUrl?.trim().orEmpty()
+        if (trimmedBaseUrl.isEmpty()) return null
+
+        return try {
+            val uri = URI(trimmedBaseUrl)
+            if (uri.rawQuery != null || uri.rawFragment != null) return null
+
+            val scheme = uri.scheme?.lowercase(Locale.US) ?: return null
+            val host = uri.host?.takeIf { it.isNotBlank() } ?: return null
+            if (scheme != SCHEME_HTTP && scheme != SCHEME_HTTPS) return null
+            if (!BuildConfig.DEBUG && scheme == SCHEME_HTTP && !isReleaseHttpAllowed()) return null
+            if (uri.userInfo != null) return null
+            if (!BuildConfig.DEBUG && isUnsafeReleaseHost(host)) return null
+
+            val path = uri.path.orEmpty()
+            if (path.isNotBlank() && path != "/") return null
+
+            val normalizedUri = URI(scheme, null, host, uri.port, "/", null, null)
+            normalizedUri.toString().ensureTrailingSlash()
+        } catch (exception: Exception) {
+            null
+        }
+    }
+
+    private fun isTrustedRemoteBaseUrl(normalizedBaseUrl: String): Boolean {
+        if (normalizedBaseUrl == normalizeBaseUrl(BuildConfig.FALLBACK_BASE_URL)) return true
+        if (BuildConfig.DEBUG) return true
+
+        return verifyBaseUrlSignature(
+            baseUrl = normalizedBaseUrl,
+            signature = remoteConfig.getString(BuildConfig.REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY)
+        )
+    }
+
+    private fun verifyBaseUrlSignature(baseUrl: String, signature: String): Boolean {
+        val publicKeyText = BuildConfig.REMOTE_CONFIG_BASE_URL_PUBLIC_KEY.stripPemFormatting()
+        val signatureText = signature.stripPemFormatting()
+        if (publicKeyText.isBlank() || signatureText.isBlank()) return false
+
+        return runCatching {
+            val publicKey = KeyFactory.getInstance(KEY_ALGORITHM_RSA).generatePublic(
+                X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyText))
+            )
+            val verifier = Signature.getInstance(SIGNATURE_ALGORITHM)
+            verifier.initVerify(publicKey)
+            verifier.update(baseUrl.toByteArray(Charsets.UTF_8))
+            verifier.verify(Base64.getDecoder().decode(signatureText))
+        }.getOrDefault(false)
+    }
+
+    private fun isReleaseHttpAllowed(): Boolean =
+        runCatching {
+            URI(BuildConfig.FALLBACK_BASE_URL).scheme?.lowercase(Locale.US) == SCHEME_HTTP
+        }.getOrDefault(false)
+
+    private fun isUnsafeReleaseHost(host: String): Boolean {
+        val normalizedHost = host.trim('[', ']')
+        if (normalizedHost.equals("localhost", ignoreCase = true)) return true
+        if (normalizedHost.endsWith(".localhost", ignoreCase = true)) return true
+        if (normalizedHost.endsWith(".local", ignoreCase = true)) return true
+        if (!normalizedHost.looksLikeIpLiteral()) return false
+
+        return runCatching {
+            val address = InetAddress.getByName(normalizedHost)
+            address.isAnyLocalAddress ||
+                address.isLoopbackAddress ||
+                address.isLinkLocalAddress ||
+                address.isSiteLocalAddress ||
+                address.isMulticastAddress
+        }.getOrDefault(true)
+    }
+
+    private fun String.looksLikeIpLiteral(): Boolean =
+        IPV4_ADDRESS_REGEX.matches(this) || contains(':')
+
+    private fun String.stripPemFormatting(): String =
+        replace(PEM_PUBLIC_KEY_BEGIN, "")
+            .replace(PEM_PUBLIC_KEY_END, "")
+            .replace(PEM_SIGNATURE_BEGIN, "")
+            .replace(PEM_SIGNATURE_END, "")
+            .filterNot { it.isWhitespace() }
+
+    private fun String.ensureTrailingSlash(): String =
+        if (endsWith('/')) this else "$this/"
+
+    private data class BaseUrlState(
+        val baseUrl: String,
+        val source: BaseUrlSource
+    )
+
+    companion object {
+        private const val PREFERENCES_NAME = "remote_config_base_url"
+        private const val KEY_LAST_SUCCESSFUL_BASE_URL = "last_successful_base_url"
+        private const val FETCH_TIMEOUT_SECONDS = 5L
+        private const val TASK_TIMEOUT_MILLIS = 6_000L
+        private val MINIMUM_FETCH_INTERVAL_SECONDS = if (BuildConfig.DEBUG) 0L else 3_600L
+        private const val SCHEME_HTTP = "http"
+        private const val SCHEME_HTTPS = "https"
+        private const val KEY_ALGORITHM_RSA = "RSA"
+        private const val SIGNATURE_ALGORITHM = "SHA256withRSA"
+        private const val PEM_PUBLIC_KEY_BEGIN = "-----BEGIN PUBLIC KEY-----"
+        private const val PEM_PUBLIC_KEY_END = "-----END PUBLIC KEY-----"
+        private const val PEM_SIGNATURE_BEGIN = "-----BEGIN SIGNATURE-----"
+        private const val PEM_SIGNATURE_END = "-----END SIGNATURE-----"
+        private val IPV4_ADDRESS_REGEX = Regex("""\d{1,3}(\.\d{1,3}){3}""")
+    }
+}

--- a/app/src/main/java/com/daily/dayo/di/BaseUrlProviderModule.kt
+++ b/app/src/main/java/com/daily/dayo/di/BaseUrlProviderModule.kt
@@ -1,0 +1,31 @@
+package com.daily.dayo.di
+
+import android.content.Context
+import com.daily.dayo.config.RemoteConfigBaseUrlProvider
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import daily.dayo.domain.provider.BaseUrlProvider
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object BaseUrlProviderModule {
+
+    @Singleton
+    @Provides
+    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
+
+    @Singleton
+    @Provides
+    fun provideBaseUrlProvider(
+        @ApplicationContext context: Context,
+        remoteConfig: FirebaseRemoteConfig
+    ): BaseUrlProvider = RemoteConfigBaseUrlProvider(
+        context = context,
+        remoteConfig = remoteConfig
+    )
+}

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -52,12 +52,10 @@ android {
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
         }
     }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -16,6 +16,15 @@ kotlin {
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
+def fallbackBaseUrlProperty = { String fallbackKey, String legacyKey ->
+    def value = properties.getProperty(fallbackKey) ?: properties.getProperty(legacyKey)
+    if (!value) {
+        throw new GradleException("Missing ${fallbackKey} in local.properties")
+    }
+    return value
+}
+def FALLBACK_BASE_URL_DEV = fallbackBaseUrlProperty('FALLBACK_BASE_URL_DEV', 'BASE_URL_DEV')
+def FALLBACK_BASE_URL_PROD = fallbackBaseUrlProperty('FALLBACK_BASE_URL_PROD', 'BASE_URL_PROD')
 
 android {
     namespace 'daily.dayo.data'
@@ -43,11 +52,13 @@ android {
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_DEV'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_PROD'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
         }
     }
     compileOptions {

--- a/data/src/main/java/daily/dayo/data/datasource/remote/retrofit/interceptor/BaseUrlRewriteInterceptor.kt
+++ b/data/src/main/java/daily/dayo/data/datasource/remote/retrofit/interceptor/BaseUrlRewriteInterceptor.kt
@@ -1,0 +1,38 @@
+package daily.dayo.data.datasource.remote.retrofit.interceptor
+
+import daily.dayo.domain.provider.BaseUrlProvider
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BaseUrlRewriteInterceptor @Inject constructor(
+    private val baseUrlProvider: BaseUrlProvider
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val providerBaseUrl = baseUrlProvider.getBaseUrl()
+        if (!baseUrlProvider.isTrustedBaseUrl(providerBaseUrl)) return chain.proceed(request)
+
+        val providerUrl = providerBaseUrl.toHttpUrlOrNull()
+            ?: return chain.proceed(request)
+
+        return try {
+            val rewrittenUrl = request.url.newBuilder()
+                .scheme(providerUrl.scheme)
+                .host(providerUrl.host)
+                .port(providerUrl.port)
+                .build()
+            chain.proceed(
+                request.newBuilder()
+                    .url(rewrittenUrl)
+                    .build()
+            )
+        } catch (exception: IllegalArgumentException) {
+            chain.proceed(request)
+        }
+    }
+}

--- a/data/src/main/java/daily/dayo/data/di/NetworkModule.kt
+++ b/data/src/main/java/daily/dayo/data/di/NetworkModule.kt
@@ -3,12 +3,15 @@ package daily.dayo.data.di
 import android.content.Context
 import daily.dayo.data.BuildConfig
 import daily.dayo.data.datasource.remote.retrofit.factory.NetworkResponseAdapterFactory
+import daily.dayo.data.datasource.remote.retrofit.interceptor.BaseUrlRewriteInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import daily.dayo.data.datasource.local.SharedManager
+import daily.dayo.domain.provider.BaseUrlProvider
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -23,17 +26,28 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient(@ApplicationContext context:Context): OkHttpClient {
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context,
+        baseUrlRewriteInterceptor: BaseUrlRewriteInterceptor,
+        baseUrlProvider: BaseUrlProvider
+    ): OkHttpClient {
         val loggingInterceptor = HttpLoggingInterceptor()
-        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+        loggingInterceptor.redactHeader("Authorization")
+        loggingInterceptor.setLevel(
+            if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+        )
         return OkHttpClient.Builder()
+            .addInterceptor(baseUrlRewriteInterceptor)
             .addInterceptor { chain: Interceptor.Chain ->
                 val request = chain.request()
+                val shouldAttachAuthorization = baseUrlProvider.isTrustedBaseUrl(request.url.toBaseOrigin())
                 // Header에 AccessToken을 삽입하지 않는 대상
                 if (request.url.encodedPath.equals("/api/v1/members/kakaoOAuth", true) ||
                     request.url.encodedPath.equals("/api/v1/members/signIn", true) ||
                     request.url.encodedPath.startsWith("/api/v1/members/signUp", true)
                 ) {
+                    chain.proceed(request)
+                } else if (!shouldAttachAuthorization) {
                     chain.proceed(request)
                 } else if (request.url.encodedPath.equals("/api/v1/members/refresh", true)) {
                     chain.proceed(request.newBuilder().apply {
@@ -57,6 +71,13 @@ object NetworkModule {
             .build()
     }
 
+    private fun HttpUrl.toBaseOrigin(): String =
+        newBuilder()
+            .encodedPath("/")
+            .query(null)
+            .build()
+            .toString()
+
     @Singleton
     @Provides
     fun provideConverterFactory(): GsonConverterFactory =
@@ -69,7 +90,7 @@ object NetworkModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BuildConfig.BASE_URL)
+            .baseUrl(BuildConfig.FALLBACK_BASE_URL)
             .addCallAdapterFactory(NetworkResponseAdapterFactory())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(gsonConverterFactory)

--- a/domain/src/main/java/daily/dayo/domain/provider/BaseUrlProvider.kt
+++ b/domain/src/main/java/daily/dayo/domain/provider/BaseUrlProvider.kt
@@ -1,0 +1,17 @@
+package daily.dayo.domain.provider
+
+enum class BaseUrlSource {
+    FALLBACK,
+    CACHED_LAST_SUCCESS,
+    REMOTE_CONFIG
+}
+
+interface BaseUrlProvider {
+    fun getBaseUrl(): String
+
+    fun getBaseUrlSource(): BaseUrlSource
+
+    fun isTrustedBaseUrl(baseUrl: String): Boolean
+
+    suspend fun refreshBaseUrl(): Boolean
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -12,6 +12,15 @@ apply plugin: "org.jetbrains.kotlin.plugin.compose"
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def NATIVE_APP_KEY = properties.getProperty('NATIVE_APP_KEY')
+def fallbackBaseUrlProperty = { String fallbackKey, String legacyKey ->
+    def value = properties.getProperty(fallbackKey) ?: properties.getProperty(legacyKey)
+    if (!value) {
+        throw new GradleException("Missing ${fallbackKey} in local.properties")
+    }
+    return value
+}
+def FALLBACK_BASE_URL_DEV = fallbackBaseUrlProperty('FALLBACK_BASE_URL_DEV', 'BASE_URL_DEV')
+def FALLBACK_BASE_URL_PROD = fallbackBaseUrlProperty('FALLBACK_BASE_URL_PROD', 'BASE_URL_PROD')
 
 kapt {
     correctErrorTypes true
@@ -57,12 +66,14 @@ android {
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_DEV'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_DEV'])
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", properties['BASE_URL_PROD'])
+            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
+            buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_PROD'])
         }
     }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -66,13 +66,11 @@ android {
     productFlavors {
         dev {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_DEV)
             buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_DEV'])
         }
         prod {
             dimension "environment"
-            buildConfigField("String", "BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "FALLBACK_BASE_URL", FALLBACK_BASE_URL_PROD)
             buildConfigField("String", "REWARDED_AD_UNIT_ID_FOLDER", properties['REWARDED_AD_UNIT_ID_FOLDER_PROD'])
         }

--- a/presentation/src/main/java/daily/dayo/presentation/activity/LoginActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/LoginActivity.kt
@@ -10,22 +10,30 @@ import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.UpdateAvailability
-import daily.dayo.presentation.viewmodel.AccountViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import daily.dayo.domain.provider.BaseUrlProvider
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.dialog.DefaultDialogAlert
+import daily.dayo.presentation.common.url.LocalBaseUrl
 import daily.dayo.presentation.screen.account.AccountScreen
 import daily.dayo.presentation.theme.DayoTheme
+import daily.dayo.presentation.viewmodel.AccountViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+    @Inject
+    lateinit var baseUrlProvider: BaseUrlProvider
+
     private val loginViewModel by viewModels<AccountViewModel>()
     private var isReady = false
     private lateinit var updateDialog: AlertDialog
@@ -37,12 +45,25 @@ class LoginActivity : AppCompatActivity() {
         }
         super.onCreate(savedInstanceState)
         createDialogUpdate()
-        checkUpdate()
         observeNetworkException()
         observeApiException()
+        refreshBaseUrlAndContinue()
+    }
+
+    private fun refreshBaseUrlAndContinue() {
+        lifecycleScope.launch {
+            baseUrlProvider.refreshBaseUrl()
+            setLoginContent()
+            checkUpdate()
+        }
+    }
+
+    private fun setLoginContent() {
         setContent {
             DayoTheme {
-                AccountScreen()
+                CompositionLocalProvider(LocalBaseUrl provides baseUrlProvider.getBaseUrl()) {
+                    AccountScreen()
+                }
             }
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/activity/MainActivity.kt
@@ -13,40 +13,63 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import dagger.hilt.android.AndroidEntryPoint
+import daily.dayo.domain.provider.BaseUrlProvider
 import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.url.LocalBaseUrl
 import daily.dayo.presentation.screen.main.MainScreen
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.viewmodel.AccountViewModel
 import daily.dayo.presentation.viewmodel.SettingNotificationViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+    @Inject
+    lateinit var baseUrlProvider: BaseUrlProvider
+
     private val accountViewModel by viewModels<AccountViewModel>()
     private val settingNotificationViewModel by viewModels<SettingNotificationViewModel>()
     private var rewardedAd: RewardedAd? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         checkCurrentNotification()
         getNotificationData()
         askNotificationPermission()
         loadRewardedAd()
+        refreshBaseUrlAndSetContent()
+    }
+
+    private fun refreshBaseUrlAndSetContent() {
+        lifecycleScope.launch {
+            baseUrlProvider.refreshBaseUrl()
+            setMainContent()
+        }
+    }
+
+    private fun setMainContent() {
         setContent {
             DayoTheme {
-                MainScreen(
-                    onAdRequest = { onRewardSuccess ->
-                        showAdIfAvailable(onRewardSuccess)
-                    },
-                    onExit = { finish() }
-                )
+                CompositionLocalProvider(LocalBaseUrl provides baseUrlProvider.getBaseUrl()) {
+                    MainScreen(
+                        onAdRequest = { onRewardSuccess ->
+                            showAdIfAvailable(onRewardSuccess)
+                        },
+                        onExit = { finish() }
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/daily/dayo/presentation/common/url/BaseUrl.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/url/BaseUrl.kt
@@ -1,0 +1,20 @@
+package daily.dayo.presentation.common.url
+
+import androidx.compose.runtime.compositionLocalOf
+import daily.dayo.presentation.BuildConfig
+
+val LocalBaseUrl = compositionLocalOf { BuildConfig.FALLBACK_BASE_URL }
+
+fun remoteUrl(baseUrl: String, path: String): String {
+    val normalizedBaseUrl = baseUrl.trimEnd('/')
+    val normalizedPath = path.trimStart('/')
+
+    return when {
+        normalizedBaseUrl.isEmpty() -> normalizedPath
+        normalizedPath.isEmpty() -> normalizedBaseUrl
+        else -> "$normalizedBaseUrl/$normalizedPath"
+    }
+}
+
+fun remoteImageUrl(baseUrl: String, imageFileName: String?): String =
+    remoteUrl(baseUrl = baseUrl, path = "images/$imageFileName")

--- a/presentation/src/main/java/daily/dayo/presentation/common/url/BaseUrl.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/common/url/BaseUrl.kt
@@ -16,5 +16,12 @@ fun remoteUrl(baseUrl: String, path: String): String {
     }
 }
 
-fun remoteImageUrl(baseUrl: String, imageFileName: String?): String =
-    remoteUrl(baseUrl = baseUrl, path = "images/$imageFileName")
+fun remoteImageUrl(baseUrl: String, imageFileName: String?): String {
+    val normalizedImageFileName = imageFileName?.trim().orEmpty()
+
+    return if (normalizedImageFileName.isEmpty()) {
+        ""
+    } else {
+        remoteUrl(baseUrl = baseUrl, path = "images/$normalizedImageFileName")
+    }
+}

--- a/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/bookmark/BookmarkScreen.kt
@@ -33,9 +33,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import daily.dayo.domain.model.BookmarkPost
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -227,10 +228,12 @@ private fun BookmarkPostItem(
     onBookmarkPostClick: (BookmarkPost) -> Unit,
     onBookmarkEditClick: () -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Box {
         RoundImageView(
             context = LocalContext.current,
-            imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",
+            imageUrl = remoteImageUrl(baseUrl, post.thumbnailImage),
             imageDescription = "bookmark post thumbnail",
             modifier = Modifier
                 .fillMaxWidth()

--- a/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/folder/FolderScreen.kt
@@ -59,13 +59,14 @@ import daily.dayo.domain.model.FolderInfo
 import daily.dayo.domain.model.FolderOrder
 import daily.dayo.domain.model.FolderPost
 import daily.dayo.domain.model.Privacy
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.createLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.hideLoadingDialog
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.resizeDialogFragment
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.showLoadingDialog
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -549,6 +550,7 @@ private fun FolderPostItem(
     onPostSelect: (Long) -> Unit
 ) {
     val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    val baseUrl = LocalBaseUrl.current
 
     Box(
         modifier = Modifier.clickable(
@@ -565,7 +567,7 @@ private fun FolderPostItem(
     ) {
         RoundImageView(
             context = LocalContext.current,
-            imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",
+            imageUrl = remoteImageUrl(baseUrl, post.thumbnailImage),
             imageDescription = "bookmark post thumbnail",
             modifier = Modifier
                 .fillMaxWidth()

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/FollowScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/FollowScreen.kt
@@ -52,9 +52,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import daily.dayo.domain.model.Follow
 import daily.dayo.domain.model.Profile
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -293,6 +294,8 @@ private fun FollowUserInfo(
     onProfileClick: (String) -> Unit,
     onFollowClick: (Follow) -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -308,7 +311,7 @@ private fun FollowUserInfo(
         ) {
             RoundImageView(
                 context = context,
-                imageUrl = "${BuildConfig.BASE_URL}/images/${follow.profileImg}",
+                imageUrl = remoteImageUrl(baseUrl, follow.profileImg),
                 roundSize = 18.dp,
                 modifier = Modifier
                     .size(36.dp)

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageEditScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageEditScreen.kt
@@ -58,7 +58,6 @@ import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import daily.dayo.domain.model.Profile
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Resource
 import daily.dayo.presentation.common.Status
@@ -67,6 +66,8 @@ import daily.dayo.presentation.common.dialog.LoadingAlertDialog.hideLoadingDialo
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.resizeDialogFragment
 import daily.dayo.presentation.common.dialog.LoadingAlertDialog.showLoadingDialog
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -93,6 +94,7 @@ internal fun MyPageEditScreen(
     val focusManager = LocalFocusManager.current
     val alertDialog = remember { mutableStateOf(createLoadingDialog(context)) }
     val bottomSheetController = LocalBottomSheetController.current
+    val baseUrl = LocalBaseUrl.current
 
     val profileUiState by profileSettingViewModel.profileInfo.observeAsState(Resource.loading(null))
     val isNicknameDuplicate by profileSettingViewModel.isNicknameDuplicate.collectAsStateWithLifecycle(false)
@@ -132,9 +134,9 @@ internal fun MyPageEditScreen(
         }
     }
 
-    LaunchedEffect(profileInfo.value?.profileImg, modifiedProfileImage) {
+    LaunchedEffect(profileInfo.value?.profileImg, modifiedProfileImage, baseUrl) {
         profileInfo.value?.profileImg?.let { profileImg ->
-            modifiedProfileImage.value = "${BuildConfig.BASE_URL}/images/${profileImg}"
+            modifiedProfileImage.value = remoteImageUrl(baseUrl, profileImg)
         }
     }
 

--- a/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/mypage/MyPageScreen.kt
@@ -46,12 +46,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import daily.dayo.domain.model.Folder
 import daily.dayo.domain.model.Profile
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
 import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_AD_START_COUNT
 import daily.dayo.presentation.common.constant.FolderConstants.MAX_FOLDER_COUNT
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -150,6 +151,8 @@ private fun MyPageProfile(
     profile: Profile?,
     onFollowButtonClick: (String, Int) -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -160,7 +163,7 @@ private fun MyPageProfile(
         // profile image
         RoundImageView(
             context = LocalContext.current,
-            imageUrl = "${BuildConfig.BASE_URL}/images/${profile?.profileImg}",
+            imageUrl = remoteImageUrl(baseUrl, profile?.profileImg),
             imageDescription = "my page profile image",
             roundSize = 24.dp,
             modifier = Modifier

--- a/presentation/src/main/java/daily/dayo/presentation/screen/notification/NotificationScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/notification/NotificationScreen.kt
@@ -58,9 +58,10 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import coil.size.Size
 import daily.dayo.domain.model.Notification
 import daily.dayo.domain.model.Topic
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.TimeChangerUtil
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray3_9FA5AE
@@ -318,6 +319,7 @@ fun NotificationView(
     onProfileClick: (String) -> Unit = {},
 ) {
     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val baseUrl = LocalBaseUrl.current
     val notificationMessage = buildAnnotatedString {
         // 1. 닉네임 포함된 메시지 인지 체크
         if (!notification.nickname.isNullOrBlank()) {
@@ -355,7 +357,7 @@ fun NotificationView(
             modifier = Modifier.weight(1f),
         ) {
             RoundImageView(
-                imageUrl = "${BuildConfig.BASE_URL}/images/${notification.profileImage}",
+                imageUrl = remoteImageUrl(baseUrl, notification.profileImage),
                 context = context,
                 modifier = Modifier
                     .size(28.dp)
@@ -428,7 +430,7 @@ fun NotificationView(
                         .fillMaxHeight()
                 )
                 RoundImageView(
-                    imageUrl = "${BuildConfig.BASE_URL}/images/${notification.image!!}",
+                    imageUrl = remoteImageUrl(baseUrl, notification.image!!),
                     context = context,
                     modifier = Modifier
                         .size(56.dp),

--- a/presentation/src/main/java/daily/dayo/presentation/screen/post/PostLikeUsersScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/post/PostLikeUsersScreen.kt
@@ -46,9 +46,10 @@ import androidx.paging.compose.itemKey
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import daily.dayo.domain.model.LikeUser
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -197,6 +198,8 @@ private fun LikeUserItem(
     onProfileClick: (String) -> Unit,
     onFollowClick: (LikeUser) -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Surface(
         color = White_FFFFFF,
         modifier = Modifier
@@ -211,7 +214,7 @@ private fun LikeUserItem(
             // profile
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data("${BuildConfig.BASE_URL}/images/${likeUser.profileImg}")
+                    .data(remoteImageUrl(baseUrl, likeUser.profileImg))
                     .build(),
                 contentDescription = "${likeUser.nickname} + profile",
                 contentScale = ContentScale.Crop,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/profile/ProfileScreen.kt
@@ -49,10 +49,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import daily.dayo.domain.model.Folder
 import daily.dayo.domain.model.Profile
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -276,6 +277,8 @@ private fun UserProfile(
     profile: Profile,
     onFollowMenuClick: (String, Int) -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -286,7 +289,7 @@ private fun UserProfile(
         // profile image
         RoundImageView(
             context = LocalContext.current,
-            imageUrl = "${BuildConfig.BASE_URL}/images/${profile.profileImg}",
+            imageUrl = remoteImageUrl(baseUrl, profile.profileImg),
             imageDescription = "profile image",
             roundSize = 24.dp,
             modifier = Modifier
@@ -484,4 +487,3 @@ private val DEFAULT_PROFILE = Profile(
     followingCount = 10,
     follow = null,
 )
-

--- a/presentation/src/main/java/daily/dayo/presentation/screen/rules/RuleScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/rules/RuleScreen.kt
@@ -15,8 +15,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteUrl
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.view.NoRippleIconButton
 import daily.dayo.presentation.view.TopNavigation
@@ -36,6 +37,8 @@ fun RuleScreen(
     onBackClick: () -> Unit = {},
     ruleType: RuleType = RuleType.PRIVACY_POLICY
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Surface(
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
@@ -59,7 +62,7 @@ fun RuleScreen(
                         webViewClient = WebViewClient()
                         settings.javaScriptEnabled = false
                         overScrollMode = View.OVER_SCROLL_NEVER
-                        loadUrl("${BuildConfig.BASE_URL}/${ruleType.fileName}.html")
+                        loadUrl(remoteUrl(baseUrl, "${ruleType.fileName}.html"))
 
                         setOnKeyListener(
                             View.OnKeyListener { v, keyCode, event ->

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchPostHashtagScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchPostHashtagScreen.kt
@@ -32,9 +32,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import daily.dayo.domain.model.SearchOrder
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -54,6 +55,7 @@ fun SearchPostHashtagScreen(
     val searchHashtagOrder by searchViewModel.searchHashtagOrder.collectAsStateWithLifecycle()
     val hashtagPosts = searchViewModel.searchTagList.collectAsLazyPagingItems()
     val hashtagPostsCount by searchViewModel.searchTagTotalCount.collectAsStateWithLifecycle(0)
+    val baseUrl = LocalBaseUrl.current
 
     LaunchedEffect(Unit) {
         with(searchViewModel) {
@@ -110,7 +112,7 @@ fun SearchPostHashtagScreen(
                 item.let { post ->
                     RoundImageView(
                         context = LocalContext.current,
-                        imageUrl = "${BuildConfig.BASE_URL}/images/${post?.thumbnailImage}",
+                        imageUrl = remoteImageUrl(baseUrl, post?.thumbnailImage),
                         imageDescription = "searched Image",
                         modifier = Modifier
                             .fillMaxWidth()

--- a/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/search/SearchResultScreen.kt
@@ -77,10 +77,11 @@ import com.skydoves.landscapist.glide.GlideImage
 import daily.dayo.domain.model.Search
 import daily.dayo.domain.model.SearchHistoryType
 import daily.dayo.domain.model.SearchUser
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Event
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -393,6 +394,7 @@ fun SearchResultTagView(
     onPostClick: (Long) -> Unit
 ) {
     val imageInteractionSource = remember { MutableInteractionSource() }
+    val baseUrl = LocalBaseUrl.current
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -414,7 +416,7 @@ fun SearchResultTagView(
                     item?.let { post ->
                         RoundImageView(
                             context = LocalContext.current,
-                            imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",
+                            imageUrl = remoteImageUrl(baseUrl, post.thumbnailImage),
                             imageDescription = "searched Image",
                             modifier = Modifier
                                 .matchParentSize()
@@ -523,8 +525,9 @@ fun SearchResultUserView(
 @Composable
 private fun SearchResultUserImageLayout(user: SearchUser, onClickProfile: (String) -> Unit) {
     val imageInteractionSource = remember { MutableInteractionSource() }
+    val baseUrl = LocalBaseUrl.current
     GlideImage(
-        imageModel = { "${BuildConfig.BASE_URL}/images/${user.profileImg}" },
+        imageModel = { remoteImageUrl(baseUrl, user.profileImg) },
         imageOptions = ImageOptions(
             contentDescription = "image description",
             contentScale = ContentScale.Crop,

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/BlockedUsersScreen.kt
@@ -39,9 +39,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.size.Size
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray3_9FA5AE
@@ -227,6 +228,8 @@ fun BlockedUser(
     onUnblockClick: (String) -> Unit = {},
     context: Context = LocalContext.current,
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Row(
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
@@ -237,7 +240,7 @@ fun BlockedUser(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         RoundImageView(
-            imageUrl = "${BuildConfig.BASE_URL}/images/${imageFileName}",
+            imageUrl = remoteImageUrl(baseUrl, imageFileName),
             context = context,
             modifier = Modifier
                 .size(36.dp)

--- a/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/settings/SettingsScreen.kt
@@ -49,11 +49,12 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import daily.dayo.domain.model.Profile
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.activity.LoginActivity
 import daily.dayo.presentation.activity.MainActivity
 import daily.dayo.presentation.common.Status
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -256,6 +257,8 @@ private fun SettingProfile(
     profile: Profile?,
     onProfileEditClick: () -> Unit
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -263,7 +266,7 @@ private fun SettingProfile(
         // profile image
         RoundImageView(
             context = LocalContext.current,
-            imageUrl = "${BuildConfig.BASE_URL}/images/${profile?.profileImg}",
+            imageUrl = remoteImageUrl(baseUrl, profile?.profileImg),
             imageDescription = stringResource(id = R.string.setting_my_profile_image_description),
             roundSize = 28.dp,
             modifier = Modifier.size(56.dp)

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteFolderScreen.kt
@@ -41,7 +41,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.size.Size
 import daily.dayo.domain.model.Folder
 import daily.dayo.domain.model.Privacy
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_AD_START_COUNT
 import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_THUMBNAIL_RADIUS_SIZE
@@ -49,6 +48,8 @@ import daily.dayo.presentation.common.constant.FolderConstants.FOLDER_THUMBNAIL_
 import daily.dayo.presentation.common.constant.FolderConstants.MAX_FOLDER_COUNT
 import daily.dayo.presentation.common.extension.clickableSingle
 import daily.dayo.presentation.common.extension.limitTo
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -265,9 +266,10 @@ fun WriteFolderItemLayout(
     isSelected: Boolean = true,
     onFolderClick: (Long, String) -> Unit = { _, _ -> },
 ) {
+    val baseUrl = LocalBaseUrl.current
     val thumbnailModel: Any = folder.thumbnailImage
         .takeIf { it.isNotBlank() }
-        ?.let { "${BuildConfig.BASE_URL}/images/$it" }
+        ?.let { remoteImageUrl(baseUrl, it) }
         ?: R.drawable.img_default_folder_dayo_logo
 
     Row(

--- a/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteScreen.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/screen/write/WriteScreen.kt
@@ -73,10 +73,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import daily.dayo.domain.model.Category
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.Status
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.screen.home.CategoryMenu
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
@@ -403,6 +404,8 @@ fun WriteUploadImages(
     deleteImage: (Int) -> Unit,
     onEditImage: (Int) -> Unit,
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     LazyRow(
         contentPadding = PaddingValues(start = 18.dp, end = 18.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -419,7 +422,7 @@ fun WriteUploadImages(
             val imageRequest = ImageRequest.Builder(context)
                 .data(
                     if (isPostEditMode) {
-                        "${BuildConfig.BASE_URL}/images/${imageAsset.uriString}"
+                        remoteImageUrl(baseUrl, imageAsset.uriString)
                     } else {
                         imageAsset.uriString
                     }

--- a/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/Comment.kt
@@ -58,10 +58,11 @@ import daily.dayo.domain.model.Comment
 import daily.dayo.domain.model.Comments
 import daily.dayo.domain.model.MentionUser
 import daily.dayo.domain.model.SearchUser
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.TimeChangerUtil
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -187,12 +188,14 @@ fun CommentView(
     onClickReport: (Long) -> Unit,
     modifier: Modifier
 ) {
+    val baseUrl = LocalBaseUrl.current
+
     Column(
         modifier = modifier,
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             RoundImageView(
-                imageUrl = "${BuildConfig.BASE_URL}/images/${comment.profileImg}",
+                imageUrl = remoteImageUrl(baseUrl, comment.profileImg),
                 context = LocalContext.current,
                 modifier = Modifier
                     .clip(CircleShape)
@@ -322,6 +325,7 @@ fun getAnnotatedCommentContent(content: String, mentionList: List<MentionUser>):
 @Composable
 fun CommentMentionSearchView(userResults: LazyPagingItems<SearchUser>, onClickFollowUser: (SearchUser) -> Unit) {
     val placeholder = AppCompatResources.getDrawable(LocalContext.current, R.drawable.ic_profile_default)
+    val baseUrl = LocalBaseUrl.current
     LazyColumn(
         modifier = Modifier
             .background(DayoTheme.colorScheme.background)
@@ -347,7 +351,7 @@ fun CommentMentionSearchView(userResults: LazyPagingItems<SearchUser>, onClickFo
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RoundImageView(
-                        imageUrl = "${BuildConfig.BASE_URL}/images/${user.profileImg}",
+                        imageUrl = remoteImageUrl(baseUrl, user.profileImg),
                         context = LocalContext.current,
                         modifier = Modifier
                             .clip(CircleShape)

--- a/presentation/src/main/java/daily/dayo/presentation/view/DetailPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/DetailPostView.kt
@@ -46,10 +46,11 @@ import coil.request.ImageRequest
 import daily.dayo.domain.model.Category
 import daily.dayo.domain.model.PostDetail
 import daily.dayo.domain.model.categoryKR
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.TimeChangerUtil
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray1_50545B
@@ -87,6 +88,7 @@ fun DetailPostView(
     var showDialog by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+    val baseUrl = LocalBaseUrl.current
 
     Column(modifier = modifier) {
         // publisher info
@@ -100,7 +102,7 @@ fun DetailPostView(
             // user profile image
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data("${BuildConfig.BASE_URL}/images/${post.profileImg}")
+                    .data(remoteImageUrl(baseUrl, post.profileImg))
                     .build(),
                 contentDescription = "${post.nickname} profile",
                 contentScale = ContentScale.Crop,
@@ -179,7 +181,7 @@ fun DetailPostView(
                 HorizontalPager(state = pagerState) {
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
-                            .data("${BuildConfig.BASE_URL}/images/${postImages[it]}")
+                            .data(remoteImageUrl(baseUrl, postImages[it]))
                             .build(),
                         contentDescription = "post images",
                         contentScale = ContentScale.Crop,

--- a/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FeedPostView.kt
@@ -61,10 +61,11 @@ import coil.request.ImageRequest
 import daily.dayo.domain.model.Category
 import daily.dayo.domain.model.Post
 import daily.dayo.domain.model.categoryKR
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.TimeChangerUtil
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray2_767B83
@@ -98,6 +99,7 @@ fun FeedPostView(
     var showDialog by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+    val baseUrl = LocalBaseUrl.current
 
     Column(modifier = modifier) {
         // publisher info
@@ -111,7 +113,7 @@ fun FeedPostView(
             // user profile image
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data("${BuildConfig.BASE_URL}/images/${post.userProfileImage}")
+                    .data(remoteImageUrl(baseUrl, post.userProfileImage))
                     .build(),
                 contentDescription = "${post.nickname} + profile",
                 contentScale = ContentScale.Crop,
@@ -179,7 +181,7 @@ fun FeedPostView(
                 HorizontalPager(state = pagerState) {
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
-                            .data("${BuildConfig.BASE_URL}/images/${postImages[it]}")
+                            .data(remoteImageUrl(baseUrl, postImages[it]))
                             .build(),
                         contentDescription = "post images",
                         contentScale = ContentScale.Crop,

--- a/presentation/src/main/java/daily/dayo/presentation/view/FolderView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/FolderView.kt
@@ -24,9 +24,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import daily.dayo.domain.model.Folder
 import daily.dayo.domain.model.Privacy
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
 import daily.dayo.presentation.common.extension.clickableSingle
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
 import daily.dayo.presentation.theme.Gray3_9FA5AE
@@ -40,6 +41,7 @@ fun FolderView(
     modifier: Modifier = Modifier,
 ) {
     val imageInteractionSource = remember { MutableInteractionSource() }
+    val baseUrl = LocalBaseUrl.current
     Column(modifier = modifier
         .clickableSingle(
             interactionSource = imageInteractionSource,
@@ -55,7 +57,7 @@ fun FolderView(
             // thumbnail image
             RoundImageView(
                 context = LocalContext.current,
-                imageUrl = "${BuildConfig.BASE_URL}/images/${folder.thumbnailImage}",
+                imageUrl = remoteImageUrl(baseUrl, folder.thumbnailImage),
                 imageDescription = folder.title,
                 modifier = Modifier
                     .border(BorderStroke(1.dp, Gray5_E8EAEE), RoundedCornerShape(8.dp))

--- a/presentation/src/main/java/daily/dayo/presentation/view/HomePostView.kt
+++ b/presentation/src/main/java/daily/dayo/presentation/view/HomePostView.kt
@@ -31,8 +31,9 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import daily.dayo.domain.model.Post
-import daily.dayo.presentation.BuildConfig
 import daily.dayo.presentation.R
+import daily.dayo.presentation.common.url.LocalBaseUrl
+import daily.dayo.presentation.common.url.remoteImageUrl
 import daily.dayo.presentation.common.extension.clickableSingle
 import daily.dayo.presentation.theme.Dark
 import daily.dayo.presentation.theme.DayoTheme
@@ -49,6 +50,7 @@ fun HomePostView(
     onClickProfile: () -> Unit
 ) {
     val imageInteractionSource = remember { MutableInteractionSource() }
+    val baseUrl = LocalBaseUrl.current
     Column(modifier = modifier) {
         Box(
             modifier = Modifier
@@ -58,7 +60,7 @@ fun HomePostView(
             // thumbnail image
             RoundImageView(
                 context = LocalContext.current,
-                imageUrl = "${BuildConfig.BASE_URL}/images/${post.thumbnailImage}",
+                imageUrl = remoteImageUrl(baseUrl, post.thumbnailImage),
                 imageDescription = "dayo pick image",
                 modifier = Modifier
                     .matchParentSize()
@@ -110,7 +112,7 @@ fun HomePostView(
         ) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data("${BuildConfig.BASE_URL}/images/${post.userProfileImage}")
+                    .data(remoteImageUrl(baseUrl, post.userProfileImage))
                     .build(),
                 contentDescription = "${post.nickname} + profile",
                 contentScale = ContentScale.Crop,


### PR DESCRIPTION
## 배경

- 현재 앱은 서버 base URL을 `local.properties` 기반 BuildConfig 값으로 빌드 시점에 주입해 사용중
- 이 구조에서는 서버 URL이 내부 사정으로 변경될 때마다 앱을 다시 빌드/배포해야 하므로, 런타임에서 dev/prod base URL을 갱신할 수 있도록 구조 개선

## 작업 목표

- Firebase Remote Config를 통해 앱 실행 시 base URL을 받아와 사용
- 단, 앱이 원격에서 받은 문자열을 서버 주소로 믿고 쓰게 되는 구조가 되기때문에 Remote Config에서 받은 URL을 바로 믿지 않고 아래의 검사를 통과해야 하도록 설계
   1. URL 형태가 안전한지 검사
   2. release에서는 내가 서명한 URL인지 확인
   3. 검증된 서버 출처에만 API 요청과 Authorization 토큰을 보내도록 막는 구조
- Remote Config를 가져오지 못해도 앱이 즉시 실패하지 않도록 마지막 성공 URL 캐싱과 fallback URL 사용
- API 요청, 이미지 URL, WebView URL이 동일한 런타임 base URL을 바라보도록 변경
- release 환경에서 URL 변조, unsafe host, 토큰 노출 가능성을 줄이도록 검증/보안 처리 추가

## 작업 내용

### 1. Runtime base URL provider 추가

`BaseUrlProvider`와 `BaseUrlSource`를 추가해 현재 base URL이 어디에서 선택됐는지 구분할 수 있도록 처리
- `REMOTE_CONFIG`: Remote Config에서 받아온 URL
- `CACHED_LAST_SUCCESS`: 이전에 Remote Config 검증에 성공해 저장된 URL
- `FALLBACK`: 빌드 시점에 주입된 `BuildConfig.FALLBACK_BASE_URL`

앱 진입점인 `LoginActivity`, `MainActivity`에서는 `setContent` 전에 `refreshBaseUrl()`을 호출하고, 선택된 base URL을 `LocalBaseUrl`로 Compose tree에 제공하는 방식

### 2. URL 선택 순서

- 앱 시작 시 초기값은 아래 순서로 결정

1. SharedPreferences에 저장된 마지막 성공 URL과 서명을 확인
4. 캐시 URL이 정규화/신뢰성 검증을 통과하면 `CACHED_LAST_SUCCESS` 사용
5. 캐시가 없거나 검증에 실패하면 캐시를 제거하고 `FALLBACK` 사용
6. 이후 `refreshBaseUrl()`에서 Remote Config fetch/activate 성공 시 `REMOTE_CONFIG`로 전환
7. Remote Config URL이 유효하면 URL과 서명을 다시 캐시에 저장

- Remote Config fetch 실패, timeout, invalid URL, 서명 검증 실패가 발생하면 현재 선택된 URL을 유지. 
- 따라서 cold start에서는 fallback으로 동작하고, 이전 성공 캐시가 있으면 캐시 URL로 계속 동작 가능

### 3. URL 검증 및 보안 처리

Remote Config 또는 cache URL은 origin 단위(scheme + host + port 조합. ex.`https://api.dayo.com:8080`)로만 허용
- `http`, `https` scheme만 허용
- query, fragment, userInfo 포함 URL 거부
- path는 비어 있거나 `/`만 허용
- release 빌드에서 localhost, `.local`, private/link-local/loopback/multicast 계열 host 차단
- release 빌드에서 fallback이 아닌 URL은 `SHA256withRSA` 서명 검증 필요
- debug 빌드는 테스트 편의를 위해 non-fallback URL 서명 검증을 우회

### 4. API 요청 base URL rewrite

- Retrofit은 생성 시 항상 `BuildConfig.FALLBACK_BASE_URL`을 사용하되 실제 요청 직전에는 `BaseUrlRewriteInterceptor`가 `BaseUrlProvider`의 현재 URL을 읽고, 신뢰 가능한 URL이면 요청의 `scheme`, `host`, `port`만 교체하는 방식

- path, query, method, body는 Retrofit이 만든 원본 요청을 유지하고, provider URL이 invalid/untrusted이거나 rewrite 중 예외가 발생하면 원본 fallback URL로 요청. Authorization 헤더는 base URL rewrite 이후 토큰이 엉뚱한 서버로 가지 않도록 요청 origin이 신뢰 가능한 base URL일 때만 첨부하도록 보완.

### 5. Presentation URL 전환

- 기존 `BuildConfig.BASE_URL` 기반 이미지/WebView URL 생성 코드를 `LocalBaseUrl`, `remoteUrl`, `remoteImageUrl` 기반으로 변경하였으며 이에 따라 게시글 이미지, 프로필 이미지, 폴더 썸네일, 알림 이미지, 검색 결과 이미지, 약관 WebView URL이 런타임 base URL을 사용

## URL 선택 / 적용 흐름
```
┌──────────────────────────────────────┐      ┌──────────────────────────────────────┐
│ local.properties / GitHub Secrets    │      │ Firebase Remote Config               │
│ - FALLBACK_BASE_URL_DEV / PROD       │      │ - api_base_url_dev / prod            │
│ - REMOTE_CONFIG_BASE_URL_PUBLIC_KEY  │      │ - api_base_url_*_signature           │
└──────────────────────────────────────┘      └──────────────────────────────────────┘
                    │                                             │
                    ▼                                             ▼
┌───────────────────────────────────────┐      ┌──────────────────────────────────────┐
│ BuildConfig                           │      │ Remote Config fetch result           │
│ - FALLBACK_BASE_URL                   │      │ - remote base URL                    │
│ - REMOTE_CONFIG_BASE_URL_KEY          │      │ - URL signature                      │
│ - REMOTE_CONFIG_BASE_URL_SIGNATURE_KEY│      │ - VALUE_SOURCE_REMOTE 확인            │
└───────────────────────────────────────┘      └──────────────────────────────────────┘
                    │                                             │
                    └──────────────────────┬──────────────────────┘
                                           ▼
                         ┌──────────────────────────────────────┐
                         │ RemoteConfigBaseUrlProvider          │
                         │ - URL normalize / origin-only 검증    │
                         │ - release SHA256withRSA 서명 검증      │
                         │ - unsafe host 차단                    │
                         │ - BaseUrlSource 결정                  │
                         └──────────────────────────────────────┘
                                           │
                  ┌────────────────────────┼────────────────────────┐
                  │                        │                        │
                  ▼                        ▼                        ▼
┌────────────────────────────┐ ┌────────────────────────────┐ ┌────────────────────────────┐
│ REMOTE_CONFIG              │ │ CACHED_LAST_SUCCESS        │ │ FALLBACK                   │
│ - Remote Config 검증 성공    │ │ - 마지막 성공 URL 재사용        │ │ - 캐시/Remote Config 실패 시 │
│ - 성공 시 cache 저장          │ │ - 앱 재실행 초기값 후보         │ │ - 빌드 시점 기본 URL          │
└────────────────────────────┘ └────────────────────────────┘ └────────────────────────────┘
                  │                        ▲
                  │                        │
                  ▼                        │
        ┌──────────────────────────────────────┐
        │ SharedPreferences cache              │
        │ - last_successful_base_url           │
        │ - last_successful_base_url_signature │
        └──────────────────────────────────────┘
                  │
                  ▼
        ┌──────────────────────────────────────┐
        │ LoginActivity / MainActivity         │
        │ - setContent 전 refreshBaseUrl()     │
        │ - LocalBaseUrl 제공                   │
        └──────────────────────────────────────┘
                  │
        ┌─────────┴──────────────────────────────┐
        │                                        │
        ▼                                        ▼
┌────────────────────────────┐        ┌──────────────────────────────────────┐
│ Presentation URL 생성       │        │ Retrofit / OkHttp                    │
│ - remoteImageUrl()         │        │ - Retrofit baseUrl = FALLBACK        │
│ - remoteUrl()              │        │ - 요청 직전 BaseUrlRewriteInterceptor  │
│ - 이미지 / WebView URL       │        │ - scheme / host / port rewrite       │
└────────────────────────────┘        └──────────────────────────────────────┘
                                                   │
                                                   ▼
                                      ┌────────────────────────────────────────┐
                                      │ API Request                            │
                                      │ - trusted origin에만 Authorization 첨부  │
                                      │ - debug logging / release logging NONE │
                                      └────────────────────────────────────────┘
```
## 적용 확인 순서
- 앱 실행 후 Remote Config 값이 정상일 때 API 요청 origin이 Remote Config URL로 rewrite되는지 확인
- Remote Config fetch 실패/timeout 상황에서 fallback 또는 cached URL로 앱이 계속 동작하는지 확인
- 앱 재시작 후 마지막 성공 URL이 CACHED_LAST_SUCCESS로 사용되는지 확인
- release 빌드에서 unsigned non-fallback URL이 적용되지 않는지 확인

## 참고
- #1106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# 풀 리퀘스트 요약

## 모듈별 기능적 영향 및 사용자 영향

### 빌드·설정 (app, data, presentation의 build.gradle)
- BuildConfig 필드 변경: 기존 BASE_URL → FALLBACK_BASE_URL로 전환. Firebase Remote Config 관련 키(REMOTECONFIG 키/서명 키, PUBLIC_KEY) 추가 및 릴리스 빌드에서 공개키 필수 검증 태스크 도입.
- 영향: 앱 설치 후에도 서버 엔드포인트를 런타임에서 교체 가능. 빌드 시점 고정 URL 의존 제거.

### 런타임 Base URL 공급 (RemoteConfigBaseUrlProvider, BaseUrlProviderModule, domain 인터페이스)
- Firebase Remote Config에서 서명된 base URL을 페치·검증(SHA256withRSA)하고, 검증된 URL을 메모리 및 SharedPreferences에 캐시. BaseUrlSource: FALLBACK, CACHED_LAST_SUCCESS, REMOTE_CONFIG로 구분.
- 시작 시 우선순위: 캐시된 마지막 성공 URL(정규화·서명 검증 통과) → FALLBACK; 이후 Remote Config 페치 활성화 시 REMOTE_CONFIG로 전환 및 캐시 갱신.
- URL 규칙: 오리진(스킴+호스트+포트)만 허용, http/https만, 쿼리/프래그먼트/userinfo 금지, 경로는 비어있거나 “/”만 허용. 릴리스 빌드에서는 localhost/.local/사설 IP 등 차단; 디버그 빌드는 서명 검사 완화 가능.

사용자 영향: 운영자가 Remote Config로 새로운 API 베이스 URL을 배포하면 재배포 없이 앱이 새 엔드포인트를 사용하도록 전환됨. 잘못된/비신뢰 URL 배포 시 서명 검증 실패로 폴백되어 사용자 서비스 중단 위험을 완화.

### 네트워킹 (NetworkModule, BaseUrlRewriteInterceptor, Retrofit 설정)
- Retrofit 기본 baseUrl은 FALLBACK_BASE_URL로 유지하되, BaseUrlRewriteInterceptor가 요청 직전 scheme/host/port만 BaseUrlProvider의 현재 값으로 교체(경로·쿼리·바디·메서드 보존).
- Authorization 헤더는 요청의 오리진이 provider의 신뢰된 base URL과 일치할 때만 첨부. 특정 인증 경로(OAuth, signIn/signUp 등)는 예외 처리. /refresh 요청은 refresh token 사용, 그 외는 access token.
- 영향: 런타임 base URL 변경 시에도 기존 API 경로·요청 내용 유지. 인증 토큰의 유출을 방지하기 위해 신뢰된 오리진으로만 헤더 전송.

### UI / 프레젠테이션 (Activity 변경 및 Compose 전역값)
- LoginActivity / MainActivity: setContent() 전에 lifecycleScope에서 baseUrlProvider.refreshBaseUrl()를 비동기 호출하고, Compose 트리에 CompositionLocalProvider(LocalBaseUrl)을 통해 현재 base URL 주입.
- 여러 화면(Bookmark, Folder, MyPage 등): BuildConfig.BASE_URL 하드코딩 제거 → LocalBaseUrl.current + remoteUrl/remoteImageUrl로 이미지·WebView URL 구성.
- 영향: 모든 UI 구성 요소가 런타임 URL을 사용하므로 엔드포인트 변경이 즉시 반영됨. 빈 이미지 경로 처리 보강(빈 문자열 무시).

---

## 주요 위험 포인트 (네트워크·오류·동시성·보안 관점)

1. 콜드 스타트·UI 차단 위험
   - LoginActivity/MainActivity가 setContent 전에 refreshBaseUrl()를 대기하는 흐름에서 Remote Config 페치가 느리거나 타임아웃(설정된 값)에 걸리면 앱 시작 지연 가능. 현재 로직의 대기·타임아웃/취소 전략이 명확하지 않음(페치 보호는 있으나 UI 블로킹 여부 검증 필요).

2. 페치/검증 실패 처리 및 재시도 부재
   - Remote Config 페치 실패 또는 서명 검증 실패 시 현재 선택을 유지하도록 설계되어 있으나, 재시도 정책(지연/백오프)이나 실패 알림(로깅/모니터링) 구현이 미흡. 잘못된 원격 값이 지속 배포되면 기대 동작 보장 자료가 불충분함.

3. race condition 및 상태 원자성
   - currentBaseUrlState는 `@Volatile로` 가시성만 확보. refreshBaseUrl()의 읽기-검증-쓰기 흐름은 원자적이지 않아 동시성 간섭 발생 가능(동시 요청 중 갱신으로 인한 불일치, Authorization 부착 판단 시점의 미스매치).

4. Authorization 결정 시점 문제
   - Authorization 헤더 부착 여부가 getBaseUrl()와 요청 오리진 비교에 의존하므로, 갱신 직후 들어오는 요청에서 예기치 않게 헤더가 부착되거나 미부착될 수 있음.

5. SharedPreferences 기반 캐시의 일관성
   - 캐시 삭제/갱신 중 멀티스레드 접근으로 부분적 노출 가능. 공개키 변경 시 기존 캐시 일괄 무효화로 인한 대규모 폴백 가능성(운영 시 주의 필요).

6. 인터셉터의 예외 처리
   - provider가 반환한 URL 파싱 실패 또는 재작성 중 IllegalArgumentException 발생 시 원본 요청을 그대로 전송하는 현재 동작은 의도적이지만, 잘못된 URL로 요청이 전송되는 사례가 발생할 수 있음(로그/모니터링 필요).

7. 보안 리스크 (디버그 빌드와 공개키 관리)
   - 디버그 빌드에서 서명 검증을 우회할 수 있어 개발자가 아닌 환경으로 코드가 배포되면 악의적 Remote Config에 취약. 릴리스용 공개키(PEM) 관리 부실 시 서명 검증 무력화 위험.

---

## 권장되는 후속 테스트 및 검증 항목

1. 기능적 검증
   - 콜드 스타트: 캐시 없는 상태에서 앱 최초 실행 → FALLBACK 사용 확인. Remote Config 성공 시 캐시와 상태(CACHED_LAST_SUCCESS/REMOTE_CONFIG) 갱신 확인.
   - Remote Config 배포 흐름: 서명된 새 URL 배포 → refreshBaseUrl() 호출 후 REMOTE_CONFIG 전환·캐시 저장 검증.
   - 서명 실패 케이스: 잘못된 서명 배포 시 검증 실패·캐시 삭제·폴백 동작 확인.

2. 네트워크·요청 검증
   - BaseUrlRewriteInterceptor: path/query/body/method 불변성 유지 확인(다양한 엔드포인트 테스트).
   - Authorization 부착 테스트: 신뢰 오리진/비신뢰 오리진 각각에서 Authorization 헤더 적절 부착·미부착 확인. OAuth·signIn·signUp 예외 경로 검증.
   - Retrofit 기본 baseUrl과 실제 요청 URL 간 불일치 없음 확인.

3. 동시성·상태 일관성 테스트
   - 병렬 요청 중 refreshBaseUrl() 실행(동시성 스트레스) → 모든 요청이 일관된 오리진으로 처리되는지, 또는 명확한 허용된 혼합 동작만 발생하는지 확인.
   - rapid refresh 반복 호출 시 SharedPreferences 쓰기 충돌, 캐시 일관성 확인.

4. 타임아웃·오프라인 상황
   - Remote Config 느린 응답/타임아웃 상황에서 UI 시작 지연 유무와 폴백 유지 확인.
   - 오프라인(네트워크 없음)에서 캐시 기반 작동 검증.

5. 보안 테스트
   - 릴리스 빌드에서 localhost/.local/사설 IP 차단, 쿼리/프래그먼트/userinfo 제거 검증.
   - 공개키(PEM) 포맷 처리·검증 성공/실패 로그 확인 및 빌드 시 공개키 미존재시 빌드 태스크(검증) 동작 확인.
   - 디버그 빌드에서 서명 우회 동작이 의도대로만 제한되는지 검토.

6. 로깅·모니터링
   - Remote Config 페치 실패, 서명 검증 실패, 인터셉터 예외 발생 시 충분한 로그와 모니터링 이벤트(에러 레벨) 추가 권장.

7. UI 연동 테스트
   - CompositionLocal로 주입된 LocalBaseUrl가 모든 화면/네비게이션 경로에서 일관되게 사용되는지 확인.
   - remoteImageUrl/remoteUrl의 슬래시 처리(leading/trailing) 및 빈 이미지 파일명 처리 검증.

---

요약: 런타임에서 Remote Config로 API 베이스 URL을 안전하게 교체하는 기능을 도입해 운영 유연성을 크게 개선했으나, 콜드 스타트·동시성·서명/공개키 관리·예외 로깅과 관련된 검증 및 보완 작업이 필요합니다. 운영 전 위의 테스트 항목(특히 릴리스 빌드 보안·타임아웃/동시성 시나리오 및 로그/모니터링)을 우선적으로 수행하시길 권장합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->